### PR TITLE
feat(medals): full Gen5 medal editing + Habitat list (B2W2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.32</UIVersion>
+    <UIVersion>1.1.33</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/MedalEditorView.axaml
+++ b/PKHeX.Avalonia/Views/MedalEditorView.axaml
@@ -3,7 +3,7 @@
              xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
              x:Class="PKHeX.Avalonia.Views.MedalEditorView"
              x:DataType="vm:MedalEditorViewModel"
-             MinWidth="500" MinHeight="450">
+             MinWidth="640" MinHeight="560">
     <DockPanel Margin="16">
         <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
             <TextBlock Text="Medal Rally" FontSize="20" FontWeight="SemiBold" />
@@ -16,60 +16,166 @@
         </StackPanel>
 
         <!-- Not Supported Message -->
-        <TextBlock IsVisible="{Binding !IsSupported}" Text="This save file does not support Medal editing. (B2W2 only)" 
-                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" 
+        <TextBlock IsVisible="{Binding !IsSupported}" Text="This save file does not support Medal editing. (B2W2 only)"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                    FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center" />
 
         <!-- Medal Content -->
         <DockPanel IsVisible="{Binding IsSupported}">
             <!-- Action Buttons -->
             <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8" Margin="0,12,0,0">
-                <Button Content="Obtain All" Command="{Binding ObtainAllCommand}" Padding="16,6" />
+                <Button Content="Give All" Command="{Binding GiveAllCommand}" Padding="16,6" />
                 <Button Content="Clear All" Command="{Binding ClearAllCommand}" Padding="16,6" />
                 <Button Content="Refresh" Command="{Binding RefreshCommand}" Padding="16,6" />
             </StackPanel>
 
-            <!-- Categories -->
-            <ItemsControl ItemsSource="{Binding Categories}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate DataType="vm:MedalCategoryViewModel">
-                        <Border Classes="section-card" Margin="0,0,0,8">
-                            <Expander Header="{Binding Name}">
-                                <Expander.HeaderTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal" Spacing="12">
-                                            <TextBlock Text="{Binding}" FontWeight="SemiBold" />
-                                            <TextBlock Text="{Binding $parent[Expander].((vm:MedalCategoryViewModel)DataContext).Summary}" 
-                                                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </Expander.HeaderTemplate>
-                                <ItemsControl ItemsSource="{Binding Medals}" Margin="0,8,0,0">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <WrapPanel />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate DataType="vm:MedalItemViewModel">
-                                            <Border MinWidth="80" Height="50" Margin="4" Padding="4" CornerRadius="4"
-                                                    Classes="view-container"
-                                                    ToolTip.Tip="{Binding StateText}">
-                                                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                                                    <TextBlock Text="{Binding Index}" HorizontalAlignment="Center" FontSize="14" FontWeight="SemiBold" />
-                                                    <TextBlock Text="{Binding StateText}" 
-                                                               HorizontalAlignment="Center" FontSize="10"
-                                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
-                                                </StackPanel>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </Expander>
+            <TabControl>
+                <!-- ===================== Medals Tab ===================== -->
+                <TabItem Header="Medals">
+                    <DockPanel>
+                        <!-- Settings + Import/Export -->
+                        <Border DockPanel.Dock="Top" Classes="section-card" Margin="0,8,0,8" Padding="12">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Settings" FontWeight="SemiBold" />
+                                <Grid ColumnDefinitions="Auto,160,Auto,160" RowDefinitions="Auto,Auto" >
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Pinned Medal" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                    <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding PinnedMedal}"
+                                                   Minimum="0" Maximum="255" FormatString="0"
+                                                   Classes="compact" Margin="0,0,16,6" />
+
+                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="Rank" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                    <StackPanel Grid.Row="0" Grid.Column="3" Orientation="Horizontal" Spacing="6" Margin="0,0,0,6">
+                                        <ComboBox ItemsSource="{Binding RankChoices}" SelectedIndex="{Binding RankIndex}"
+                                                  MinWidth="110" />
+                                        <Button Content="Recalculate" Command="{Binding RecalculateRankCommand}" Padding="8,4" />
+                                    </StackPanel>
+
+                                    <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                              Content="Tutorial Complete" IsChecked="{Binding IsTutorialComplete}" />
+                                </Grid>
+
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Button Content="Import (.ml5)" Command="{Binding ImportAllCommand}" Padding="12,4" />
+                                    <Button Content="Export (.ml5)" Command="{Binding ExportAllCommand}" Padding="12,4" />
+                                </StackPanel>
+                            </StackPanel>
                         </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+
+                        <!-- Editable Medal Grid -->
+                        <Border Classes="section-card" CornerRadius="4" Padding="0" ClipToBounds="True">
+                            <DataGrid ItemsSource="{Binding MedalRows}"
+                                      AutoGenerateColumns="False"
+                                      CanUserResizeColumns="True"
+                                      CanUserSortColumns="False"
+                                      IsReadOnly="False"
+                                      MinHeight="320">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="48" IsReadOnly="True" />
+                                    <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="120" IsReadOnly="True" />
+                                    <DataGridTemplateColumn Header="State" Width="160">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:MedalItemViewModel">
+                                                <ComboBox ItemsSource="{Binding StateChoices}"
+                                                          SelectedIndex="{Binding StateIndex}"
+                                                          HorizontalAlignment="Stretch" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Unread" Width="70">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:MedalItemViewModel">
+                                                <CheckBox IsChecked="{Binding IsUnread}"
+                                                          HorizontalAlignment="Center" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Date (yyyy-MM-dd)" Width="*">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:MedalItemViewModel">
+                                                <TextBox Text="{Binding Date}"
+                                                         IsEnabled="{Binding CanHaveDate}"
+                                                         Watermark="—"
+                                                         HorizontalAlignment="Stretch" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </Border>
+                    </DockPanel>
+                </TabItem>
+
+                <!-- ===================== Habitat Tab ===================== -->
+                <TabItem Header="Habitat">
+                    <DockPanel>
+                        <!-- Habitat Settings + Actions -->
+                        <Border DockPanel.Dock="Top" Classes="section-card" Margin="0,8,0,8" Padding="12">
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Settings" FontWeight="SemiBold" />
+                                <Grid ColumnDefinitions="Auto,160" RowDefinitions="Auto">
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Last Encounter Type" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <ComboBox Grid.Row="0" Grid.Column="1" ItemsSource="{Binding EncounterTypeChoices}"
+                                              SelectedIndex="{Binding LastEncounterTypeIndex}" MinWidth="120" />
+                                </Grid>
+                                <CheckBox Content="Tutorial Viewed" IsChecked="{Binding HabitatTutorialViewed}" />
+                                <CheckBox Content="Tutorial Complete (Capture)" IsChecked="{Binding HabitatTutorialCompleteCapture}" />
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Button Content="Complete All" Command="{Binding HabitatCompleteAllCommand}" Padding="12,4" />
+                                    <Button Content="Clear All" Command="{Binding HabitatClearAllCommand}" Padding="12,4" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Editable Habitat Grid -->
+                        <Border Classes="section-card" CornerRadius="4" Padding="0" ClipToBounds="True">
+                            <DataGrid ItemsSource="{Binding HabitatRows}"
+                                      AutoGenerateColumns="False"
+                                      CanUserResizeColumns="True"
+                                      CanUserSortColumns="False"
+                                      IsReadOnly="False"
+                                      MinHeight="320">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="#" Binding="{Binding Index}" Width="48" IsReadOnly="True" />
+                                    <DataGridTemplateColumn Header="Complete" Width="80">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:HabitatRowViewModel">
+                                                <CheckBox IsChecked="{Binding IsComplete}" HorizontalAlignment="Center" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Grass" Width="*">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:HabitatRowViewModel">
+                                                <ComboBox ItemsSource="{Binding HabitatCompletionChoices}"
+                                                          SelectedIndex="{Binding GrassIndex}"
+                                                          HorizontalAlignment="Stretch" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Surf" Width="*">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:HabitatRowViewModel">
+                                                <ComboBox ItemsSource="{Binding HabitatCompletionChoices}"
+                                                          SelectedIndex="{Binding SurfIndex}"
+                                                          HorizontalAlignment="Stretch" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Fish" Width="*">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate DataType="vm:HabitatRowViewModel">
+                                                <ComboBox ItemsSource="{Binding HabitatCompletionChoices}"
+                                                          SelectedIndex="{Binding FishIndex}"
+                                                          HorizontalAlignment="Stretch" />
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </Border>
+                    </DockPanel>
+                </TabItem>
+            </TabControl>
         </DockPanel>
     </DockPanel>
 </UserControl>

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -468,7 +468,7 @@ public partial class MainWindowViewModel
     {
         if (CurrentSave is null) return;
         await _windowService.ShowDialogAsync(
-            new MedalEditorViewModel(CurrentSave),
+            new MedalEditorViewModel(CurrentSave, _dialogService),
             "Medal Rally Editor");
     }
 

--- a/PKHeX.Presentation/ViewModels/MedalEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MedalEditorViewModel.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PKHeX.Core;
@@ -8,19 +12,30 @@ namespace PKHeX.Presentation.ViewModels;
 
 public partial class MedalEditorViewModel : ViewModelBase
 {
+    private const int MaxMedals = 255;
+    private const string DateFormat = "yyyy-MM-dd";
+    private const string MedalListExtension = "ml5";
+
     private readonly SaveFile _sav;
+    private readonly IDialogService? _dialogService;
     private readonly MedalList5? _medals;
+    private HabitatList5? _habitat;
 
-    private static readonly string[] CategoryNames = ["Special", "Adventure", "Battle", "Entertainment", "Challenge"];
+    private bool _suppressSettingsWrite;
 
-    public MedalEditorViewModel(SaveFile sav)
+    public MedalEditorViewModel(SaveFile sav) : this(sav, null) { }
+
+    public MedalEditorViewModel(SaveFile sav, IDialogService? dialogService)
     {
         _sav = sav;
+        _dialogService = dialogService;
 
         if (sav is SAV5B2W2 b2w2)
         {
             _medals = b2w2.Medals;
+            _habitat = _medals.HabitatList;
             IsSupported = true;
+            BuildEnumChoices();
             LoadData();
         }
     }
@@ -28,27 +43,73 @@ public partial class MedalEditorViewModel : ViewModelBase
     public bool IsSupported { get; }
     public string GameInfo => $"{_sav.Version} - Medals (255)";
 
+    public string[] StateChoices { get; private set; } = [];
+    public string[] HabitatCompletionChoices { get; private set; } = [];
+    public string[] RankChoices { get; private set; } = [];
+    public string[] EncounterTypeChoices { get; private set; } = [];
+
     [ObservableProperty]
     private ObservableCollection<MedalCategoryViewModel> _categories = [];
 
     [ObservableProperty]
+    private ObservableCollection<MedalItemViewModel> _medalRows = [];
+
+    [ObservableProperty]
+    private ObservableCollection<HabitatRowViewModel> _habitatRows = [];
+
+    [ObservableProperty]
     private int _totalObtained;
 
+    // Medal list settings.
+    [ObservableProperty]
+    private int _pinnedMedal;
+
+    [ObservableProperty]
+    private int _rankIndex;
+
+    [ObservableProperty]
+    private bool _isTutorialComplete;
+
+    // Habitat settings.
+    [ObservableProperty]
+    private bool _habitatTutorialViewed;
+
+    [ObservableProperty]
+    private bool _habitatTutorialCompleteCapture;
+
+    [ObservableProperty]
+    private int _lastEncounterTypeIndex;
+
+    private void BuildEnumChoices()
+    {
+        StateChoices = Enum.GetNames<MedalState5>();
+        HabitatCompletionChoices = Enum.GetNames<HabitatCompletion5>();
+        RankChoices = Enum.GetNames<MedalRank5>();
+        EncounterTypeChoices = Enum.GetNames<HabitatEncounterType5>();
+    }
+
     private void LoadData()
+    {
+        LoadMedalData();
+        LoadHabitatData();
+        LoadHabitatSettings();
+    }
+
+    private void LoadMedalData()
     {
         if (_medals is null) return;
 
         Categories.Clear();
+        MedalRows.Clear();
         TotalObtained = 0;
 
-        // Category ranges from MedalList5.GetMedalType
         var ranges = new (int start, int end, string name)[]
         {
             (0, 6, "Special"),
             (7, 104, "Adventure"),
             (105, 160, "Battle"),
             (161, 235, "Entertainment"),
-            (236, 254, "Challenge")
+            (236, 254, "Challenge"),
         };
 
         foreach (var (start, end, name) in ranges)
@@ -56,33 +117,235 @@ public partial class MedalEditorViewModel : ViewModelBase
             var cat = new MedalCategoryViewModel(name);
             for (int i = start; i <= end; i++)
             {
-                var medal = _medals[i];
-                var vm = new MedalItemViewModel(i, medal.State, medal.IsObtained);
+                var vm = new MedalItemViewModel(this, i);
                 cat.Medals.Add(vm);
-                if (medal.IsObtained) TotalObtained++;
+                MedalRows.Add(vm);
+                if (vm.IsObtained) TotalObtained++;
             }
             Categories.Add(cat);
         }
+
+        _suppressSettingsWrite = true;
+        PinnedMedal = _medals.PinnedMedal;
+        RankIndex = (int)_medals.Rank;
+        IsTutorialComplete = _medals.IsTutorialComplete;
+        _suppressSettingsWrite = false;
+    }
+
+    private void LoadHabitatData()
+    {
+        if (_habitat is null) return;
+
+        HabitatRows.Clear();
+        for (int i = 0; i < HabitatList5.HabitatCount; i++)
+            HabitatRows.Add(new HabitatRowViewModel(this, i));
+    }
+
+    private void LoadHabitatSettings()
+    {
+        if (_habitat is not { } habitat) return;
+
+        _suppressSettingsWrite = true;
+        HabitatTutorialViewed = habitat.IsTutorialViewed;
+        HabitatTutorialCompleteCapture = habitat.IsTutorialCompleteCapture;
+        LastEncounterTypeIndex = (int)habitat.LastEncounterType;
+        _suppressSettingsWrite = false;
+    }
+
+    internal Medal5 GetMedal(int index) => _medals![index];
+
+    internal HabitatStatus5 GetHabitat(int index) => _habitat!.GetHabitat(index);
+
+    internal void MarkEdited() => _sav.State.Edited = true;
+
+    internal void RecountObtained()
+    {
+        if (_medals is null) return;
+        TotalObtained = _medals.GetCountObtained();
+    }
+
+    partial void OnPinnedMedalChanged(int value)
+    {
+        if (_suppressSettingsWrite || _medals is null) return;
+        if (value is < 0 or > MaxMedals) return;
+        _medals.PinnedMedal = (byte)value;
+        MarkEdited();
+    }
+
+    partial void OnRankIndexChanged(int value)
+    {
+        if (_suppressSettingsWrite || _medals is null) return;
+        if (value < 0) return;
+        _medals.Rank = (MedalRank5)value;
+        MarkEdited();
+    }
+
+    partial void OnIsTutorialCompleteChanged(bool value)
+    {
+        if (_suppressSettingsWrite || _medals is null) return;
+        _medals.IsTutorialComplete = value;
+        MarkEdited();
+    }
+
+    partial void OnHabitatTutorialViewedChanged(bool value)
+    {
+        if (_suppressSettingsWrite || _habitat is not { } habitat) return;
+        habitat.IsTutorialViewed = value;
+        MarkEdited();
+    }
+
+    partial void OnHabitatTutorialCompleteCaptureChanged(bool value)
+    {
+        if (_suppressSettingsWrite || _habitat is not { } habitat) return;
+        habitat.IsTutorialCompleteCapture = value;
+        MarkEdited();
+    }
+
+    partial void OnLastEncounterTypeIndexChanged(int value)
+    {
+        if (_suppressSettingsWrite || _habitat is not { } habitat) return;
+        if (value < 0) return;
+        habitat.LastEncounterType = (HabitatEncounterType5)value;
+        MarkEdited();
     }
 
     [RelayCommand]
-    private void ObtainAll()
+    private void GiveAll()
     {
-        _medals?.ObtainAll(DateOnly.FromDateTime(System.DateTime.Now));
-        LoadData();
+        if (_medals is null) return;
+        _medals.GiveAll(EncounterDate.GetDateNDS(), unread: true);
+        MarkEdited();
+        LoadMedalData();
+        RefreshMedalRows();
     }
 
     [RelayCommand]
     private void ClearAll()
     {
         if (_medals is null) return;
-        for (int i = 0; i < 255; i++)
+        for (int i = 0; i < MaxMedals; i++)
             _medals[i].Clear();
-        LoadData();
+        MarkEdited();
+        LoadMedalData();
+        RefreshMedalRows();
+    }
+
+    [RelayCommand]
+    private void RecalculateRank()
+    {
+        if (_medals is null) return;
+        RankIndex = (int)_medals.CalculateRank();
+        // RankIndex setter persists + marks edited.
+    }
+
+    [RelayCommand]
+    private void HabitatCompleteAll()
+    {
+        if (_habitat is not { } habitat) return;
+        habitat.CompleteAll();
+        MarkEdited();
+        RefreshHabitatRows();
+    }
+
+    [RelayCommand]
+    private void HabitatClearAll()
+    {
+        if (_habitat is not { } habitat) return;
+        for (int i = 0; i < HabitatList5.HabitatCount; i++)
+            habitat.GetHabitat(i).Clear();
+        MarkEdited();
+        RefreshHabitatRows();
     }
 
     [RelayCommand]
     private void Refresh() => LoadData();
+
+    [RelayCommand]
+    private async Task ExportAllAsync()
+    {
+        if (_medals is null) return;
+        if (_dialogService is null) return;
+
+        var path = await _dialogService.SaveFileAsync("Export Medal List", GetDefaultFileName(), [MedalListExtension]);
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            await File.WriteAllBytesAsync(path, _medals.AllMedals.ToArray());
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Export Error", ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ImportAllAsync()
+    {
+        if (_medals is null) return;
+        if (_dialogService is null) return;
+
+        var path = await _dialogService.OpenFileAsync("Import Medal List", [MedalListExtension]);
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            var data = await File.ReadAllBytesAsync(path);
+            if (data.Length != MedalList5.LengthAllMedals)
+            {
+                await _dialogService.ShowErrorAsync("Import Error",
+                    $"Medal list size mismatch. Expected {MedalList5.LengthAllMedals} bytes, got {data.Length} bytes.");
+                return;
+            }
+
+            data.AsSpan().CopyTo(_medals.AllMedals);
+            MarkEdited();
+            LoadMedalData();
+            RefreshMedalRows();
+            await _dialogService.ShowInformationAsync("Import Successful", "Medal list has been imported.");
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Import Error", ex.Message);
+        }
+    }
+
+    private void RefreshMedalRows()
+    {
+        foreach (var row in MedalRows)
+            row.RefreshFromSave();
+        RecountObtained();
+    }
+
+    private void RefreshHabitatRows()
+    {
+        foreach (var row in HabitatRows)
+            row.RefreshFromSave();
+    }
+
+    private string GetDefaultFileName()
+    {
+        var name = PathUtil.CleanFileName($"{_sav.OT} {_sav.Version}.{MedalListExtension}");
+        return string.IsNullOrWhiteSpace(name) ? $"Medals.{MedalListExtension}" : name;
+    }
+
+    internal static bool TryParseDate(string? text, out DateOnly date)
+    {
+        date = default;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        if (!DateOnly.TryParse(text, System.Globalization.CultureInfo.CurrentCulture, System.Globalization.DateTimeStyles.None, out date) &&
+            !DateOnly.TryParseExact(text, DateFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out date))
+        {
+            return false;
+        }
+
+        return EncounterDate.IsValidDateNDS(date);
+    }
+
+    internal static string FormatDate(DateOnly date) => date.ToString(DateFormat, System.Globalization.CultureInfo.InvariantCulture);
 }
 
 public partial class MedalCategoryViewModel : ViewModelBase
