### PR TITLE
feat(gen5): Global Link (Dream World) editor

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.34</UIVersion>
+    <UIVersion>1.1.35</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -38,6 +38,7 @@ public static class ViewLocator
         [typeof(FolderListViewModel)] = () => new FolderList(),
         [typeof(GearBREditorViewModel)] = () => new GearBREditor(),
         [typeof(Geonet4EditorViewModel)] = () => new Geonet4Editor(),
+        [typeof(GlobalLink5EditorViewModel)] = () => new GlobalLink5Editor(),
         [typeof(GroupViewerViewModel)] = () => new GroupViewer(),
         [typeof(HallOfFame1EditorViewModel)] = () => new HallOfFame1Editor(),
         [typeof(HallOfFame3EditorViewModel)] = () => new HallOfFame3EditorView(),

--- a/PKHeX.Avalonia/Views/GlobalLink5Editor.axaml
+++ b/PKHeX.Avalonia/Views/GlobalLink5Editor.axaml
@@ -1,0 +1,164 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="700"
+             x:Class="PKHeX.Avalonia.Views.GlobalLink5Editor"
+             x:DataType="vm:GlobalLink5EditorViewModel"
+             MinWidth="640" MinHeight="560">
+    <DockPanel Margin="16">
+        <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
+            <TextBlock Text="Global Link (Dream World)" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding GameInfo}" FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        </StackPanel>
+
+        <!-- Not Supported Message -->
+        <TextBlock IsVisible="{Binding !IsSupported}" Text="This save file does not support Global Link editing. (Gen 5 only)"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                   FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+        <!-- Content -->
+        <TabControl IsVisible="{Binding IsSupported}">
+            <!-- ===================== Status Tab ===================== -->
+            <TabItem Header="Status">
+                <StackPanel Spacing="12" Margin="0,8,0,0">
+                    <!-- Counters / status -->
+                    <Border Classes="section-card" Padding="12">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="Upload" FontWeight="SemiBold" />
+                            <Grid ColumnDefinitions="Auto,160,Auto,160" RowDefinitions="Auto,Auto">
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Upload Count" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding UploadCount}"
+                                               Minimum="-1" Maximum="2147483647" FormatString="0"
+                                               Classes="compact" Margin="0,0,16,6" />
+
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="Upload Status" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                <NumericUpDown Grid.Row="0" Grid.Column="3" Value="{Binding UploadStatus}"
+                                               Minimum="0" Maximum="255" FormatString="0"
+                                               Classes="compact" Margin="0,0,0,6" />
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Upload Date" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding UploadDate}" VerticalAlignment="Center" />
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Flags -->
+                    <Border Classes="section-card" Padding="12">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Account Flags" FontWeight="SemiBold" />
+                            <CheckBox Content="Slot Present" IsChecked="{Binding IsSlotPresent}" />
+                            <CheckBox Content="Registered (Dream World access as BW)" IsChecked="{Binding IsRegistered}" />
+                            <CheckBox Content="Account Full Access (Game Sync done)" IsChecked="{Binding IsAccountFullAccess}" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Furniture selection / downloaded content -->
+                    <Border Classes="section-card" Padding="12">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="Selection &amp; Downloaded Content" FontWeight="SemiBold" />
+                            <Grid ColumnDefinitions="Auto,160,Auto,160" RowDefinitions="Auto,Auto,Auto">
+                                <TextBlock Grid.Row="0" Grid.Column="0" Text="Selected Furniture (0x7F=none)" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding SelectedFurnitureIndex}"
+                                               Minimum="0" Maximum="127" FormatString="0"
+                                               Classes="compact" Margin="0,0,16,6" />
+                                <CheckBox Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2"
+                                          Content="Furniture Synchronized" IsChecked="{Binding IsFurnitureSynchronized}" Margin="0,0,0,6" />
+
+                                <TextBlock Grid.Row="1" Grid.Column="0" Text="Musical" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                <NumericUpDown Grid.Row="1" Grid.Column="1" Value="{Binding Musical}"
+                                               Minimum="0" Maximum="255" FormatString="0"
+                                               Classes="compact" Margin="0,0,16,6" />
+
+                                <TextBlock Grid.Row="1" Grid.Column="2" Text="C-Gear Skin" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                <NumericUpDown Grid.Row="1" Grid.Column="3" Value="{Binding CGearSkin}"
+                                               Minimum="0" Maximum="255" FormatString="0"
+                                               Classes="compact" Margin="0,0,0,6" />
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Dex Skin" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                <NumericUpDown Grid.Row="2" Grid.Column="1" Value="{Binding DexSkin}"
+                                               Minimum="0" Maximum="255" FormatString="0"
+                                               Classes="compact" />
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </TabItem>
+
+            <!-- ===================== Items Tab ===================== -->
+            <TabItem Header="Items">
+                <Border Classes="section-card" CornerRadius="4" Padding="0" ClipToBounds="True" Margin="0,8,0,0">
+                    <DataGrid ItemsSource="{Binding Items}"
+                              AutoGenerateColumns="False"
+                              CanUserResizeColumns="True"
+                              CanUserSortColumns="False"
+                              IsReadOnly="False"
+                              MinHeight="320">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="#" Binding="{Binding Slot}" Width="40" IsReadOnly="True" />
+                            <DataGridTemplateColumn Header="" Width="36">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate DataType="vm:GlobalLinkItemViewModel">
+                                        <Image Width="24" Height="24"
+                                               Source="{Binding Sprite, Converter={StaticResource PngBytesToBitmap}}"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTemplateColumn Header="Item" Width="*">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate DataType="vm:GlobalLinkItemViewModel">
+                                        <ComboBox ItemsSource="{Binding ItemList}"
+                                                  SelectedValue="{Binding ItemId}"
+                                                  SelectedValueBinding="{Binding Value}"
+                                                  DisplayMemberBinding="{Binding Text}"
+                                                  HorizontalAlignment="Stretch" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTemplateColumn Header="Quantity" Width="120">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate DataType="vm:GlobalLinkItemViewModel">
+                                        <NumericUpDown Value="{Binding Quantity}"
+                                                       Minimum="0" Maximum="255" FormatString="0"
+                                                       Classes="compact"
+                                                       HorizontalAlignment="Stretch" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Border>
+            </TabItem>
+
+            <!-- ===================== Furniture Tab ===================== -->
+            <TabItem Header="Furniture">
+                <Border Classes="section-card" CornerRadius="4" Padding="0" ClipToBounds="True" Margin="0,8,0,0">
+                    <DataGrid ItemsSource="{Binding Furniture}"
+                              AutoGenerateColumns="False"
+                              CanUserResizeColumns="True"
+                              CanUserSortColumns="False"
+                              IsReadOnly="False"
+                              MinHeight="200">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="#" Binding="{Binding Slot}" Width="40" IsReadOnly="True" />
+                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" IsReadOnly="True" />
+                            <DataGridTemplateColumn Header="Value (0x7E=empty)" Width="160">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate DataType="vm:GlobalLinkFurnitureViewModel">
+                                        <NumericUpDown Value="{Binding Value}"
+                                                       Minimum="0" Maximum="65535" FormatString="0"
+                                                       Classes="compact"
+                                                       HorizontalAlignment="Stretch" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </Border>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/GlobalLink5Editor.axaml.cs
+++ b/PKHeX.Avalonia/Views/GlobalLink5Editor.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class GlobalLink5Editor : UserControl
+{
+    public GlobalLink5Editor()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -80,6 +80,7 @@
                     <MenuItem Header="Medal Rally (B2W2)" Command="{Binding OpenMedalCommand}" />
                     <MenuItem Header="Unity Tower (BW/B2W2)" Command="{Binding OpenUnityTower5Command}" />
                     <MenuItem Header="Entralink Forest" Command="{Binding OpenEntralinkCommand}" />
+                    <MenuItem Header="Global Link (Dream World)" Command="{Binding OpenGlobalLink5Command}" />
                     <MenuItem Header="DLC - C-Gear/PWT/Musical" Command="{Binding OpenDLC5Command}" />
                 </MenuItem>
                 <MenuItem Header="Gen 6">

--- a/PKHeX.Presentation/ViewModels/GlobalLink5EditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/GlobalLink5EditorViewModel.cs
@@ -1,0 +1,232 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Editor for the Gen 5 Global Link / Pokémon Dream World (PGL) save block (<see cref="GlobalLink5"/>),
+/// reachable as <see cref="SAV5.GlobalLink"/>. Edits write through the live save buffer that the block wraps.
+/// </summary>
+public partial class GlobalLink5EditorViewModel : ViewModelBase
+{
+    private readonly SAV5? _sav;
+    private readonly GlobalLink5? _block;
+    private readonly ISpriteRenderer? _spriteRenderer;
+    private readonly bool _loading;
+
+    public bool IsSupported { get; }
+
+    /// <summary>Human-readable description of the loaded game, or an unsupported notice.</summary>
+    public string GameInfo { get; } = "No Generation 5 save loaded.";
+
+    public GlobalLink5EditorViewModel(SAV5 sav, ISpriteRenderer? spriteRenderer = null)
+    {
+        _loading = true;
+        _sav = sav;
+        _spriteRenderer = spriteRenderer;
+        _block = sav.GlobalLink;
+        IsSupported = true;
+        GameInfo = $"{sav.Version} — Global Link (Dream World)";
+
+        // Counters / status
+        _uploadCount = _block.UploadCount;
+        _uploadStatus = _block.UploadStatus;
+
+        // Flags
+        _isSlotPresent = _block.IsSlotPresent;
+        _isRegistered = _block.IsRegistered;
+        _isAccountFullAccess = _block.IsAccountFullAccess;
+
+        // Selected furniture / sync
+        _selectedFurnitureIndex = _block.SelectedFurnitureIndex;
+        _isFurnitureSynchronized = _block.IsFurnitureSynchronized;
+
+        // Downloaded-content trackers
+        _musical = _block.Musical;
+        _cGearSkin = _block.CGearSkin;
+        _dexSkin = _block.DexSkin;
+
+        // Upload date (DateQuad5 has setters, but the block exposes it as a read-only computed
+        // property over a fresh slice, so we surface it read-only here).
+        var date = _block.UploadDate;
+        UploadDate = date.IsEmpty ? "Never" : date.ToDateOnly().ToString("yyyy-MM-dd");
+
+        // Build the item-name list for the combo. Global Link items are arbitrary held items,
+        // so every id 0..MaxItemID is offered (mirrors InventoryEditor's name-list fallback).
+        var itemStrings = Core.GameInfo.Strings.GetItemStrings(sav.Context, sav.Version);
+        int max = sav.MaxItemID;
+        var itemList = new List<ComboItem>(max + 1);
+        for (int i = 0; i <= max && i < itemStrings.Length; i++)
+        {
+            var name = string.IsNullOrEmpty(itemStrings[i]) ? $"(Item #{i:000})" : itemStrings[i];
+            itemList.Add(new ComboItem(name, i));
+        }
+        ItemList = itemList;
+
+        for (int i = 0; i < GlobalLink5.CountItems; i++)
+            Items.Add(new GlobalLinkItemViewModel(this, i, _block.GetItem(i), _block.GetItemQuantity(i), itemList, _spriteRenderer));
+
+        for (int i = 0; i < GlobalLink5.CountFurniture; i++)
+        {
+            var furniture = _block.GetFurniture(i);
+            Furniture.Add(new GlobalLinkFurnitureViewModel(this, i, furniture.Value, furniture.Name));
+        }
+
+        _loading = false;
+    }
+
+    // ---- Counters / status ----
+
+    [ObservableProperty]
+    private int _uploadCount;
+
+    [ObservableProperty]
+    private byte _uploadStatus;
+
+    public string UploadDate { get; } = "Never";
+
+    // ---- Flags ----
+
+    [ObservableProperty]
+    private bool _isSlotPresent;
+
+    [ObservableProperty]
+    private bool _isRegistered;
+
+    [ObservableProperty]
+    private bool _isAccountFullAccess;
+
+    // ---- Selected furniture / sync ----
+
+    [ObservableProperty]
+    private byte _selectedFurnitureIndex;
+
+    [ObservableProperty]
+    private bool _isFurnitureSynchronized;
+
+    // ---- Downloaded-content trackers ----
+
+    [ObservableProperty]
+    private byte _musical;
+
+    [ObservableProperty]
+    private byte _cGearSkin;
+
+    [ObservableProperty]
+    private byte _dexSkin;
+
+    // ---- Item grid ----
+
+    public IReadOnlyList<ComboItem> ItemList { get; } = [];
+
+    [ObservableProperty]
+    private ObservableCollection<GlobalLinkItemViewModel> _items = [];
+
+    // ---- Furniture grid ----
+
+    [ObservableProperty]
+    private ObservableCollection<GlobalLinkFurnitureViewModel> _furniture = [];
+
+    // ---- Write-through hooks ----
+
+    partial void OnUploadCountChanged(int value) => Apply(b => b.UploadCount = value);
+    partial void OnUploadStatusChanged(byte value) => Apply(b => b.UploadStatus = value);
+    partial void OnIsSlotPresentChanged(bool value) => Apply(b => b.IsSlotPresent = value);
+    partial void OnIsRegisteredChanged(bool value) => Apply(b => b.IsRegistered = value);
+    partial void OnIsAccountFullAccessChanged(bool value) => Apply(b => b.IsAccountFullAccess = value);
+    partial void OnSelectedFurnitureIndexChanged(byte value) => Apply(b => b.SelectedFurnitureIndex = value);
+    partial void OnIsFurnitureSynchronizedChanged(bool value) => Apply(b => b.IsFurnitureSynchronized = value);
+    partial void OnMusicalChanged(byte value) => Apply(b => b.Musical = value);
+    partial void OnCGearSkinChanged(byte value) => Apply(b => b.CGearSkin = value);
+    partial void OnDexSkinChanged(byte value) => Apply(b => b.DexSkin = value);
+
+    private void Apply(System.Action<GlobalLink5> write)
+    {
+        if (_loading || _block is null)
+            return;
+        write(_block);
+        MarkEdited();
+    }
+
+    internal void SetItem(int index, ushort itemId, byte quantity)
+    {
+        if (_loading || _block is null)
+            return;
+        _block.SetItem(index, itemId);
+        _block.SetItemQuantity(index, quantity);
+        MarkEdited();
+    }
+
+    internal void SetFurniture(int index, ushort value)
+    {
+        if (_loading || _block is null)
+            return;
+        var furniture = _block.GetFurniture(index);
+        furniture.Value = value;
+        MarkEdited();
+    }
+
+    private void MarkEdited()
+    {
+        if (_sav is not null)
+            _sav.State.Edited = true;
+    }
+}
+
+/// <summary>One of the 20 stored Global Link item slots: an item id (combo) plus a 0..255 quantity.</summary>
+public partial class GlobalLinkItemViewModel : ViewModelBase
+{
+    private readonly GlobalLink5EditorViewModel _parent;
+    private readonly int _index;
+    private readonly ISpriteRenderer? _spriteRenderer;
+
+    public GlobalLinkItemViewModel(GlobalLink5EditorViewModel parent, int index, ushort itemId, byte quantity, IReadOnlyList<ComboItem> itemList, ISpriteRenderer? spriteRenderer)
+    {
+        _parent = parent;
+        _index = index;
+        _itemId = itemId;
+        _quantity = quantity;
+        _spriteRenderer = spriteRenderer;
+        ItemList = itemList;
+    }
+
+    public int Slot => _index + 1;
+    public IReadOnlyList<ComboItem> ItemList { get; }
+
+    public byte[]? Sprite => _spriteRenderer?.GetItemSprite(ItemId);
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Sprite))]
+    private int _itemId;
+
+    [ObservableProperty]
+    private int _quantity;
+
+    partial void OnItemIdChanged(int value) => _parent.SetItem(_index, (ushort)value, (byte)Quantity);
+    partial void OnQuantityChanged(int value) => _parent.SetItem(_index, (ushort)ItemId, (byte)value);
+}
+
+/// <summary>One of the 5 stored Dream World furniture slots (<see cref="DreamFurniture5"/>).</summary>
+public partial class GlobalLinkFurnitureViewModel : ViewModelBase
+{
+    private readonly GlobalLink5EditorViewModel _parent;
+    private readonly int _index;
+
+    public GlobalLinkFurnitureViewModel(GlobalLink5EditorViewModel parent, int index, ushort value, string name)
+    {
+        _parent = parent;
+        _index = index;
+        _value = value;
+        Name = name;
+    }
+
+    public int Slot => _index + 1;
+    public string Name { get; }
+
+    [ObservableProperty]
+    private int _value;
+
+    partial void OnValueChanged(int value) => _parent.SetFurniture(_index, (ushort)value);
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -307,6 +307,15 @@ public partial class MainWindowViewModel
     }
 
     [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task OpenGlobalLink5Async()
+    {
+        if (CurrentSave is not SAV5 sav) return;
+        await _windowService.ShowDialogAsync(
+            new GlobalLink5EditorViewModel(sav, _spriteRenderer),
+            "Global Link Editor (Gen 5)");
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenPokedexAsync()
     {
         if (CurrentSave is null) return;

--- a/Tests/PKHeX.Avalonia.Tests/GlobalLink5EditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/GlobalLink5EditorTests.cs
@@ -1,0 +1,124 @@
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class GlobalLink5EditorTests
+{
+    [Fact]
+    public void GlobalLink5_B2W2_LoadsAndIsSupported()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        Assert.True(vm.IsSupported);
+        Assert.Equal(GlobalLink5.CountItems, vm.Items.Count);
+        Assert.Equal(GlobalLink5.CountFurniture, vm.Furniture.Count);
+        Assert.NotEmpty(vm.ItemList);
+    }
+
+    [Fact]
+    public void GlobalLink5_BW_LoadsAndIsSupported()
+    {
+        var sav = new SAV5BW();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        Assert.True(vm.IsSupported);
+        Assert.Equal(GlobalLink5.CountItems, vm.Items.Count);
+        Assert.Equal(GlobalLink5.CountFurniture, vm.Furniture.Count);
+    }
+
+    [Fact]
+    public void GlobalLink5_ReflectsExistingBlockValues()
+    {
+        var sav = new SAV5B2W2();
+        sav.GlobalLink.UploadCount = 42;
+        sav.GlobalLink.IsRegistered = true;
+        sav.GlobalLink.Musical = 7;
+        sav.GlobalLink.SetItem(0, 1);          // Master Ball
+        sav.GlobalLink.SetItemQuantity(0, 5);
+
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        Assert.Equal(42, vm.UploadCount);
+        Assert.True(vm.IsRegistered);
+        Assert.Equal(7, vm.Musical);
+        Assert.Equal(1, vm.Items[0].ItemId);
+        Assert.Equal(5, vm.Items[0].Quantity);
+    }
+
+    [Fact]
+    public void GlobalLink5_Flags_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        vm.IsSlotPresent = true;
+        vm.IsRegistered = true;
+        vm.IsAccountFullAccess = true;
+        vm.IsFurnitureSynchronized = true;
+
+        Assert.True(sav.GlobalLink.IsSlotPresent);
+        Assert.True(sav.GlobalLink.IsRegistered);
+        Assert.True(sav.GlobalLink.IsAccountFullAccess);
+        Assert.True(sav.GlobalLink.IsFurnitureSynchronized);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void GlobalLink5_Counters_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        vm.UploadCount = 123;
+        vm.UploadStatus = 9;
+        vm.SelectedFurnitureIndex = 3;
+        vm.Musical = 11;
+        vm.CGearSkin = 22;
+        vm.DexSkin = 33;
+
+        Assert.Equal(123, sav.GlobalLink.UploadCount);
+        Assert.Equal(9, sav.GlobalLink.UploadStatus);
+        Assert.Equal(3, sav.GlobalLink.SelectedFurnitureIndex);
+        Assert.Equal(11, sav.GlobalLink.Musical);
+        Assert.Equal(22, sav.GlobalLink.CGearSkin);
+        Assert.Equal(33, sav.GlobalLink.DexSkin);
+    }
+
+    [Fact]
+    public void GlobalLink5_Items_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        vm.Items[2].ItemId = 4;       // Poké Ball
+        vm.Items[2].Quantity = 250;
+
+        Assert.Equal(4, sav.GlobalLink.GetItem(2));
+        Assert.Equal(250, sav.GlobalLink.GetItemQuantity(2));
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void GlobalLink5_Furniture_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new GlobalLink5EditorViewModel(sav);
+
+        vm.Furniture[1].Value = 200;
+
+        Assert.Equal(200, sav.GlobalLink.GetFurniture(1).Value);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void GlobalLink5_LoadingDoesNotMarkEdited()
+    {
+        var sav = new SAV5B2W2();
+        _ = new GlobalLink5EditorViewModel(sav);
+
+        Assert.False(sav.State.Edited);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new **Global Link (Dream World / PGL) editor** for Gen5 (BW + B2W2) — present upstream but missing from Avalonia. Binds the `SAV5.GlobalLink` block; no `PKHeX.Core` changes.

### Features
- **Status tab**: upload count/status, upload date (read-only — the block exposes no date setter), account flags (`IsSlotPresent`, `IsRegistered`, `IsAccountFullAccess`), selected-furniture index + sync flag, and Musical / C-Gear Skin / Dex Skin selections.
- **Items tab**: the 20 Global Link item slots — id combo + quantity (0–255) with item sprite icons (reusing `ISpriteRenderer.GetItemSprite`), write-through via `GetItem/SetItem`/`GetItemQuantity/SetItemQuantity`.
- **Furniture tab**: the 5 Dream-World furniture entries (name + value).

All edits write through the live block and mark the save edited; loading does not.

## Changes
- `PKHeX.Presentation/ViewModels/GlobalLink5EditorViewModel.cs` — new VM (+ item/furniture row VMs).
- `PKHeX.Avalonia/Views/GlobalLink5Editor.axaml` (+ .axaml.cs) — new tabbed view.
- Wiring: `MainWindowViewModel.EditorDialogs.cs` (`OpenGlobalLink5Async`, gated `SAV5`), `ViewLocator.cs`, `MainWindow.axaml` menu item.
- `Tests/PKHeX.Avalonia.Tests/GlobalLink5EditorTests.cs` — 8 tests (B2W2/BW load, gating, reflect existing values, write-through for flags/counters/items/furniture, no-edit-on-load).
- `Directory.Build.props` — UIVersion 1.1.34 → 1.1.35.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2297 passed, 1 skipped, 0 failed (+8 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
