### PR TITLE
Improvement: Introduce AppImage support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           mkdir -p AppDir/usr/bin
 
-          cp publish/PKHeX.Avalonia AppDir/usr/bin/
+          cp publish/* AppDir/usr/bin/
 
           cp PKHeX.Avalonia/Assets/Icons/icon.png AppDir/pkhex.png
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,43 @@ jobs:
           zip -r ../${{ matrix.artifact }}.zip .
           cd ..
 
+      - name: Build AppImage
+        if: matrix.rid == 'linux-x64'
+        shell: bash
+        run: |
+          mkdir -p AppDir/usr/bin
+
+          cp publish/PKHeX.Avalonia AppDir/usr/bin/
+
+          cp PKHeX.Avalonia/Assets/Icons/icon.png AppDir/pkhex.png
+
+          cat > AppDir/AppRun << 'EOF'
+          #!/bin/bash
+          HERE="$(dirname "$(readlink -f "$0")")"
+          exec "$HERE/usr/bin/PKHeX.Avalonia" "$@"
+          EOF
+
+          chmod +x AppDir/AppRun
+
+          cat > AppDir/pkhex.desktop << 'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=PKHeX
+          Exec=PKHeX.Avalonia
+          Icon=pkhex
+          Categories=Utility;
+          Terminal=false
+          EOF
+
+          wget -q \
+            https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage
+
+          chmod +x appimagetool-x86_64.AppImage
+
+          ARCH=x86_64 \
+            ./appimagetool-x86_64.AppImage AppDir \
+            PKHeX-Avalonia-linux-x64.AppImage
+
       # Windows: zip the publish folder
       - name: Package (Windows)
         if: matrix.rid == 'win-x64'
@@ -115,7 +152,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.zip
+          path: |
+            ${{ matrix.artifact }}.zip
+            *.AppImage
           retention-days: 5
 
   release:
@@ -148,6 +187,8 @@ jobs:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
-          files: artifacts/**/*.zip
+          files: |
+            artifacts/**/*.zip
+            artifacts/**/*.AppImage
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,9 @@ jobs:
           ARCH=x86_64 \
             ./appimagetool-x86_64.AppImage AppDir \
             PKHeX-Avalonia-linux-x64.AppImage
+          
+          # remove the AppImage tool from the artifact list since we don't need it anymore
+          rm appimagetool-x86_64.AppImage
 
       # Windows: zip the publish folder
       - name: Package (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,9 @@ jobs:
           chmod +x appimagetool-x86_64.AppImage
 
           ARCH=x86_64 \
-            ./appimagetool-x86_64.AppImage AppDir \
+            ./appimagetool-x86_64.AppImage \
+            --appimage-extract-and-run \
+            AppDir \
             PKHeX-Avalonia-linux-x64.AppImage
           
           # remove the AppImage tool from the artifact list since we don't need it anymore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           EOF
 
           wget -q \
-            https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
 
           chmod +x appimagetool-x86_64.AppImage
 


### PR DESCRIPTION
This change enhances the current release action to automatically build and publish an AppImage additionally to the already existing zip creation.

The benefit of this is that it is easier to deploy this onto various linux systems, especially in combination with AppImage management tools, such as Gear Lever which even makes automatic updates possible.