### PR TITLE
🎨 Palette: Improve accessibility with AutomationProperties.Name

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-01-24 - [Accessibility in Avalonia]
 **Learning:** Explicitly disabling `FocusAdorner` for all buttons in a global style without providing a clear alternative focus state (like a high-contrast border or background change) breaks keyboard navigation accessibility. Adding `AutomationProperties.Name` to icon-only buttons or buttons with symbolic content (like ◀/▶) is essential for screen reader support in Avalonia.
 **Action:** When working with Avalonia, ensure every interactive element has a perceptible focus state and descriptive `AutomationProperties.Name` if its purpose isn't clear from text content alone.
+
+## 2025-01-25 - [Cohesive Accessibility Labeling]
+**Learning:** In complex editor UIs with many unlabeled inputs (like stats or IDs), adding `AutomationProperties.Name` provides a massive accessibility boost with zero visual impact. For grid-based data like Pokémon slots, reusing existing tooltip summary properties for `AutomationProperties.Name` ensures consistency between visual and screen reader feedback.
+**Action:** Always check symbol-based controls (like markings) and input-dense grids for missing programmatic labels.

--- a/PKHeX.Avalonia/Views/BoxViewer.axaml
+++ b/PKHeX.Avalonia/Views/BoxViewer.axaml
@@ -90,6 +90,7 @@
                                     DragDrop.AllowDrop="True"
                                     DragDrop.Drop="OnSlotDrop"
                                     ToolTip.Tip="{Binding ToolTipSummary}"
+                                    AutomationProperties.Name="{Binding ToolTipSummary}"
                                     Click="OnSlotClicked"
                                     DoubleTapped="OnSlotDoubleTapped"
                                     Tag="{Binding}">

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -160,11 +160,13 @@
                                     <Grid Grid.Row="1" Grid.Column="0" ColumnDefinitions="*,8,*">
                                         <StackPanel Grid.Column="0">
                                             <TextBlock Text="Level" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" FormatString="0" ShowButtonSpinner="False" />
+                                            <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" FormatString="0" ShowButtonSpinner="False"
+                                                           AutomationProperties.Name="Level" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2">
                                             <TextBlock Text="EXP" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding Exp}" Minimum="0" Maximum="10000000" FormatString="0" ShowButtonSpinner="False" />
+                                            <NumericUpDown Value="{Binding Exp}" Minimum="0" Maximum="10000000" FormatString="0" ShowButtonSpinner="False"
+                                                           AutomationProperties.Name="Experience Points" />
                                         </StackPanel>
                                     </Grid>
 
@@ -251,43 +253,43 @@
                                 <!-- HP -->
                                 <TextBlock Grid.Row="2" Grid.Column="0" Text="HP" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Base_HP}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="2" Grid.Column="2" Value="{Binding IvHP}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="2" Grid.Column="3" Value="{Binding EvHP}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="2" Grid.Column="2" Value="{Binding IvHP}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="HP IV" />
+                                <NumericUpDown Grid.Row="2" Grid.Column="3" Value="{Binding EvHP}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="HP EV" />
                                 <TextBlock Grid.Row="2" Grid.Column="4" Text="{Binding Stat_HP}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
                                 <!-- Atk -->
                                 <TextBlock Grid.Row="3" Grid.Column="0" Text="Atk" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Base_ATK}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="3" Grid.Column="2" Value="{Binding IvATK}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="3" Grid.Column="3" Value="{Binding EvATK}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="3" Grid.Column="2" Value="{Binding IvATK}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Attack IV" />
+                                <NumericUpDown Grid.Row="3" Grid.Column="3" Value="{Binding EvATK}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Attack EV" />
                                 <TextBlock Grid.Row="3" Grid.Column="4" Text="{Binding Stat_ATK}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
                                 <!-- Def -->
                                 <TextBlock Grid.Row="4" Grid.Column="0" Text="Def" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Base_DEF}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="4" Grid.Column="2" Value="{Binding IvDEF}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="4" Grid.Column="3" Value="{Binding EvDEF}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="4" Grid.Column="2" Value="{Binding IvDEF}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Defense IV" />
