### PR TITLE
feat(pkm-editor): Stat Alignment, Form Argument, TSV feedback

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.30</UIVersion>
+    <UIVersion>1.1.31</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -180,6 +180,15 @@
                                         <ComboBox ItemsSource="{Binding NatureList}"
                                                   SelectedValue="{Binding Nature}" SelectedValueBinding="{Binding Value}"
                                                   DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" />
+
+                                        <!-- Stat Alignment (gen8+) -->
+                                        <StackPanel IsVisible="{Binding ShowStatAlignment}" Margin="0,12,0,0">
+                                            <TextBlock Text="Stat Alignment" FontWeight="SemiBold" Margin="0,0,0,4" />
+                                            <ComboBox ItemsSource="{Binding NatureList}"
+                                                      SelectedValue="{Binding StatAlignment}" SelectedValueBinding="{Binding Value}"
+                                                      DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch"
+                                                      AutomationProperties.Name="Stat Alignment" />
+                                        </StackPanel>
                                     </StackPanel>
 
                                     <!-- Ability -->
@@ -518,17 +527,22 @@
                                                   DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" />
                                     </StackPanel>
 
-                                    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" ColumnDefinitions="*,16,*" Margin="0,12,0,0">
-                                        <StackPanel Grid.Column="0">
+                                    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto" Margin="0,12,0,0">
+                                        <StackPanel Grid.Row="0" Grid.Column="0">
                                             <TextBlock Text="TID" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding TrainerID}" Minimum="0" Maximum="4294967295" FormatString="0" ShowButtonSpinner="False"
-                                                           AutomationProperties.Name="Trainer ID" />
+                                                           AutomationProperties.Name="Trainer ID"
+                                                           ToolTip.Tip="{Binding Tsv, StringFormat='TSV: {0}'}" />
                                         </StackPanel>
-                                        <StackPanel Grid.Column="2">
+                                        <StackPanel Grid.Row="0" Grid.Column="2">
                                             <TextBlock Text="SID" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding Sid}" Minimum="0" Maximum="65535" FormatString="0" ShowButtonSpinner="False"
-                                                           AutomationProperties.Name="Secret ID" />
+                                                           AutomationProperties.Name="Secret ID"
+                                                           ToolTip.Tip="{Binding Tsv, StringFormat='TSV: {0}'}" />
                                         </StackPanel>
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" Margin="0,4,0,0"
+                                                   Opacity="0.6" Text="{Binding Tsv, StringFormat='TSV: {0}'}"
+                                                   AutomationProperties.Name="Trainer Shiny Value" />
                                     </Grid>
                                 </Grid>
                             </Border>
@@ -570,6 +584,24 @@
                                             </Grid>
                                         </StackPanel>
                                     </Grid>
+                                </StackPanel>
+                            </Border>
+
+                            <!-- Form Argument -->
+                            <Border IsVisible="{Binding ShowFormArgument}" Classes="section-card"
+                                    CornerRadius="4" Padding="12">
+                                <StackPanel>
+                                    <TextBlock Text="Form Argument" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
+                                    <ComboBox IsVisible="{Binding ShowFormArgumentNamed}"
+                                              ItemsSource="{Binding FormArgumentList}"
+                                              SelectedIndex="{Binding FormArgumentValue}"
+                                              HorizontalAlignment="Stretch"
+                                              AutomationProperties.Name="Form Argument" />
+                                    <NumericUpDown IsVisible="{Binding ShowFormArgumentRaw}"
+                                                   Value="{Binding FormArgumentValue}" Minimum="0"
+                                                   Maximum="{Binding FormArgumentMax}" FormatString="0"
+                                                   ShowButtonSpinner="True"
+                                                   AutomationProperties.Name="Form Argument" />
                                 </StackPanel>
                             </Border>
 

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
@@ -176,6 +176,94 @@ public partial class PokemonEditorViewModel
     [ObservableProperty]
     private int _abilityNumber;
 
