### PR TITLE
fix: add workflows permission to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: write
+  # Required when the tagged commit tree includes .github/workflows/ changes
+  workflows: write
 
 jobs:
   check-version:


### PR DESCRIPTION
## Summary

Fix the v1.1.15 release failure by adding `workflows: write` permission to the Release workflow.

## Problem

The Release workflow failed with:
```
! [remote rejected] v1.1.15 -> v1.1.15 (refusing to allow a GitHub App to create or update
workflow .github/workflows/ci.yml without workflows permission)
```

This happened because the tagged commit tree includes the `ci.yml` changes from PR #59, and GitHub requires `workflows` permission on the `GITHUB_TOKEN` to push refs that touch workflow files.

## Fix

Add `workflows: write` to the `permissions` block in `release.yml`.

## Test plan

- [ ] Merge this PR, then re-run the failed Release workflow via `workflow_dispatch` to cut v1.1.15