+                                <NumericUpDown Grid.Row="4" Grid.Column="3" Value="{Binding EvDEF}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Defense EV" />
                                 <TextBlock Grid.Row="4" Grid.Column="4" Text="{Binding Stat_DEF}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
                                 <!-- SpA -->
                                 <TextBlock Grid.Row="5" Grid.Column="0" Text="SpA" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding Base_SPA}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="5" Grid.Column="2" Value="{Binding IvSPA}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="5" Grid.Column="3" Value="{Binding EvSPA}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="5" Grid.Column="2" Value="{Binding IvSPA}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Special Attack IV" />
+                                <NumericUpDown Grid.Row="5" Grid.Column="3" Value="{Binding EvSPA}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Special Attack EV" />
                                 <TextBlock Grid.Row="5" Grid.Column="4" Text="{Binding Stat_SPA}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
                                 <!-- SpD -->
                                 <TextBlock Grid.Row="6" Grid.Column="0" Text="SpD" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Base_SPD}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="6" Grid.Column="2" Value="{Binding IvSPD}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="6" Grid.Column="3" Value="{Binding EvSPD}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="6" Grid.Column="2" Value="{Binding IvSPD}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Special Defense IV" />
+                                <NumericUpDown Grid.Row="6" Grid.Column="3" Value="{Binding EvSPD}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Special Defense EV" />
                                 <TextBlock Grid.Row="6" Grid.Column="4" Text="{Binding Stat_SPD}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
                                 <!-- Spe -->
                                 <TextBlock Grid.Row="7" Grid.Column="0" Text="Spe" FontWeight="SemiBold" VerticalAlignment="Center" />
                                 <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding Base_SPE}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.7" />
-                                <NumericUpDown Grid.Row="7" Grid.Column="2" Value="{Binding IvSPE}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
-                                <NumericUpDown Grid.Row="7" Grid.Column="3" Value="{Binding EvSPE}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" />
+                                <NumericUpDown Grid.Row="7" Grid.Column="2" Value="{Binding IvSPE}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Speed IV" />
+                                <NumericUpDown Grid.Row="7" Grid.Column="3" Value="{Binding EvSPE}" Minimum="0" Maximum="252" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" Margin="2" AutomationProperties.Name="Speed EV" />
                                 <TextBlock Grid.Row="7" Grid.Column="4" Text="{Binding Stat_SPE}" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Center" />
                             </Grid>
                         </Border>
@@ -515,11 +517,13 @@
                                     <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" ColumnDefinitions="*,16,*" Margin="0,12,0,0">
                                         <StackPanel Grid.Column="0">
                                             <TextBlock Text="TID" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding TrainerID}" Minimum="0" Maximum="4294967295" FormatString="0" ShowButtonSpinner="False" />
+                                            <NumericUpDown Value="{Binding TrainerID}" Minimum="0" Maximum="4294967295" FormatString="0" ShowButtonSpinner="False"
+                                                           AutomationProperties.Name="Trainer ID" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="2">
                                             <TextBlock Text="SID" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding Sid}" Minimum="0" Maximum="65535" FormatString="0" ShowButtonSpinner="False" />
+                                            <NumericUpDown Value="{Binding Sid}" Minimum="0" Maximum="65535" FormatString="0" ShowButtonSpinner="False"
+                                                           AutomationProperties.Name="Secret ID" />
                                         </StackPanel>
                                     </Grid>
                                 </Grid>
@@ -567,12 +571,12 @@
                                 <StackPanel>
                                     <TextBlock Text="Markings" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
                                     <UniformGrid Columns="6">