+    // Form Argument (species/form-dependent extra value, e.g. Alcremie topping, Furfrou trim days)
+    private FormArgumentType _formArgumentType = FormArgumentType.None;
+
+    [ObservableProperty]
+    private int _formArgumentValue;
+
+    [ObservableProperty]
+    private int _formArgumentMax;
+
+    [ObservableProperty]
+    private IReadOnlyList<string> _formArgumentList = [];
+
+    /// <summary>Whether the current entity/species/form uses a Form Argument at all.</summary>
+    public bool ShowFormArgument => _pk is IFormArgument && _formArgumentType != FormArgumentType.None;
+
+    /// <summary>The Form Argument is a named selection (e.g. Alcremie topping).</summary>
+    public bool ShowFormArgumentNamed => ShowFormArgument && _formArgumentType == FormArgumentType.Named;
+
+    /// <summary>The Form Argument is a raw numeric value (everything editable that isn't Named).</summary>
+    public bool ShowFormArgumentRaw => ShowFormArgument && _formArgumentType != FormArgumentType.Named;
+
+    /// <summary>Re-evaluates the Form Argument type/range for the current species/form and reloads its value.</summary>
+    private void UpdateFormArgument()
+    {
+        if (_pk is not IFormArgument fa)
+        {
+            _formArgumentType = FormArgumentType.None;
+            FormArgumentList = [];
+            FormArgumentMax = 0;
+            NotifyFormArgumentVisibility();
+            return;
+        }
+
+        var species = (ushort)Species;
+        var form = (byte)Form;
+        _formArgumentType = FormArgumentUtil.GetType(species, form, _pk.Context);
+        FormArgumentList = _formArgumentType == FormArgumentType.Named
+            ? FormConverter.GetFormArgumentStrings(species)
+            : [];
+        FormArgumentMax = (int)FormArgumentUtil.GetFormArgumentMaxEdge(species, form, _pk.Context);
+
+        // Triple types (Furfrou/Hoopa) pack remain/elapsed/max into FormArgument; surface the "remain" value.
+        var current = FormArgumentUtil.IsFormArgumentTypeDateTriple(species, form)
+            ? fa.FormArgumentRemain
+            : fa.FormArgument;
+
+        var wasLoading = _isLoading;
+        _isLoading = true;
+        FormArgumentValue = (int)Math.Min(current, (uint)FormArgumentMax);
+        _isLoading = wasLoading;
+
+        NotifyFormArgumentVisibility();
+    }
+
+    private void NotifyFormArgumentVisibility()
+    {
+        OnPropertyChanged(nameof(ShowFormArgument));
+        OnPropertyChanged(nameof(ShowFormArgumentNamed));
+        OnPropertyChanged(nameof(ShowFormArgumentRaw));
+    }
+
+    partial void OnFormArgumentValueChanged(int value)
+    {
+        if (_isLoading) return;
+        if (_pk is not IFormArgument)
+            return;
+        _pk.ChangeFormArgument((uint)value);
+        Validate();
+    }
+
+    /// <summary>Trainer Shiny Value derived from the current TID/SID (format-aware via Core).</summary>
+    public int Tsv => (int)_pk.TSV;
+
     partial void OnOriginalTrainerGenderChanged(int value) { if (!_isLoading) Validate(); }
-    partial void OnTrainerIDChanged(long value) { if (!_isLoading) Validate(); }
+
+    partial void OnTrainerIDChanged(long value)
+    {
+        if (_isLoading) return;
+        _pk.DisplayTID = (uint)value;
+        OnPropertyChanged(nameof(Tsv));
+        Validate();
+    }
+
+    partial void OnSidChanged(int value)
+    {
+        if (_isLoading) return;
+        _pk.DisplaySID = (uint)value;
+        OnPropertyChanged(nameof(Tsv));
+        Validate();
+    }
 }

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Stats.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Stats.cs
@@ -1,6 +1,7 @@
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PKHeX.Core;
 
 namespace PKHeX.Presentation.ViewModels;
 
