### PR TITLE
ci: skip redundant CI on PR merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+# Prevent duplicate runs: group by PR number for PR events, by ref for pushes.
+# cancel-in-progress drops stale runs when new commits land on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
+    # Skip CI on PR merge commits — the PR check already validated this code.
+    # Direct pushes (sync, bump) still run CI normally.
+    if: >-
+      github.event_name == 'pull_request' ||
+      !startsWith(github.event.head_commit.message, 'Merge pull request #')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Skip the duplicate CI run that fires when a PR merges to main (the push event), saving 3 runner jobs per merge
- Add `concurrency` groups to cancel stale runs and prevent pile-ups

## Problem

CI triggers on both `pull_request` and `push` to main. When a PR merges, the push event fires a second CI run on code that was already tested by the PR check. This wastes ~5 min of runner time across 3 OS matrices every merge.

## How it works

| Event | Commit message | CI runs? |
|---|---|---|
| `pull_request` (any) | — | Yes (always) |
| `push` from PR merge | `Merge pull request #58 from ...` | **Skipped** |
| `push` from direct commit | `sync: update PKHeX.Core to upstream ...` | Yes |
| `push` from direct commit | `bump: update UIVersion to 1.1.14` | Yes |

The `concurrency` group also ensures:
- New pushes to a PR branch cancel the previous in-flight run
- Back-to-back merges to main don't pile up (latest wins)

## Test plan

- [x] Merge this PR and verify CI does NOT trigger a second run on main
- [x] Verify the next `sync:` or `bump:` direct push still triggers CI