### PR TITLE
feat(editors): Nickname filter, Mirage Island, inventory sprites

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.31</UIVersion>
+    <UIVersion>1.1.32</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/ISpriteRenderer.cs
+++ b/PKHeX.Application/Abstractions/ISpriteRenderer.cs
@@ -11,6 +11,7 @@ public interface ISpriteRenderer
 {
     byte[]? GetSprite(PKM pk, bool isEgg = false);
     byte[]? GetSprite(ushort species, byte form, byte gender, uint formarg, bool shiny, EntityContext context);
+    byte[]? GetItemSprite(int itemId);
     byte[]? GetEmptySlot();
     void Initialize(SaveFile sav);
 }

--- a/PKHeX.Avalonia/Services/AvaloniaSpriteRenderer.cs
+++ b/PKHeX.Avalonia/Services/AvaloniaSpriteRenderer.cs
@@ -54,6 +54,13 @@ public sealed class AvaloniaSpriteRenderer : ISpriteRenderer
         return EncodePng(skBitmap);
     }
 
+    public byte[]? GetItemSprite(int itemId)
+    {
+        var skBitmap = _loader.GetItemSprite(itemId);
+        if (skBitmap is null) return null;
+        return EncodePng(skBitmap);
+    }
+
     public byte[]? GetEmptySlot()
     {
         using var surface = SKSurface.Create(new SKImageInfo(SpriteWidth, SpriteHeight));

--- a/PKHeX.Avalonia/Views/InventoryEditor.axaml
+++ b/PKHeX.Avalonia/Views/InventoryEditor.axaml
@@ -51,6 +51,18 @@
                                           CanUserSortColumns="False"
                                           MaxHeight="450">
                                     <DataGrid.Columns>
+                                        <!-- Icon Column -->
+                                        <DataGridTemplateColumn Header="" Width="36">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate DataType="vm:InventoryItemViewModel">
+                                                    <Image Width="24" Height="24"
+                                                           Source="{Binding Sprite, Converter={StaticResource PngBytesToBitmap}}"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center" />
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+
                                         <!-- Item Column -->
                                         <DataGridTemplateColumn Header="Item" Width="*">
                                             <DataGridTemplateColumn.CellTemplate>

--- a/PKHeX.Avalonia/Views/Misc3Editor.axaml
+++ b/PKHeX.Avalonia/Views/Misc3Editor.axaml
@@ -63,6 +63,17 @@
                                     </Grid>
                                 </StackPanel>
                             </Border>
+
+                            <!-- Other Section (R/S/E only) -->
+                            <Border Classes="section-card" Padding="12" IsVisible="{Binding CanForceMirageIsland}">
+                                <StackPanel Spacing="12">
+                                    <TextBlock Text="Other" FontWeight="SemiBold" Opacity="0.6" />
+                                    <Button Content="Mirage Island Appear: Match First Party Member"
+                                            Command="{Binding ForceMirageIslandCommand}"
+                                            IsVisible="{Binding CanForceMirageIsland}"
+                                            HorizontalAlignment="Left" />
+                                </StackPanel>
+                            </Border>
                         </StackPanel>
                     </ScrollViewer>
                 </TabItem>

--- a/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
@@ -36,6 +36,11 @@
                         </StackPanel>
 
                         <StackPanel Spacing="4">
+                            <TextBlock Text="Nickname" Opacity="0.7" FontSize="12"/>
+                            <TextBox Text="{Binding Nickname}" Watermark="Nickname" HorizontalAlignment="Stretch"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
                             <TextBlock Text="Shiny" Opacity="0.7" FontSize="12"/>
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <RadioButton Content="Any" IsChecked="{Binding IsShiny, Converter={StaticResource ObjectNullConverter}}"/>

--- a/PKHeX.Presentation/ViewModels/InventoryEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/InventoryEditorViewModel.cs
@@ -8,12 +8,14 @@ namespace PKHeX.Presentation.ViewModels;
 public partial class InventoryEditorViewModel : ViewModelBase
 {
     private readonly SaveFile _sav;
+    private readonly ISpriteRenderer _spriteRenderer;
     private readonly PlayerBag? _bag;
     private readonly IReadOnlyList<InventoryPouch> _originalPouches;
 
-    public InventoryEditorViewModel(SaveFile sav)
+    public InventoryEditorViewModel(SaveFile sav, ISpriteRenderer spriteRenderer)
     {
         _sav = sav;
+        _spriteRenderer = spriteRenderer;
 
         // sav.Inventory can throw on blank SCBlock-based saves (LA, SV, ZA) where
         // blocks have Type=None and are not yet populated. Fall back to empty.
@@ -44,7 +46,7 @@ public partial class InventoryEditorViewModel : ViewModelBase
         // Create pouch view models
         foreach (var pouch in _originalPouches)
         {
-            Pouches.Add(new InventoryPouchViewModel(pouch, _itemNames));
+            Pouches.Add(new InventoryPouchViewModel(pouch, _itemNames, _spriteRenderer));
         }
 
         if (Pouches.Count > 0)
@@ -128,11 +130,13 @@ public partial class InventoryPouchViewModel : ViewModelBase
 {
     private readonly InventoryPouch _pouch;
     private readonly string[] _itemNames;
+    private readonly ISpriteRenderer _spriteRenderer;
 
-    public InventoryPouchViewModel(InventoryPouch pouch, string[] itemNames)
+    public InventoryPouchViewModel(InventoryPouch pouch, string[] itemNames, ISpriteRenderer spriteRenderer)
     {
         _pouch = pouch;
         _itemNames = itemNames;
+        _spriteRenderer = spriteRenderer;
         PouchName = pouch.Type.ToString();
         MaxCount = pouch.MaxCount;
 
@@ -177,7 +181,7 @@ public partial class InventoryPouchViewModel : ViewModelBase
         foreach (var item in _pouch.Items)
         {
             var name = item.Index < _itemNames.Length ? _itemNames[item.Index] : $"Item #{item.Index}";
-            Items.Add(new InventoryItemViewModel(item, name, ItemList, MaxCount));
+            Items.Add(new InventoryItemViewModel(item, name, ItemList, MaxCount, _spriteRenderer));
         }
     }
 
@@ -236,8 +240,9 @@ public partial class InventoryPouchViewModel : ViewModelBase
 public partial class InventoryItemViewModel : ViewModelBase
 {
     private readonly InventoryItem _item;
+    private readonly ISpriteRenderer _spriteRenderer;
 
-    public InventoryItemViewModel(InventoryItem item, string name, IReadOnlyList<ComboItem> itemList, int maxCount)
+    public InventoryItemViewModel(InventoryItem item, string name, IReadOnlyList<ComboItem> itemList, int maxCount, ISpriteRenderer spriteRenderer)
     {
         _item = item;
         _itemId = item.Index;
@@ -245,10 +250,13 @@ public partial class InventoryItemViewModel : ViewModelBase
         _itemName = name;
         ItemList = itemList;
         MaxCount = maxCount;
+        _spriteRenderer = spriteRenderer;
     }
 
     [ObservableProperty] private IReadOnlyList<ComboItem> _itemList;
     public int MaxCount { get; }
+
+    public byte[]? Sprite => _spriteRenderer.GetItemSprite(ItemId);
 
     public void RefreshLanguage()
     {
@@ -271,5 +279,6 @@ public partial class InventoryItemViewModel : ViewModelBase
     {
         var item = ItemList.FirstOrDefault(i => i.Value == value);
         ItemName = item?.Text ?? $"Item #{value}";
+        OnPropertyChanged(nameof(Sprite));
     }
 }

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -129,7 +129,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 PartyViewer = partyViewer;
 
                 TrainerEditor = new TrainerEditorViewModel(sav);
-                InventoryEditor = new InventoryEditorViewModel(sav);
+                InventoryEditor = new InventoryEditorViewModel(sav, _spriteRenderer);
                 EventFlagsEditor = new EventFlagsEditorViewModel(sav);
                 MysteryGiftEditor = new MysteryGiftEditorViewModel(sav, _dialogService);
                 BatchEditor = new BatchEditorViewModel(sav, _dialogService);

--- a/PKHeX.Presentation/ViewModels/Misc3EditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/Misc3EditorViewModel.cs
@@ -41,6 +41,22 @@ public partial class Misc3EditorViewModel : ViewModelBase
 
     #endregion
 
+    #region Other (R/S/E only)
+
+    public bool CanForceMirageIsland => _sav.SmallBlock is ISaveBlock3SmallHoenn;
+
+    [RelayCommand]
+    private void ForceMirageIsland()
+    {
+        if (_sav.SmallBlock is not ISaveBlock3SmallHoenn) return;
+        var party1 = _sav.LargeBlock.PartyBuffer;
+        if (party1.Length < 2) return;
+        var pidLow = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(party1);
+        _sav.SetWork(0x24, pidLow); // mirage island rand value is work 0x24; matching party slot-0 PID-low triggers the island
+    }
+
+    #endregion
+
     #region Records
 
     [ObservableProperty]

--- a/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
@@ -33,6 +33,7 @@ public partial class PKMDatabaseViewModel : ViewModelBase
     [ObservableProperty] private int _nature;
     [ObservableProperty] private int _ability;
     [ObservableProperty] private int _item;
+    [ObservableProperty] private string _nickname = string.Empty;
     [ObservableProperty] private bool? _isShiny;
     [ObservableProperty] private bool? _isLegal;
 
@@ -164,6 +165,7 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         Nature = (Nature)Nature,
         Ability = Ability,
         Item = Item,
+        Nickname = Nickname,
         SearchShiny = IsShiny,
         SearchLegal = IsLegal,
         Context = _sav.Context

--- a/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
@@ -78,7 +78,7 @@ public class DatabaseTests : IDisposable
 
         GameInfo.FilteredSources = new FilteredGameDataSource(sav, GameInfo.Sources);
 
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         var pouch = vm.Pouches.First(p => p.PouchName == "Items");
 
         var firstItem = pouch.ItemList.First(x => x.Value > 0);

--- a/Tests/PKHeX.Avalonia.Tests/InventoryEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/InventoryEditorTests.cs
@@ -19,7 +19,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
     public void InventoryEditor_SaveCommand_PersistsItemCount()
     {
         var sav = new SAV6XY();
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
 
         Assert.NotEmpty(vm.Pouches);
         var pouch = vm.Pouches.First(p => p.ItemList.Count > 0 && p.Items.Count > 0);
@@ -34,7 +34,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
         vm.SaveCommand.Execute(null);
 
         // Verify by reloading a fresh ViewModel from the same save
-        var vm2 = new InventoryEditorViewModel(sav);
+        var vm2 = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         var pouch2 = vm2.Pouches.First(p => p.PouchName == pouch.PouchName);
         var item2 = pouch2.Items[0];
 
@@ -56,7 +56,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
     public void InventoryEditor_GiveAll_SetsMaxCountAfterSave(GameVersion version, string label)
     {
         var sav = BlankSaveFile.Get(version);
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
 
         if (vm.Pouches.Count == 0) { output.WriteLine($"{label}: no pouches, skipping"); return; }
 
@@ -81,7 +81,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
     public void InventoryEditor_ClearAll_ZerosAllItems()
     {
         var sav = new SAV6XY();
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
 
         var pouch = vm.Pouches.FirstOrDefault(p => p.ItemList.Count > 0);
         if (pouch == null) { output.WriteLine("Gen6: no pouch with items, skipping"); return; }
@@ -97,7 +97,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
         vm.SaveCommand.Execute(null);
 
         // Verify via fresh ViewModel reload
-        var vm2 = new InventoryEditorViewModel(sav);
+        var vm2 = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         var pouch2 = vm2.Pouches.First(p => p.PouchName == pouch.PouchName);
         Assert.All(pouch2.Items, item => Assert.Equal(0, item.Count));
         output.WriteLine($"Gen6 '{pouch.PouchName}': all items zeroed after ClearAll ✓");
@@ -111,7 +111,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
     public void InventoryEditor_ResetCommand_DiscardsUncommittedChanges()
     {
         var sav = new SAV6XY();
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
 
         var pouch = vm.Pouches.FirstOrDefault(p => p.Items.Count > 0);
         if (pouch == null) { output.WriteLine("Gen6: no pouch, skipping"); return; }
@@ -139,7 +139,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
     public void InventoryEditor_ItemCount_RoundTripsExactly()
     {
         var sav = new SAV3E();
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
 
         var pouch = vm.Pouches.FirstOrDefault(p => p.ItemList.Count > 0 && p.Items.Count > 0);
         if (pouch == null) { output.WriteLine("Gen3 Emerald: no pouch with items, skipping"); return; }
@@ -151,7 +151,7 @@ public class InventoryEditorTests(ITestOutputHelper output)
 
         vm.SaveCommand.Execute(null);
 
-        var vm2 = new InventoryEditorViewModel(sav);
+        var vm2 = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         var pouch2 = vm2.Pouches.First(p => p.PouchName == pouch.PouchName);
         Assert.Equal(targetItemId, pouch2.Items[0].ItemId);
         Assert.Equal(50, pouch2.Items[0].Count);

--- a/Tests/PKHeX.Avalonia.Tests/LayoutTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LayoutTests.cs
@@ -109,7 +109,7 @@ public class LayoutTests
     [AvaloniaFact]
     public void Verify_InventoryEditor_Layout()
     {
-        var vm = new InventoryEditorViewModel(_saveFile);
+        var vm = new InventoryEditorViewModel(_saveFile, new Moq.Mock<ISpriteRenderer>().Object);
         // TODO: Populate inventory with max items if possible, but requires complex mocking
         var view = new InventoryEditor { DataContext = vm };
         ForceLayout(view);

--- a/Tests/PKHeX.Avalonia.Tests/RealSaveFileTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/RealSaveFileTests.cs
@@ -209,7 +209,7 @@ public class RealSaveFileTests(ITestOutputHelper output)
 
         var ex = Record.Exception(() =>
         {
-            var vm = new InventoryEditorViewModel(sav);
+            var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
             output.WriteLine($"Inventory pouches: {vm.Pouches.Count}");
         });
         Assert.Null(ex);
@@ -370,7 +370,7 @@ public class RealSaveFileTests(ITestOutputHelper output)
 
         var ex = Record.Exception(() =>
         {
-            var vm = new InventoryEditorViewModel(sav);
+            var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
             output.WriteLine($"Sun inventory pouches: {vm.Pouches.Count}");
         });
         Assert.Null(ex);

--- a/Tests/PKHeX.Avalonia.Tests/RealSaveIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/RealSaveIntegrationTests.cs
@@ -135,7 +135,7 @@ public class RealSaveIntegrationTests(ITestOutputHelper output)
         output.WriteLine(label);
         var ex = Record.Exception(() =>
         {
-            var vm = new InventoryEditorViewModel(sav);
+            var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
             output.WriteLine($"  Pouches: {vm.Pouches.Count}");
         });
         Assert.Null(ex);
@@ -377,7 +377,7 @@ public class RealSaveIntegrationTests(ITestOutputHelper output)
     public void Inventory_GiveAll_SetsNonZero(SaveFile sav, string label)
     {
         output.WriteLine(label);
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         if (vm.Pouches.Count == 0)
         {
             output.WriteLine($"  skip — no pouches");
@@ -398,7 +398,7 @@ public class RealSaveIntegrationTests(ITestOutputHelper output)
     public void Inventory_ClearAll_SetsZero(SaveFile sav, string label)
     {
         output.WriteLine(label);
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         if (vm.Pouches.Count == 0)
         {
             output.WriteLine($"  skip — no pouches");

--- a/Tests/PKHeX.Avalonia.Tests/SaveLoadAuditTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SaveLoadAuditTests.cs
@@ -115,7 +115,7 @@ public class SaveLoadAuditTests(ITestOutputHelper output)
     public void ViewModel_InventoryEditor_DoesNotThrow(SaveFile sav, string label)
     {
         output.WriteLine(label);
-        var ex = Record.Exception(() => new InventoryEditorViewModel(sav));
+        var ex = Record.Exception(() => new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object));
         Assert.Null(ex);
     }
 
@@ -187,7 +187,7 @@ public class SaveLoadAuditTests(ITestOutputHelper output)
     public void InventoryEditor_GiveAll_SetsNonZeroCountOnEveryPouch(SaveFile sav, string label)
     {
         output.WriteLine(label);
-        var vm = new InventoryEditorViewModel(sav);
+        var vm = new InventoryEditorViewModel(sav, new Moq.Mock<ISpriteRenderer>().Object);
         if (vm.Pouches.Count == 0)
         {
             output.WriteLine($"  skip — no pouches");


### PR DESCRIPTION
## Summary

Three small UI feature gaps from the frontend-parity audit (upstream WinForms changes never ported to Avalonia). All use Core APIs already present in the mirror; no `PKHeX.Core` changes.

### 1. Nickname filter — PKM Database
Upstream added a Nickname text filter to the database. Added a `Nickname` filter bound to `SearchSettings.Nickname`, with a TextBox in the filter sidebar.

### 2. Mirage Island force-appear — Gen3 R/S/E Misc editor
Ported upstream's "Mirage Island Appear: Match First Party Member" cheat: sets work `0x24` to the low 16 bits of party slot 0's PID (the value the game compares against to make the island appear). Visible only for R/S/E (`ISaveBlock3SmallHoenn`).

### 3. Item sprite column — Inventory editor
Inventory rows now show the item icon. Added `GetItemSprite(int)` to `ISpriteRenderer` (implemented in `AvaloniaSpriteRenderer` via the existing sprite loader), threaded the renderer into the inventory view-models, and added an icon column bound through the existing `PngBytesToBitmap` converter.

## Changes
- `PKHeX.Application/Abstractions/ISpriteRenderer.cs`, `PKHeX.Avalonia/Services/AvaloniaSpriteRenderer.cs` — `GetItemSprite`.
- `PKHeX.Presentation/ViewModels/{PKMDatabaseViewModel,Misc3EditorViewModel,InventoryEditorViewModel,MainWindowViewModel}.cs` — VM wiring.
- `PKHeX.Avalonia/Views/{PKMDatabaseView,Misc3Editor,InventoryEditor}.axaml` — UI.
- Tests updated to pass an `ISpriteRenderer` to the inventory VM constructor (mock).
- `Directory.Build.props` — UIVersion 1.1.31 → 1.1.32.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2271 passed, 1 skipped, 0 failed
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
