### PR TITLE
chore(release): bump UIVersion to 1.1.26

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.25</UIVersion>
+    <UIVersion>1.1.26</UIVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps `UIVersion` `1.1.25 → 1.1.26` in `Directory.Build.props`.

## Why
Cuts the **v1.1.26** release that ships the Linux **AppImage** support added in #75. The release pipeline (`.github/workflows/release.yml`) triggers on a push to `main` that changes `Directory.Build.props`, so merging this is what tags `v1.1.26` and runs the build/release across all platforms — including the new AppImage step — for the first time.

## Validation note
The AppImage step is not exercised by PR CI (the release workflow only runs on push-to-main / manual dispatch). A local cross-publish smoke test confirmed the `linux-x64` publish output is flat (so the non-recursive `cp publish/*` is safe) and the AppDir assembly succeeds. The `appimagetool` packaging itself first runs on this release. Plan is **fix-forward** if the run trips.

Follow-up (optional): the published AppImage currently bundles `.pdb` debug symbols and a stray macOS `icon.icns` (~3.5 MB) — can be stripped in a later cleanup.