@@ -100,26 +363,166 @@ public partial class MedalCategoryViewModel : ViewModelBase
     private ObservableCollection<MedalItemViewModel> _medals = [];
 }
 
-public class MedalItemViewModel
+public partial class MedalItemViewModel : ViewModelBase
 {
-    public MedalItemViewModel(int index, MedalState5 state, bool isObtained)
+    private readonly MedalEditorViewModel _parent;
+    private bool _suppressWrite;
+
+    public MedalItemViewModel(MedalEditorViewModel parent, int index)
     {
+        _parent = parent;
         Index = index;
-        State = state;
-        IsObtained = isObtained;
+        Type = MedalList5.GetMedalType(index).ToString();
+        RefreshFromSave();
     }
 
     public int Index { get; }
-    public MedalState5 State { get; }
-    public bool IsObtained { get; }
+    public string Type { get; }
 
-    public string StateText => State switch
+    [ObservableProperty]
+    private int _stateIndex;
+
+    [ObservableProperty]
+    private bool _isUnread;
+
+    [ObservableProperty]
+    private string _date = string.Empty;
+
+    [ObservableProperty]
+    private bool _canHaveDate;
+
+    [ObservableProperty]
+    private bool _isObtained;
+
+    [ObservableProperty]
+    private string _stateText = string.Empty;
+
+    public string[] StateChoices => _parent.StateChoices;
+
+    internal void RefreshFromSave()
+    {
+        var medal = _parent.GetMedal(Index);
+        _suppressWrite = true;
+        StateIndex = (int)medal.State;
+        IsUnread = medal.IsUnread;
+        CanHaveDate = medal.CanHaveDate;
+        Date = medal is { CanHaveDate: true, HasDate: true } ? MedalEditorViewModel.FormatDate(medal.Date) : string.Empty;
+        IsObtained = medal.IsObtained;
+        StateText = StateToText((MedalState5)StateIndex);
+        _suppressWrite = false;
+    }
+
+    partial void OnStateIndexChanged(int value)
+    {
+        if (_suppressWrite || value < 0) return;
+        var medal = _parent.GetMedal(Index);
+        medal.State = (MedalState5)value;
+        // When transitioning to a state that can carry a date but lacks one, stamp now (mirrors upstream).
+        if (medal is { CanHaveDate: true, HasDate: false })
+            medal.Date = EncounterDate.GetDateNDS();
+        _parent.MarkEdited();
+
+        // Re-read derived fields (date / obtained / canHaveDate) without re-triggering writes.
+        _suppressWrite = true;
+        CanHaveDate = medal.CanHaveDate;
+        Date = medal is { CanHaveDate: true, HasDate: true } ? MedalEditorViewModel.FormatDate(medal.Date) : string.Empty;
+        IsObtained = medal.IsObtained;
+        StateText = StateToText((MedalState5)value);
+        _suppressWrite = false;
+
+        _parent.RecountObtained();
+    }
+
+    partial void OnIsUnreadChanged(bool value)
+    {
+        if (_suppressWrite) return;
+        var medal = _parent.GetMedal(Index);
+        medal.IsUnread = value;
+        _parent.MarkEdited();
+    }
+
+    partial void OnDateChanged(string value)
+    {
+        if (_suppressWrite) return;
+        var medal = _parent.GetMedal(Index);
+        if (!medal.CanHaveDate) return;
+        if (!MedalEditorViewModel.TryParseDate(value, out var date)) return;
+
+        medal.Date = date;
+        _parent.MarkEdited();
+
+        _suppressWrite = true;
+        Date = MedalEditorViewModel.FormatDate(date);
+        _suppressWrite = false;
+    }
+
+    private static string StateToText(MedalState5 state) => state switch
     {
         MedalState5.Unobtained => "Not Obtained",
         MedalState5.HintReady => "Hint Ready",
         MedalState5.HintObtained => "Hint Obtained",
         MedalState5.ObtainReady => "Ready to Obtain",
-        MedalState5.Obtained => "Obtained ✓",
-        _ => State.ToString()
+        MedalState5.Obtained => "Obtained",
+        _ => state.ToString(),
     };
+}
+
+public partial class HabitatRowViewModel : ViewModelBase
+{
+    private readonly MedalEditorViewModel _parent;
+    private bool _suppressWrite;
+
+    public HabitatRowViewModel(MedalEditorViewModel parent, int index)
+    {
+        _parent = parent;
+        Index = index;
+        RefreshFromSave();
+    }
+
+    public int Index { get; }
+
+    public string[] HabitatCompletionChoices => _parent.HabitatCompletionChoices;
+
+    [ObservableProperty]
+    private bool _isComplete;
+
+    [ObservableProperty]
+    private int _grassIndex;
+
+    [ObservableProperty]
+    private int _surfIndex;
+
+    [ObservableProperty]
+    private int _fishIndex;
+
+    internal void RefreshFromSave()
+    {
+        var habitat = _parent.GetHabitat(Index);
+        _suppressWrite = true;
+        IsComplete = habitat.IsComplete;
+        GrassIndex = (int)habitat.GetStatus(HabitatEncounterType5.Grass);
+        SurfIndex = (int)habitat.GetStatus(HabitatEncounterType5.Surf);
+        FishIndex = (int)habitat.GetStatus(HabitatEncounterType5.Fish);
+        _suppressWrite = false;
+    }
+
+    partial void OnIsCompleteChanged(bool value)
+    {
+        if (_suppressWrite) return;
+        var habitat = _parent.GetHabitat(Index);
+        habitat.IsComplete = value;
+        _parent.MarkEdited();
+    }
+
+    partial void OnGrassIndexChanged(int value) => SetStatus(HabitatEncounterType5.Grass, value);
+    partial void OnSurfIndexChanged(int value) => SetStatus(HabitatEncounterType5.Surf, value);
+    partial void OnFishIndexChanged(int value) => SetStatus(HabitatEncounterType5.Fish, value);
+
+    private void SetStatus(HabitatEncounterType5 type, int value)
+    {
+        if (_suppressWrite || value < 0) return;
+        var habitat = _parent.GetHabitat(Index);
+        habitat.SetStatus(type, (HabitatCompletion5)value);
+        _parent.MarkEdited();
+    }
 }

