### PR TITLE
Fix .main save files being unselectable in the open dialog on macOS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.22</UIVersion>
+    <UIVersion>1.1.23</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Services/DialogService.cs
+++ b/PKHeX.Avalonia/Services/DialogService.cs
@@ -21,15 +21,7 @@ public sealed class DialogService : IDialogService
         var window = GetMainWindow();
         if (window is null) return null;
 
-        var fileTypes = new List<FilePickerFileType>
-        {
-            new("All Files") { Patterns = ["*.*"] }
-        };
-
-        if (filters is not null)
-        {
-            fileTypes.Insert(0, new FilePickerFileType("Supported Files") { Patterns = filters });
-        }
+        var fileTypes = FileDialogFilterFactory.BuildOpenFileTypes(filters);
 
         var options = new FilePickerOpenOptions
         {

--- a/PKHeX.Avalonia/Services/FileDialogFilterFactory.cs
+++ b/PKHeX.Avalonia/Services/FileDialogFilterFactory.cs
@@ -1,0 +1,53 @@
+using global::Avalonia.Platform.Storage;
+
+namespace PKHeX.Avalonia.Services;
+
+/// <summary>
+/// Builds <see cref="FilePickerFileType"/> lists for file dialogs.
+/// </summary>
+/// <remarks>
+/// Avalonia's macOS native dialog ignores glob patterns: it extracts ".ext" suffixes from
+/// each pattern and silently drops the rest ("main", "*"), and only the literal "*.*"
+/// pattern marks a filter as "allow any file". Glob-based pickers (Windows/Linux) have the
+/// opposite quirk: "*.*" does not match extensionless files, only "*" does. Filters built
+/// here therefore carry wildcard intent in both forms.
+/// </remarks>
+public static class FileDialogFilterFactory
+{
+    /// <summary>
+    /// Patterns for the "Open Save File" dialog. Covers classic saves (*.sav),
+    /// raw dumps (*.bin), Switch saves (*.main, or the literal extensionless file
+    /// name "main"), and anything else via wildcard — save files come in many names
+    /// (savedata.bin, sav.dat, ...), so the dialog must never block a selection.
+    /// </summary>
+    public static readonly string[] OpenSaveFilePatterns = ["*.sav", "*.bin", "*.main", "main", "*"];
+
+    private static readonly string[] AnyFilePatterns = ["*", "*.*"];
+
+    public static List<FilePickerFileType> BuildOpenFileTypes(string[]? filters)
+    {
+        var fileTypes = new List<FilePickerFileType>
+        {
+            new("All Files") { Patterns = AnyFilePatterns }
+        };
+
+        if (filters is not null)
+        {
+            fileTypes.Insert(0, new FilePickerFileType("Supported Files") { Patterns = WithBothWildcardForms(filters) });
+        }
+
+        return fileTypes;
+    }
+
+    private static string[] WithBothWildcardForms(string[] patterns)
+    {
+        bool hasGlobAny = patterns.Contains("*");
+        bool hasMacAny = patterns.Contains("*.*");
+
+        if (hasGlobAny && !hasMacAny)
+            return [.. patterns, "*.*"];
+        if (hasMacAny && !hasGlobAny)
+            return [.. patterns, "*"];
+        return patterns;
+    }
+}

--- a/PKHeX.Avalonia/ViewModels/MainWindowViewModel.FileCommands.cs
+++ b/PKHeX.Avalonia/ViewModels/MainWindowViewModel.FileCommands.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.Input;
+using PKHeX.Avalonia.Services;
 using PKHeX.Avalonia.Views;
 using PKHeX.Core;
 
@@ -11,7 +12,7 @@ public partial class MainWindowViewModel
     {
         var path = await _dialogService.OpenFileAsync(
             "Open Save File",
-            ["*.sav", "*.bin", "main", "*"]);
+            FileDialogFilterFactory.OpenSaveFilePatterns);
 
         if (string.IsNullOrEmpty(path))
             return;

--- a/Tests/PKHeX.Avalonia.Tests/FileDialogFilterTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/FileDialogFilterTests.cs
@@ -1,0 +1,112 @@
+using Avalonia.Platform.Storage;
+using PKHeX.Avalonia.Services;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Regression tests for the file-open dialog filters (.main save files unselectable on macOS).
+///
+/// Avalonia's macOS native dialog does NOT use glob patterns directly. It converts each
+/// FilePickerFileType to a list of file extensions via TryGetExtensions(), silently dropping
+/// any pattern without a ".ext" suffix (e.g. "main", "*"). A type only allows arbitrary
+/// files when its patterns contain the literal "*.*" (IsAnyType). With the old filters
+/// ["*.sav", "*.bin", "main", "*"], the default "Supported Files" entry collapsed to just
+/// {sav, bin} on macOS, greying out .main Switch saves in the picker.
+/// </summary>
+public class FileDialogFilterTests
+{
+    /// <summary>
+    /// Mirror of Avalonia 11.2.3 FilePickerFileType.TryGetExtensions()
+    /// (src/Avalonia.Base/Platform/Storage/FilePickerFileType.cs) — what the macOS
+    /// native dialog actually receives for a filter type.
+    /// </summary>
+    private static string[] GetMacOsExtensions(FilePickerFileType type) =>
+        (type.Patterns ?? [])
+        .Select(Path.GetExtension)
+        .Where(e => !string.IsNullOrEmpty(e) && !e.Contains('*') && e.StartsWith('.'))
+        .Select(e => e!.TrimStart('.'))
+        .ToArray();
+
+    /// <summary>
+    /// Mirror of Avalonia's IsAnyType check (Avalonia.Native StorageProviderApi.cs):
+    /// only the literal "*.*" pattern makes a filter type allow any file on macOS.
+    /// </summary>
+    private static bool IsMacOsAnyType(FilePickerFileType type) =>
+        type.Patterns?.Contains("*.*") == true;
+
+    [Fact]
+    public void OpenSavePatterns_IncludeDotMainExtension()
+    {
+        Assert.Contains("*.main", FileDialogFilterFactory.OpenSaveFilePatterns);
+    }
+
+    [Fact]
+    public void OpenSavePatterns_KeepExtensionlessMainAndWildcard()
+    {
+        // Windows/Linux match the literal file name "main" and arbitrary names via glob.
+        Assert.Contains("main", FileDialogFilterFactory.OpenSaveFilePatterns);
+        Assert.Contains("*", FileDialogFilterFactory.OpenSaveFilePatterns);
+    }
+
+    [Fact]
+    public void SupportedFiles_OnMacOs_AllowMainExtension()
+    {
+        var types = FileDialogFilterFactory.BuildOpenFileTypes(FileDialogFilterFactory.OpenSaveFilePatterns);
+        var supported = types[0];
+
+        Assert.Equal("Supported Files", supported.Name);
+        Assert.Contains("main", GetMacOsExtensions(supported));
+    }
+
+    [Fact]
+    public void SupportedFiles_WithWildcardIntent_AllowAnyFileOnMacOs()
+    {
+        // An extensionless Switch save named "main" cannot be expressed as a macOS file
+        // extension, so a caller passing a wildcard must yield an any-type filter there.
+        var types = FileDialogFilterFactory.BuildOpenFileTypes(["*.sav", "*"]);
+        var supported = types[0];
+
+        Assert.True(IsMacOsAnyType(supported));
+    }
+
+    [Fact]
+    public void SupportedFiles_WithoutWildcard_KeepStrictFiltering()
+    {
+        var types = FileDialogFilterFactory.BuildOpenFileTypes(["*.pl6"]);
+        var supported = types[0];
+
+        Assert.False(IsMacOsAnyType(supported));
+        Assert.Equal(["pl6"], GetMacOsExtensions(supported));
+    }
+
+    [Fact]
+    public async Task MainSaveFiles_LoadThroughTheAppLoadPath()
+    {
+        // The dialog filter was the only thing blocking .main files; lock down the rest
+        // of the pipeline (SaveFileService -> FileUtil -> SaveUtil) so it stays that way.
+        var dir = Fixtures.SaveFileFixture.FindSaveFilesPath();
+        Assert.NotNull(dir);
+
+        var mainSaves = Directory.GetFiles(dir, "*.main");
+        Assert.NotEmpty(mainSaves);
+
+        var service = new SaveFileService();
+        foreach (var path in mainSaves)
+        {
+            Assert.True(await service.LoadSaveFileAsync(path), $"Failed to load {Path.GetFileName(path)}");
+        }
+    }
+
+    [Fact]
+    public void AllFiles_MatchExtensionlessFilesOnLinuxAndAnyFileOnMacOs()
+    {
+        // "*.*" alone fails to match extensionless files ("main") on glob-based pickers;
+        // "*" alone is dropped on macOS. Both forms must be present.
+        var types = FileDialogFilterFactory.BuildOpenFileTypes(null);
+        var allFiles = types[^1];
+
+        Assert.Equal("All Files", allFiles.Name);
+        Assert.Contains("*", allFiles.Patterns!);
+        Assert.True(IsMacOsAnyType(allFiles));
+    }
+}


### PR DESCRIPTION
## Problem
.main save files (Switch saves: LGPE, SWSH, BDSP, PLA, SV, ZA) could not be opened in the editor — they appeared greyed out in the file-open dialog on macOS.

## Root cause
Avalonia's macOS native dialog does not use glob patterns directly. `FilePickerFileType.TryGetExtensions()` converts each pattern to a file extension via `Path.GetExtension` and **silently drops** anything without a `.ext` suffix — including `"main"` and `"*"`. A filter only allows arbitrary files when its patterns contain the literal `"*.*"` (the `IsAnyType` check in Avalonia.Native).

The open-save filter `["*.sav", "*.bin", "main", "*"]` therefore collapsed to just `{sav, bin}` on macOS, so the default "Supported Files" filter blocked every .main file. (Core detection was verified fine: all .main fixtures load correctly through `FileUtil.GetSupportedFile`, the app's exact load path.)

## Fix (Avalonia layer only — PKHeX.Core untouched)
- New `FileDialogFilterFactory` owns dialog filter construction (extracted from `DialogService`):
  - adds `*.main` to the open-save patterns so the extension survives the macOS conversion
  - carries wildcard intent in **both** forms — `"*"` (glob pickers need it for extensionless files like the literal Switch `main` file) and `"*.*"` (the only form macOS honors as allow-any) — for the caller filter and the "All Files" entry
- `MainWindowViewModel.OpenFileAsync` uses the shared pattern constant

## Tests (TDD — written first, watched fail)
- 6 unit tests mirroring Avalonia 11.2.3's exact macOS conversion logic (`TryGetExtensions`/`IsAnyType`), which failed against the old filters and pass now
- 1 end-to-end regression test loading every `.main` fixture through `SaveFileService.LoadSaveFileAsync`

Full suite: **1788 passed, 0 failed**.

## Note (separate issue, follow-up flagged)
While verifying, found that `Tests/savefiles/gen7b_letsgopikachu.bin` (zero-filled) and `gen8_sword.bin` (size matches no known SWSH revision) never load, and `SaveFileFixture` silently skips unloadable saves — so LGPE/SWSH currently have no real-save test coverage. Tracked separately.