-                                        <CheckBox Content="●" IsChecked="{Binding MarkingCircle}" ToolTip.Tip="Circle" FontSize="16" HorizontalAlignment="Center" />
-                                        <CheckBox Content="▲" IsChecked="{Binding MarkingTriangle}" ToolTip.Tip="Triangle" FontSize="16" HorizontalAlignment="Center" />
-                                        <CheckBox Content="■" IsChecked="{Binding MarkingSquare}" ToolTip.Tip="Square" FontSize="16" HorizontalAlignment="Center" />
-                                        <CheckBox Content="♥" IsChecked="{Binding MarkingHeart}" ToolTip.Tip="Heart" FontSize="16" HorizontalAlignment="Center" />
-                                        <CheckBox Content="★" IsChecked="{Binding MarkingStar}" ToolTip.Tip="Star" FontSize="16" IsVisible="{Binding HasSixMarkings}" HorizontalAlignment="Center" />
-                                        <CheckBox Content="◆" IsChecked="{Binding MarkingDiamond}" ToolTip.Tip="Diamond" FontSize="16" IsVisible="{Binding HasSixMarkings}" HorizontalAlignment="Center" />
+                                        <CheckBox Content="●" IsChecked="{Binding MarkingCircle}" ToolTip.Tip="Circle" AutomationProperties.Name="Circle Marking" FontSize="16" HorizontalAlignment="Center" />
+                                        <CheckBox Content="▲" IsChecked="{Binding MarkingTriangle}" ToolTip.Tip="Triangle" AutomationProperties.Name="Triangle Marking" FontSize="16" HorizontalAlignment="Center" />
+                                        <CheckBox Content="■" IsChecked="{Binding MarkingSquare}" ToolTip.Tip="Square" AutomationProperties.Name="Square Marking" FontSize="16" HorizontalAlignment="Center" />
+                                        <CheckBox Content="♥" IsChecked="{Binding MarkingHeart}" ToolTip.Tip="Heart" AutomationProperties.Name="Heart Marking" FontSize="16" HorizontalAlignment="Center" />
+                                        <CheckBox Content="★" IsChecked="{Binding MarkingStar}" ToolTip.Tip="Star" AutomationProperties.Name="Star Marking" FontSize="16" IsVisible="{Binding HasSixMarkings}" HorizontalAlignment="Center" />
+                                        <CheckBox Content="◆" IsChecked="{Binding MarkingDiamond}" ToolTip.Tip="Diamond" AutomationProperties.Name="Diamond Marking" FontSize="16" IsVisible="{Binding HasSixMarkings}" HorizontalAlignment="Center" />
                                     </UniformGrid>
                                 </StackPanel>
                             </Border>


### PR DESCRIPTION
This PR improves the accessibility of the PKHeX Avalonia interface by adding `AutomationProperties.Name` to several key controls that previously lacked programmatic labels.

### 💡 What:
- Added descriptive names to the "Markings" checkboxes in the Pokémon Editor (Circle, Triangle, etc.), which previously only had Unicode symbols as content.
- Added descriptive names to the Stat IV/EV inputs, Trainer ID, Secret ID, Level, and EXP fields.
- Bound the `AutomationProperties.Name` of Box Slot buttons to their `ToolTipSummary`, ensuring screen readers provide the same helpful info as tooltips.

### 🎯 Why:
To ensure that users navigating via keyboard and screen readers can understand and interact with the complex editor interface effectively. These changes have no visual impact but significantly improve the "micro-UX" for accessibility.

### ♿ Accessibility Improvements:
- Screen readers will now correctly identify markings (e.g., "Circle Marking" instead of "black circle symbol").
- Stat inputs now explicitly announce their purpose (e.g., "HP IV" instead of just "Numeric Up Down").
- Box slots now announce the Pokémon they contain.

---
*PR created automatically by Jules for task [3557617867324327866](https://jules.google.com/task/3557617867324327866) started by @realgarit*