### PR TITLE
feat(donut): Donut Generator (PLZA)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.33</UIVersion>
+    <UIVersion>1.1.34</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/DonutEditor.axaml
+++ b/PKHeX.Avalonia/Views/DonutEditor.axaml
@@ -34,6 +34,33 @@
                     </StackPanel>
                 </DockPanel>
 
+                <!-- Generator -->
+                <Expander DockPanel.Dock="Top" Header="Generator" Margin="0,0,0,12" IsExpanded="False">
+                    <StackPanel Spacing="12" Margin="0,8,0,0">
+                        <TextBlock Text="Fill a range of donut slots with random shiny-template donuts using the selected flavor types."
+                                   TextWrapping="Wrap" Opacity="0.7" />
+                        <Grid ColumnDefinitions="Auto,8,Auto,24,Auto,8,Auto">
+                            <TextBlock Grid.Column="0" Text="Start:" VerticalAlignment="Center" />
+                            <NumericUpDown Grid.Column="2" Width="120" Value="{Binding GenerateStart}" Minimum="0" Maximum="999" />
+                            <TextBlock Grid.Column="4" Text="End:" VerticalAlignment="Center" />
+                            <NumericUpDown Grid.Column="6" Width="120" Value="{Binding GenerateEnd}" Minimum="0" Maximum="999" />
+                        </Grid>
+                        <TextBlock Text="Flavor Types" FontWeight="SemiBold" />
+                        <Border Classes="section-card" CornerRadius="4" MaxHeight="220">
+                            <ScrollViewer>
+                                <ItemsControl ItemsSource="{Binding FlavorOptions}" Margin="8">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="vm:DonutFlavorOptionViewModel">
+                                            <CheckBox IsChecked="{Binding IsSelected}" Content="{Binding Name}" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Border>
+                        <Button Content="Generate" Command="{Binding GenerateCommand}" HorizontalAlignment="Left" />
+                    </StackPanel>
+                </Expander>
+
                 <Grid ColumnDefinitions="250,16,*">
                     <!-- Donut List -->
                     <ListBox Grid.Column="0"

--- a/PKHeX.Presentation/ViewModels/DonutEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/DonutEditorViewModel.cs
@@ -19,6 +19,7 @@ public partial class DonutEditorViewModel : ViewModelBase
         IsSupported = true;
 
         LoadDonuts();
+        LoadFlavorOptions();
     }
 
     public bool IsSupported { get; }
@@ -28,6 +29,41 @@ public partial class DonutEditorViewModel : ViewModelBase
 
     [ObservableProperty]
     private DonutEntryViewModel? _selectedDonut;