--- a/Tests/PKHeX.Avalonia.Tests/MedalEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/MedalEditorTests.cs
@@ -1,0 +1,201 @@
+using System.Linq;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class MedalEditorTests
+{
+    private static SAV5B2W2 NewSave() => new();
+
+    [Fact]
+    public void Medal_NonB2W2_IsNotSupported()
+    {
+        var vm = new MedalEditorViewModel(new SAV5BW());
+        Assert.False(vm.IsSupported);
+        Assert.Empty(vm.MedalRows);
+        Assert.Empty(vm.HabitatRows);
+    }
+
+    [Fact]
+    public void Medal_B2W2_LoadsAllRowsAndHabitat()
+    {
+        var vm = new MedalEditorViewModel(NewSave());
+
+        Assert.True(vm.IsSupported);
+        Assert.Equal(255, vm.MedalRows.Count);
+        Assert.Equal(HabitatList5.HabitatCount, vm.HabitatRows.Count);
+        Assert.Equal(5, vm.Categories.Count);
+        Assert.Equal(255, vm.Categories.Sum(c => c.Medals.Count));
+    }
+
+    [Fact]
+    public void Medal_EditState_WritesThroughToSave()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        var row = vm.MedalRows[10];
+        row.StateIndex = (int)MedalState5.Obtained;
+
+        Assert.Equal(MedalState5.Obtained, sav.Medals[10].State);
+        Assert.True(row.IsObtained);
+        Assert.True(row.CanHaveDate);
+        // Stamping a date is automatic when transitioning into a date-capable obtained state.
+        Assert.NotEqual(string.Empty, row.Date);
+        Assert.Equal(1, vm.TotalObtained);
+    }
+
+    [Fact]
+    public void Medal_UnreadFlag_WritesThroughToSave()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        vm.MedalRows[3].IsUnread = true;
+        Assert.True(sav.Medals[3].IsUnread);
+
+        vm.MedalRows[3].IsUnread = false;
+        Assert.False(sav.Medals[3].IsUnread);
+    }
+
+    [Fact]
+    public void Medal_Date_DisabledWhenStateCannotHaveDate()
+    {
+        var vm = new MedalEditorViewModel(NewSave());
+        var row = vm.MedalRows[0];
+        Assert.Equal((int)MedalState5.Unobtained, row.StateIndex);
+        Assert.False(row.CanHaveDate);
+    }
+
+    [Fact]
+    public void Medal_GiveAll_ObtainsEverythingAndSetsRank()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        vm.GiveAllCommand.Execute(null);
+
+        Assert.Equal(255, vm.TotalObtained);
+        Assert.Equal(255, sav.Medals.GetCountObtained());
+        Assert.Equal((int)MedalRank5.Legend, vm.RankIndex);
+        Assert.True(vm.MedalRows.All(r => r.IsObtained));
+    }
+
+    [Fact]
+    public void Medal_ClearAll_ResetsEverything()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+        vm.GiveAllCommand.Execute(null);
+
+        vm.ClearAllCommand.Execute(null);
+
+        Assert.Equal(0, vm.TotalObtained);
+        Assert.Equal(0, sav.Medals.GetCountObtained());
+        Assert.True(vm.MedalRows.All(r => !r.IsObtained));
+    }
+
+    [Fact]
+    public void Medal_Settings_WriteThroughToSave()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        vm.PinnedMedal = 42;
+        vm.RankIndex = (int)MedalRank5.Master;
+        vm.IsTutorialComplete = true;
+
+        Assert.Equal(42, sav.Medals.PinnedMedal);
+        Assert.Equal(MedalRank5.Master, sav.Medals.Rank);
+        Assert.True(sav.Medals.IsTutorialComplete);
+    }
+
+    [Fact]
+    public void Medal_RecalculateRank_MatchesObtainedCount()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        // Obtain 100 medals -> Elite rank (>=100).
+        for (int i = 0; i < 100; i++)
+            vm.MedalRows[i].StateIndex = (int)MedalState5.Obtained;
+
+        vm.RankIndex = (int)MedalRank5.None; // wrong on purpose
+        vm.RecalculateRankCommand.Execute(null);
+
+        Assert.Equal((int)MedalRank5.Elite, vm.RankIndex);
+        Assert.Equal(MedalRank5.Elite, sav.Medals.Rank);
+    }
+
+    [Fact]
+    public void Habitat_EditStatus_WritesThroughToSave()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        var row = vm.HabitatRows[5];
+        row.GrassIndex = (int)HabitatCompletion5.Complete;
+        row.SurfIndex = (int)HabitatCompletion5.Caught;
+        row.FishIndex = (int)HabitatCompletion5.Seen;
+        row.IsComplete = true;
+
+        var habitat = sav.Medals.HabitatList.GetHabitat(5);
+        Assert.Equal(HabitatCompletion5.Complete, habitat.GetStatus(HabitatEncounterType5.Grass));
+        Assert.Equal(HabitatCompletion5.Caught, habitat.GetStatus(HabitatEncounterType5.Surf));
+        Assert.Equal(HabitatCompletion5.Seen, habitat.GetStatus(HabitatEncounterType5.Fish));
+        Assert.True(habitat.IsComplete);
+    }
+
+    [Fact]
+    public void Habitat_CompleteAll_ThenClearAll()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        vm.HabitatCompleteAllCommand.Execute(null);
+        Assert.True(vm.HabitatRows.All(r => r.IsComplete));
+        for (int i = 0; i < HabitatList5.HabitatCount; i++)
+            Assert.True(sav.Medals.HabitatList.GetHabitat(i).IsComplete);
+
+        vm.HabitatClearAllCommand.Execute(null);
+        Assert.True(vm.HabitatRows.All(r => !r.IsComplete));
+        for (int i = 0; i < HabitatList5.HabitatCount; i++)
+            Assert.False(sav.Medals.HabitatList.GetHabitat(i).IsComplete);
+    }
+
+    [Fact]
+    public void Habitat_Settings_WriteThroughToSave()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+
+        vm.HabitatTutorialViewed = true;
+        vm.HabitatTutorialCompleteCapture = true;
+        vm.LastEncounterTypeIndex = (int)HabitatEncounterType5.Surf;
+
+        var habitat = sav.Medals.HabitatList;
+        Assert.True(habitat.IsTutorialViewed);
+        Assert.True(habitat.IsTutorialCompleteCapture);
+        Assert.Equal(HabitatEncounterType5.Surf, habitat.LastEncounterType);
+    }
+
+    [Fact]
+    public void Medal_ImportExportBlob_RoundTrips()
+    {
+        var sav = NewSave();
+        var vm = new MedalEditorViewModel(sav);
+        vm.GiveAllCommand.Execute(null);
+
+        // Snapshot the exported blob, mutate, then restore via the same span surface used by import/export.
+        var exported = sav.Medals.AllMedals.ToArray();
+        Assert.Equal(MedalList5.LengthAllMedals, exported.Length);
+
+        vm.ClearAllCommand.Execute(null);
+        Assert.Equal(0, sav.Medals.GetCountObtained());
+
+        exported.AsSpan().CopyTo(sav.Medals.AllMedals);
+        Assert.Equal(255, sav.Medals.GetCountObtained());
+    }
+}