@@ -14,7 +15,7 @@ public partial class PokemonEditorViewModel
     private int _statHPMax;
 
     [ObservableProperty]
-    private int _statNature;
+    private int _statAlignment;
 
     [ObservableProperty]
     private int _hpType;
@@ -89,6 +90,11 @@ public partial class PokemonEditorViewModel
     public int IVTotal => IvHP + IvATK + IvDEF + IvSPA + IvSPD + IvSPE;
     public int EVTotal => EvHP + EvATK + EvDEF + EvSPA + EvSPD + EvSPE;
 
+    /// <summary>
+    /// Gen8+ formats store the displayed-stat alignment independently of <see cref="PKM.Nature"/>.
+    /// </summary>
+    public bool ShowStatAlignment => _pk.Format >= 8;
+
     private void RecalculateStats()
     {
         if (_isLoading) return; // Don't overwrite _pk during loading
@@ -130,6 +136,9 @@ public partial class PokemonEditorViewModel
         EvSPD = 0;
         EvSPE = 0;
     }
+
+    // Stat Alignment changes the displayed stats (gen8+ stores it independently of Nature).
+    partial void OnStatAlignmentChanged(int value) { if (!_isLoading) { _pk.StatAlignment = (Nature)value; RecalculateStats(); Validate(); } }
 
     // Recalculate once per change, then let NotifyPropertyChangedFor push the new values to the UI.
     partial void OnIvHPChanged(int value) { if (!_isLoading) { RecalculateStats(); Validate(); } }

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -230,6 +230,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
             StatHPCurrent = _pk.Stat_HPCurrent;
             StatHPMax = _pk.Stat_HPMax;
             StatusCondition = _pk.Status_Condition;
+            StatAlignment = (int)_pk.StatAlignment;
 
             // Trust any year in a broad valid range (Gen 3+ era: 2000–2199, with pre-2000 fallback)
             MetDate = _pk.MetDate is { } md && md.Year > 1900 && md.Year < 2200
@@ -247,6 +248,9 @@ public partial class PokemonEditorViewModel : ViewModelBase
             OnPropertyChanged(nameof(Ability));
             OnPropertyChanged(nameof(MetDate));
             OnPropertyChanged(nameof(EggDate));
+            OnPropertyChanged(nameof(ShowStatAlignment));
+            OnPropertyChanged(nameof(Tsv));
+            UpdateFormArgument();
 
             OriginalTrainerFriendship = _pk.OriginalTrainerFriendship;
             HandlingTrainerFriendship = _pk.HandlingTrainerFriendship;
@@ -256,7 +260,6 @@ public partial class PokemonEditorViewModel : ViewModelBase
 
             // Misc
             AbilityNumber = _pk.AbilityNumber;
-            StatNature = (int)_pk.StatAlignment;
             HpType = _pk.HPType;
             IsPokerusInfected = _pk.IsPokerusInfected;
             IsPokerusCured = _pk.IsPokerusCured;
@@ -334,6 +337,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
         if (_isLoading) return;
         RecalculateStats();
         UpdateAbilityList();
+        UpdateFormArgument();
         UpdateSprite();
     }
 
@@ -446,6 +450,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
         _pk.Nickname = Nickname;
         _pk.Stat_Level = (byte)Level;
         _pk.Nature = (Nature)Nature;
+        _pk.StatAlignment = (Nature)StatAlignment;
         _pk.Ability = Ability;
         _pk.HeldItem = HeldItem;
         _pk.Ball = (byte)Ball;
@@ -563,6 +568,9 @@ public partial class PokemonEditorViewModel : ViewModelBase
             mht.HandlingTrainerMemoryVariable = (ushort)HtMemoryVariable;
         }
 
+        if (_pk is IFormArgument && _formArgumentType != FormArgumentType.None)
+            _pk.ChangeFormArgument((uint)FormArgumentValue);
+
         _pk.ResetPartyStats();
         
         return _pk.Clone();
@@ -604,6 +612,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
         RecalculateStats();
         UpdateFormList();
         UpdateAbilityList();