+
+    // --- Generator ---
+    [ObservableProperty]
+    private ObservableCollection<DonutFlavorOptionViewModel> _flavorOptions = [];
+
+    [ObservableProperty]
+    private int _generateStart;
+
+    [ObservableProperty]
+    private int _generateEnd = DonutPocket9a.MaxCount;
+
+    /// <summary>
+    /// Builds the selectable flavor list, matching the upstream generator which keeps only flavors whose
+    /// two-digit type index (characters 6-7 of the internal name, e.g. <c>sweet_03</c>) is in the range [3, 21].
+    /// </summary>
+    private void LoadFlavorOptions()
+    {
+        FlavorOptions.Clear();
+        foreach (var (hash, name) in DonutInfo.Flavors)
+        {
+            if (!TryGetFlavorTypeIndex(name, out _))
+                continue;
+            FlavorOptions.Add(new DonutFlavorOptionViewModel(name, hash) { IsSelected = true });
+        }
+    }
+
+    private static bool TryGetFlavorTypeIndex(string name, out int typeIndex)
+    {
+        typeIndex = -1;
+        if (name.Length < 8 || !int.TryParse(name.AsSpan(6, 2), out var value) || value is < 3 or > 21)
+            return false;
+
+        typeIndex = value - 3;
+        return true;
+    }
 
     private void LoadDonuts()
     {
@@ -76,6 +112,38 @@ public partial class DonutEditorViewModel : ViewModelBase
     {
         LoadDonuts();
     }
+
+    [RelayCommand]
+    private void Generate()
+    {
+        var hashes = FlavorOptions.Where(z => z.IsSelected).Select(z => z.Hash).ToArray();
+        if (hashes.Length == 0)
+            return;
+
+        var start = Math.Clamp(GenerateStart, 0, DonutPocket9a.MaxCount);
+        var end = Math.Clamp(GenerateEnd, 0, DonutPocket9a.MaxCount);
+        if (start > end)
+            return;
+
+        _pocket.SetRandomShinyTemplateRange(hashes, start, end);
+        _sav.State.Edited = true;
+        LoadDonuts();
+    }
+}
+
+public partial class DonutFlavorOptionViewModel : ViewModelBase
+{
+    public DonutFlavorOptionViewModel(string name, ulong hash)
+    {
+        Name = name;
+        Hash = hash;
+    }
+
+    public string Name { get; }
+    public ulong Hash { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
 }
 
 public partial class DonutEntryViewModel : ViewModelBase

--- a/Tests/PKHeX.Avalonia.Tests/DonutGeneratorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/DonutGeneratorTests.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class DonutGeneratorTests
+{
+    [Fact]
+    public void Generator_PopulatesFlavorOptions_AllSelectedByDefault()
+    {
+        var sav = new SAV9ZA();
+        var vm = new DonutEditorViewModel(sav);
+
+        Assert.True(vm.IsSupported);
+        Assert.NotEmpty(vm.FlavorOptions);
+        Assert.All(vm.FlavorOptions, o => Assert.True(o.IsSelected));
+
+        // Mirrors upstream filter: only flavors whose two-digit type index (chars 6-7) is in [3, 21].
+        Assert.All(vm.FlavorOptions, o =>
+        {
+            Assert.True(o.Name.Length >= 8);
+            var value = int.Parse(o.Name.Substring(6, 2));
+            Assert.InRange(value, 3, 21);
+        });
+
+        // Default range spans the whole pocket.
+        Assert.Equal(0, vm.GenerateStart);
+        Assert.Equal(DonutPocket9a.MaxCount, vm.GenerateEnd);
+    }
+
+    [Fact]
+    public void Generate_OverRange_WritesShinyTemplateDonuts()
+    {
+        var sav = new SAV9ZA();
+        var vm = new DonutEditorViewModel(sav);
+
+        // Choose a single flavor set so every generated donut's flavors come from it.
+        var chosen = vm.FlavorOptions.First();
+        foreach (var option in vm.FlavorOptions)
+            option.IsSelected = option == chosen;
+
+        const int start = 10;
+        const int end = 25; // end-exclusive in Core
+        vm.GenerateStart = start;
+        vm.GenerateEnd = end;
+
+        vm.GenerateCommand.Execute(null);
+
+        // Save is marked dirty.
+        Assert.True(sav.State.Edited);
+
+        var pocket = sav.Donuts;
+        var chosenHash = chosen.Hash;
+
+        // Indices in [start, end) are populated with the chosen flavor (only one option => Flavor0 set, rest 0).
+        for (int i = start; i < end; i++)
+        {
+            var donut = pocket.GetDonut(i);
+            Assert.NotEqual(0ul, donut.MillisecondsSince1970); // timestamp applied
+            Assert.Equal(chosenHash, donut.Flavor0);
+            Assert.Equal(0ul, donut.Flavor1);
+            Assert.Equal(0ul, donut.Flavor2);
+        }
+
+        // The slot just past the range is untouched (no flavors written).
+        var after = pocket.GetDonut(end);
+        Assert.Equal(0ul, after.Flavor0);
+    }
+
+    [Fact]
+    public void Generate_WithMultipleFlavors_DrawsOnlyFromSelectedSet()
+    {
+        var sav = new SAV9ZA();
+        var vm = new DonutEditorViewModel(sav);
+
+        // Pick the first three flavor options as the allowed pool.
+        var pool = vm.FlavorOptions.Take(3).ToList();
+        var allowed = pool.Select(z => z.Hash).ToHashSet();
+        foreach (var option in vm.FlavorOptions)
+            option.IsSelected = pool.Contains(option);
+
+        vm.GenerateStart = 0;
+        vm.GenerateEnd = 50;
+        vm.GenerateCommand.Execute(null);
+
+        var pocket = sav.Donuts;
+        for (int i = 0; i < 50; i++)
+        {
+            var donut = pocket.GetDonut(i);
+            foreach (var flavor in donut.GetFlavors())
+            {
+                if (flavor == 0ul)
+                    continue;
+                Assert.Contains(flavor, allowed);
+            }
+        }
+
+        // VM list reloaded after generate.
+        Assert.Equal(DonutPocket9a.MaxCount, vm.Donuts.Count);
+    }
+
+    [Fact]
+    public void Generate_NoFlavorSelected_DoesNothing()
+    {
+        var sav = new SAV9ZA();
+        var vm = new DonutEditorViewModel(sav);
+        foreach (var option in vm.FlavorOptions)
+            option.IsSelected = false;
+
+        vm.GenerateStart = 0;
+        vm.GenerateEnd = 10;
+        vm.GenerateCommand.Execute(null);
+
+        Assert.False(sav.State.Edited);
+        Assert.Equal(0ul, sav.Donuts.GetDonut(0).Flavor0);
+    }
+
+    [Fact]
+    public void Generate_StartAfterEnd_DoesNothing()
+    {
+        var sav = new SAV9ZA();
+        var vm = new DonutEditorViewModel(sav);
+
+        vm.GenerateStart = 40;
+        vm.GenerateEnd = 10;
+        vm.GenerateCommand.Execute(null);
+
+        Assert.False(sav.State.Edited);
+        Assert.Equal(0ul, sav.Donuts.GetDonut(20).Flavor0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the upstream **Donut Generator** (PLZA / Gen9-ZA) to the existing donut editor — a separate feature from the per-donut editor that bulk-fills a range of donut slots with random shiny templates drawn from a chosen set of flavors. No `PKHeX.Core` changes.

### What it does
A collapsible "Generator" section in the Donut editor:
- a checklist of flavor types (matching upstream's filter: internal-name type index in `[3, 21]`),
- Start / End range NumericUpDowns (0–`DonutPocket9a.MaxCount` = 999),
- a **Generate** button → `DonutPocket9a.SetRandomShinyTemplateRange(selectedHashes, start, end)`, then reloads the list and marks the save edited.

Guards: requires ≥1 flavor selected, clamps the range, no-op when start > end.

## Changes
- `PKHeX.Presentation/ViewModels/DonutEditorViewModel.cs` — `FlavorOptions` (selectable Name+Hash items), `GenerateStart/End`, `Generate` command, upstream-matching flavor filter.
- `PKHeX.Avalonia/Views/DonutEditor.axaml` — Generator expander (flavor checklist + range + button).
- `Tests/PKHeX.Avalonia.Tests/DonutGeneratorTests.cs` — 5 tests (flavor population/range, write-through to `_sav.Donuts` over [start,end), multi-flavor pool, no-op guards).
- `Directory.Build.props` — UIVersion 1.1.33 → 1.1.34.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2289 passed, 1 skipped, 0 failed (+5 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