### PR DESCRIPTION
## Summary

Upgrades the Gen5 (B2W2) Medals editor from a read-only viewer to full parity with upstream `SAV_Medals5`, including the **Habitat list** that upstream added in the sync window. No `PKHeX.Core` changes — all editing writes through the mirrored `MedalList5`/`HabitatList5` structs.

### What's new
- **Editable medals**: per-medal `State`, `IsUnread`, and acquired `Date` (enabled only when the state `CanHaveDate`; auto-stamps the date on transition, matching upstream).
- **Medal settings**: `PinnedMedal`, `Rank` with a Recalculate action (`CalculateRank()`), `IsTutorialComplete`.
- **`.ml5` import/export** of the full medal blob (`AllMedals`/`LengthAllMedals`), via the same `IDialogService` file pattern as the Block/DLC5 editors.
- **Habitat list (new)**: one row per habitat (`HabitatList5.HabitatCount`) with `IsComplete` + Grass/Surf/Fish status (`HabitatCompletion5`), Complete-All/Clear, and habitat settings (`IsTutorialViewed`, `IsTutorialCompleteCapture`, `LastEncounterType`).
- View restructured into a **Medals / Habitat TabControl**; existing Give-All/Clear-All retained.

## Changes
- `PKHeX.Presentation/ViewModels/MedalEditorViewModel.cs` — editable rows, settings, `.ml5` IO, habitat rows (+ optional `IDialogService` ctor param, `(SaveFile)` overload kept).
- `PKHeX.Avalonia/Views/MedalEditorView.axaml` — tabbed editable grids.
- `PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs` — pass `_dialogService`.
- `Tests/PKHeX.Avalonia.Tests/MedalEditorTests.cs` — 13 new tests (state/unread/date/settings/rank/habitat write-through + `.ml5` round-trip).
- `Directory.Build.props` — UIVersion 1.1.32 → 1.1.33.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2284 passed, 1 skipped, 0 failed (+13 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