+        UpdateFormArgument();
         UpdateSprite();
         UpdateTitle();
         OnPropertyChanged(nameof(CanOpenTechRecord));

--- a/Tests/PKHeX.Avalonia.Tests/ComprehensiveTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ComprehensiveTests.cs
@@ -488,14 +488,16 @@ public class ComprehensiveTests
             "Species", "Form", "Ability", "Level", "TargetPKM", "Nature", "Gender",
             "EggLocation", "MetLocation", "MetLevel", "OriginalTrainerGender", "Ball",
             "RelearnMove1", "RelearnMove2", "RelearnMove3", "RelearnMove4",
-            "StatHPCurrent", "StatHPMax", "Valid", "Version", "StatNature", "HpType",
+            "StatHPCurrent", "StatHPMax", "Valid", "Version", "StatAlignment", "HpType",
             "IsPokerusInfected", "IsPokerusCured", "AbilityNumber", "Id32", "IsNicknamed",
-            "StatusCondition", "HandlingTrainerName", "HandlingTrainerGender", 
+            "StatusCondition", "HandlingTrainerName", "HandlingTrainerGender",
             "HandlingTrainerFriendship", "CurrentHandler", "OriginalTrainerFriendship",
             "ContestCool", "ContestBeauty", "ContestCute", "ContestSmart", "ContestTough", "ContestSheen",
             "OtMemory", "OtMemoryIntensity", "OtMemoryFeeling", "OtMemoryVariable",
             "HtMemory", "HtMemoryIntensity", "HtMemoryFeeling", "HtMemoryVariable",
-            "Sid"
+            "Sid",
+            // Conditional on IFormArgument + species/form; not present on the PK3 test fixture.
+            "FormArgumentValue", "FormArgumentMax"
         };
 
         foreach (var prop in properties)


### PR DESCRIPTION
## Summary

Closes three PKM-editor field gaps found in the upstream frontend-parity audit (upstream WinForms changes never ported to the Avalonia editor). All three bind Core APIs that were already present in the mirror — pure UI additions, no `PKHeX.Core` changes.

### 1. Stat Alignment (gen8+)
`PKM.StatAlignment` (the displayed-stat nature, independent of `Nature` on format ≥ 8) was already *loaded* into the view-model but bound to no control and never written back — so it was inert. Now surfaced as a "Stat Alignment" combo (reusing the Nature list), visible only for gen8+ entities, with proper writeback in `PreparePKM` and stat recalculation on change.

### 2. TSV (Trainer Shiny Value) feedback
TID/SID editing showed no shiny-value feedback. Added a format-aware `Tsv` (Core's `PKM.TSV`) shown as a label under the TID/SID fields and as a tooltip on each, recomputed live as TID/SID change.

### 3. Form Argument editor
The species/form-dependent form argument (Alcremie topping, Furfrou trim days, Yamask-A damage, etc.) had no editor. Added a mode-switching control via `FormArgumentUtil.GetType`: a named combo (`FormConverter.GetFormArgumentStrings`) or a raw numeric (capped at `GetFormArgumentMaxEdge`), re-evaluated on species/form change, written back through `PKM.ChangeFormArgument`.

## Changes
- `PKHeX.Presentation/ViewModels/PokemonEditorViewModel.{cs,Stats.cs,Misc.cs}` — VM fields, load/writeback, change hooks.
- `PKHeX.Avalonia/Views/PokemonEditor.axaml` — Stat Alignment combo, TSV label/tooltips, Form Argument section.
- `Tests/PKHeX.Avalonia.Tests/ComprehensiveTests.cs` — round-trip exclusion list updated (renamed `StatNature`→`StatAlignment`; `FormArgumentValue/Max` are conditional on `IFormArgument`, absent on the PK3 fixture).
- `Directory.Build.props` — UIVersion 1.1.30 → 1.1.31.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2271 passed, 1 skipped, 0 failed
- ✅ No `PKHeX.Core` edits (Core stays 1:1 with upstream)

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
