### PR TITLE
feat(gen5): Join Avenue editor (B2W2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.36</UIVersion>
+    <UIVersion>1.1.37</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -45,6 +45,7 @@ public static class ViewLocator
         [typeof(HallOfFame7EditorViewModel)] = () => new HallOfFame7Editor(),
         [typeof(HallOfFameEditorViewModel)] = () => new HallOfFameEditor(),
         [typeof(HoneyTreeEditorViewModel)] = () => new HoneyTreeEditor(),
+        [typeof(JoinAvenueEditorViewModel)] = () => new JoinAvenueEditor(),
         [typeof(LegalityViewModel)] = () => new LegalityView(),
         [typeof(Link6EditorViewModel)] = () => new Link6Editor(),
         [typeof(MailBoxEditorViewModel)] = () => new MailBoxEditor(),

--- a/PKHeX.Avalonia/Views/JoinAvenueEditor.axaml
+++ b/PKHeX.Avalonia/Views/JoinAvenueEditor.axaml
@@ -1,0 +1,321 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="860" d:DesignHeight="760"
+             x:Class="PKHeX.Avalonia.Views.JoinAvenueEditor"
+             x:DataType="vm:JoinAvenueEditorViewModel"
+             MinWidth="820" MinHeight="640">
+    <UserControl.Resources>
+        <!-- Reusable single-species + sprite editor (Gen 5). -->
+        <DataTemplate x:Key="SpeciesTemplate" DataType="vm:JoinAvenueSpeciesViewModel">
+            <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                <Image Width="32" Height="32" VerticalAlignment="Center"
+                       Source="{Binding Sprite, Converter={StaticResource PngBytesToBitmap}}" />
+                <ComboBox Width="180" ItemsSource="{Binding SpeciesSource}"
+                          SelectedValue="{Binding Species}"
+                          SelectedValueBinding="{Binding Value}"
+                          DisplayMemberBinding="{Binding Text}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- Shared IJoinAvenueEntity5 fields, reused by Self / Visitor / Fan / Occupant / Assistant panes. -->
+        <DataTemplate x:Key="CommonEntityTemplate" DataType="vm:JoinAvenueEntityViewModel">
+            <Border Classes="section-card" Padding="12">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="General" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="Auto,160,24,Auto,160" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Name}" Margin="0,0,0,4" />
+                        <TextBlock Grid.Row="0" Grid.Column="3" Text="Shout" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding Shout}" Margin="0,0,0,4" />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Greeting" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Greeting}" Margin="0,0,0,4" />
+                        <TextBlock Grid.Row="1" Grid.Column="3" Text="Farewell" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding Farewell}" Margin="0,0,0,4" />
+
+                        <TextBlock Grid.Row="2" Grid.Column="0" Text="TID16" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <NumericUpDown Grid.Row="2" Grid.Column="1" Value="{Binding Tid16}" Minimum="0" Maximum="65535" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                        <TextBlock Grid.Row="2" Grid.Column="3" Text="Sprite ID" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <NumericUpDown Grid.Row="2" Grid.Column="4" Value="{Binding SpriteId}" Minimum="0" Maximum="65535" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Gender" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding GenderList}"
+                                  SelectedValue="{Binding Gender}" SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" Margin="0,0,0,4" />
+                        <TextBlock Grid.Row="3" Grid.Column="3" Text="Language" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <NumericUpDown Grid.Row="3" Grid.Column="4" Value="{Binding Language}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Version" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <NumericUpDown Grid.Row="4" Grid.Column="1" Value="{Binding Version}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                        <TextBlock Grid.Row="4" Grid.Column="3" Text="Country / Subregion" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <StackPanel Grid.Row="4" Grid.Column="4" Orientation="Horizontal" Spacing="6" Margin="0,0,0,4">
+                            <NumericUpDown Value="{Binding Country}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="76" />
+                            <NumericUpDown Value="{Binding Subregion}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="76" />
+                        </StackPanel>
+
+                        <TextBlock Grid.Row="5" Grid.Column="0" Text="Played (h / m)" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Spacing="6" Margin="0,0,0,4">
+                            <NumericUpDown Value="{Binding PlayedHours}" Minimum="0" Maximum="1023" FormatString="0" Classes="compact" Width="76" />
+                            <NumericUpDown Value="{Binding PlayedMinutes}" Minimum="0" Maximum="59" FormatString="0" Classes="compact" Width="76" />
+                        </StackPanel>
+                        <TextBlock Grid.Row="5" Grid.Column="3" Text="Met (Y / M / D)" VerticalAlignment="Center" Margin="0,0,8,4" />
+                        <StackPanel Grid.Row="5" Grid.Column="4" Orientation="Horizontal" Spacing="6" Margin="0,0,0,4">
+                            <NumericUpDown Value="{Binding MetYear}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="64" />
+                            <NumericUpDown Value="{Binding MetMonth}" Minimum="0" Maximum="12" FormatString="0" Classes="compact" Width="56" />
+                            <NumericUpDown Value="{Binding MetDay}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" Width="56" />
+                        </StackPanel>
+
+                        <TextBlock Grid.Row="6" Grid.Column="0" Text="Seed" VerticalAlignment="Center" Margin="0,0,8,0" />
+                        <NumericUpDown Grid.Row="6" Grid.Column="1" Value="{Binding Seed}" Minimum="0" Maximum="4294967295" FormatString="0" Classes="compact" />
+                        <CheckBox Grid.Row="6" Grid.Column="3" Grid.ColumnSpan="2" Content="Interacted Today" IsChecked="{Binding IsInteractedToday}" VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <!-- A full Visitor / Occupant / Self pane (common + visitor-specific + favorite species + import/export). -->
+        <DataTemplate x:Key="VisitorPaneTemplate" DataType="vm:JoinAvenueVisitorEntryViewModel">
+            <StackPanel Spacing="12">
+                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource CommonEntityTemplate}" />
+                <Border Classes="section-card" Padding="12">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Visitor / Shop" FontWeight="SemiBold" />
+                        <Grid ColumnDefinitions="Auto,160,24,Auto,160" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Avenue Level" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="0" Grid.Column="1" Value="{Binding JoinAvenueLevel}" Minimum="0" Maximum="127" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                            <TextBlock Grid.Row="0" Grid.Column="3" Text="Avenue Rank" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="0" Grid.Column="4" Value="{Binding JoinAvenueRank}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                            <TextBlock Grid.Row="1" Grid.Column="0" Text="Shop Type" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ShopTypeList}"
+                                      SelectedValue="{Binding ShopTypeIndex}" SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" Margin="0,0,0,4" />
+                            <TextBlock Grid.Row="1" Grid.Column="3" Text="Desired Shop Type" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="1" Grid.Column="4" Value="{Binding DesiredShopType}" Minimum="0" Maximum="65535" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Shop Level" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="1" Value="{Binding ShopLevel}" Minimum="0" Maximum="{Binding ShopMaxLevel}" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                            <TextBlock Grid.Row="2" Grid.Column="3" Text="Shop Experience" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="4" Value="{Binding ShopExperience}" Minimum="0" Maximum="65535" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="Dex Seen" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="3" Grid.Column="1" Value="{Binding DexSeen}" Minimum="0" Maximum="1023" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                            <TextBlock Grid.Row="3" Grid.Column="3" Text="Origin (0=NPC, 1=Player)" VerticalAlignment="Center" Margin="0,0,8,4" />
+                            <NumericUpDown Grid.Row="3" Grid.Column="4" Value="{Binding Origin}" Minimum="0" Maximum="65535" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                            <TextBlock Grid.Row="4" Grid.Column="0" Text="Medal Rank / Hint / Count" VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <StackPanel Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="4" Orientation="Horizontal" Spacing="6">
+                                <NumericUpDown Value="{Binding MedalRank}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="90" />
+                                <NumericUpDown Value="{Binding MedalHint}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="90" />
+                                <NumericUpDown Value="{Binding MedalCount}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="90" />
+                            </StackPanel>
+                        </Grid>
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Favorite Species" VerticalAlignment="Center" Width="120" />
+                            <ContentControl Content="{Binding Favorite}" ContentTemplate="{StaticResource SpeciesTemplate}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="Import (.jav5)" Command="{Binding ImportCommand}" />
+                    <Button Content="Export (.jav5)" Command="{Binding ExportCommand}" />
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- A full Fan pane. -->
+        <DataTemplate x:Key="FanPaneTemplate" DataType="vm:JoinAvenueFanEntryViewModel">
+            <StackPanel Spacing="12">
+                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource CommonEntityTemplate}" />
+                <Border Classes="section-card" Padding="12">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Fan" FontWeight="SemiBold" />
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Species" VerticalAlignment="Center" Width="120" />
+                            <ContentControl Content="{Binding FanSpecies}" ContentTemplate="{StaticResource SpeciesTemplate}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Bubble Target" VerticalAlignment="Center" Width="120" />
+                            <NumericUpDown Value="{Binding BubbleTarget}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="120" />
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="Import (.jah5)" Command="{Binding ImportCommand}" />
+                    <Button Content="Export (.jah5)" Command="{Binding ExportCommand}" />
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+
+        <!-- A full Assistant pane. -->
+        <DataTemplate x:Key="AssistantPaneTemplate" DataType="vm:JoinAvenueAssistantEntryViewModel">
+            <StackPanel Spacing="12">
+                <ContentControl Content="{Binding}" ContentTemplate="{StaticResource CommonEntityTemplate}" />
+                <Border Classes="section-card" Padding="12">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="Assistant Positions" FontWeight="SemiBold" />
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <NumericUpDown Value="{Binding Position0}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="100" />
+                            <NumericUpDown Value="{Binding Position1}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="100" />
+                            <NumericUpDown Value="{Binding Position2}" Minimum="0" Maximum="255" FormatString="0" Classes="compact" Width="100" />
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="Import (.jaa5)" Command="{Binding ImportCommand}" />
+                    <Button Content="Export (.jaa5)" Command="{Binding ExportCommand}" />
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <DockPanel Margin="16">
+        <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
+            <TextBlock Text="Join Avenue" FontSize="20" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding GameInfo}" FontSize="12" Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+        </StackPanel>
+
+        <!-- Not Supported Message -->
+        <TextBlock IsVisible="{Binding !IsSupported}" Text="This save file does not support Join Avenue editing. (B2W2 only)"
+                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                   FontStyle="Italic" HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+        <TabControl IsVisible="{Binding IsSupported}">
+            <!-- ===================== Settings ===================== -->
+            <TabItem Header="Settings">
+                <ScrollViewer Margin="0,8,0,0">
+                    <StackPanel Spacing="12">
+                        <Border Classes="section-card" Padding="12">
+                            <StackPanel Spacing="8">
+                                <TextBlock Text="Avenue" FontWeight="SemiBold" />
+                                <Grid ColumnDefinitions="Auto,200,24,Auto,200" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding AvenueName}" MaxLength="20" Margin="0,0,0,4" />
+                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="Player Title" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding PlayerTitle}" MaxLength="20" Margin="0,0,0,4" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Rank" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <NumericUpDown Grid.Row="1" Grid.Column="1" Value="{Binding Rank}" Minimum="0" Maximum="{Binding MaxRank}" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                                    <TextBlock Grid.Row="1" Grid.Column="3" Text="Experience" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <NumericUpDown Grid.Row="1" Grid.Column="4" Value="{Binding Experience}" Minimum="0" Maximum="4294967295" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Ceiling Color" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding CeilingColorList}"
+                                              SelectedValue="{Binding CeilingColorIndex}" SelectedValueBinding="{Binding Value}"
+                                              DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" Margin="0,0,0,4" />
+                                    <TextBlock Grid.Row="2" Grid.Column="3" Text="Flags (raw)" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <NumericUpDown Grid.Row="2" Grid.Column="4" Value="{Binding Flags}" Minimum="0" Maximum="4294967295" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+
+                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Seed" VerticalAlignment="Center" Margin="0,0,8,4" />
+                                    <NumericUpDown Grid.Row="3" Grid.Column="1" Value="{Binding Seed}" Minimum="0" Maximum="4294967295" FormatString="0" Classes="compact" Margin="0,0,0,4" />
+                                    <CheckBox Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2" Content="Script Flag" IsChecked="{Binding ScriptFlag}" VerticalAlignment="Center" />
+
+                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Promotion Days" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <NumericUpDown Grid.Row="4" Grid.Column="1" Value="{Binding PromotionDaysElapsed}" Minimum="0" Maximum="{Binding MaxPromotionDays}" FormatString="0" Classes="compact" />
+                                    <CheckBox Grid.Row="4" Grid.Column="3" Grid.ColumnSpan="2" Content="Promotion Active" IsChecked="{Binding IsPromotionActive}" VerticalAlignment="Center" />
+                                </Grid>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Classes="section-card" Padding="12">
+                            <StackPanel Spacing="8">
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Grid.Column="0" Text="Visiting Player Database (32 remembered TIDs, 0xFFFFFFFF = empty)" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                    <Button Grid.Column="1" Content="Clear All" Command="{Binding ClearVisitingPlayersCommand}" />
+                                </Grid>
+                                <Grid ColumnDefinitions="Auto,160,24,Auto,160">
+                                    <TextBlock Grid.Column="0" Text="Count" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <NumericUpDown Grid.Column="1" Value="{Binding VisitingPlayerCount}" Minimum="0" Maximum="{Binding MaxVisitingPlayers}" FormatString="0" Classes="compact" />
+                                    <TextBlock Grid.Column="3" Text="Insert Index" VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <NumericUpDown Grid.Column="4" Value="{Binding VisitingPlayerInsertIndex}" Minimum="0" Maximum="31" FormatString="0" Classes="compact" />
+                                </Grid>
+                                <Border CornerRadius="4" ClipToBounds="True">
+                                    <DataGrid ItemsSource="{Binding VisitingPlayers}"
+                                              AutoGenerateColumns="False" CanUserResizeColumns="True"
+                                              CanUserSortColumns="False" IsReadOnly="False" MinHeight="260" MaxHeight="320">
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn Header="#" Binding="{Binding Slot}" Width="60" IsReadOnly="True" />
+                                            <DataGridTemplateColumn Header="Trainer ID (32-bit)" Width="*">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate DataType="vm:JoinAvenueVisitingPlayerViewModel">
+                                                        <NumericUpDown Value="{Binding Value}" Minimum="0" Maximum="4294967295" FormatString="0" Classes="compact" HorizontalAlignment="Stretch" />
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                        </DataGrid.Columns>
+                                    </DataGrid>
+                                </Border>
+                            </StackPanel>
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- ===================== Self ===================== -->
+            <TabItem Header="Self">
+                <ScrollViewer Margin="0,8,0,0">
+                    <ContentControl Content="{Binding Self}" ContentTemplate="{StaticResource VisitorPaneTemplate}" />
+                </ScrollViewer>
+            </TabItem>
+
+            <!-- ===================== Visitors ===================== -->
+            <TabItem Header="Visitors">
+                <DockPanel Margin="0,8,0,0">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                        <TextBlock Text="Visitor" VerticalAlignment="Center" />
+                        <ComboBox MinWidth="180" ItemsSource="{Binding Visitors}" SelectedItem="{Binding SelectedVisitor}"
+                                  DisplayMemberBinding="{Binding Label}" />
+                    </StackPanel>
+                    <ScrollViewer>
+                        <ContentControl Content="{Binding SelectedVisitor}" ContentTemplate="{StaticResource VisitorPaneTemplate}" />
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
+            <!-- ===================== Fans ===================== -->
+            <TabItem Header="Fans">
+                <DockPanel Margin="0,8,0,0">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                        <TextBlock Text="Fan" VerticalAlignment="Center" />
+                        <ComboBox MinWidth="180" ItemsSource="{Binding Fans}" SelectedItem="{Binding SelectedFan}"
+                                  DisplayMemberBinding="{Binding Label}" />
+                    </StackPanel>
+                    <ScrollViewer>
+                        <ContentControl Content="{Binding SelectedFan}" ContentTemplate="{StaticResource FanPaneTemplate}" />
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
+            <!-- ===================== Occupants ===================== -->
+            <TabItem Header="Occupants">
+                <DockPanel Margin="0,8,0,0">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                        <TextBlock Text="Occupant" VerticalAlignment="Center" />
+                        <ComboBox MinWidth="180" ItemsSource="{Binding Occupants}" SelectedItem="{Binding SelectedOccupant}"
+                                  DisplayMemberBinding="{Binding Label}" />
+                    </StackPanel>
+                    <ScrollViewer>
+                        <ContentControl Content="{Binding SelectedOccupant}" ContentTemplate="{StaticResource VisitorPaneTemplate}" />
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+
+            <!-- ===================== Assistants ===================== -->
+            <TabItem Header="Assistants">
+                <DockPanel Margin="0,8,0,0">
+                    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+                        <TextBlock Text="Assistant" VerticalAlignment="Center" />
+                        <ComboBox MinWidth="180" ItemsSource="{Binding Assistants}" SelectedItem="{Binding SelectedAssistant}"
+                                  DisplayMemberBinding="{Binding Label}" />
+                    </StackPanel>
+                    <ScrollViewer>
+                        <ContentControl Content="{Binding SelectedAssistant}" ContentTemplate="{StaticResource AssistantPaneTemplate}" />
+                    </ScrollViewer>
+                </DockPanel>
+            </TabItem>
+        </TabControl>
+    </DockPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/JoinAvenueEditor.axaml.cs
+++ b/PKHeX.Avalonia/Views/JoinAvenueEditor.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class JoinAvenueEditor : UserControl
+{
+    public JoinAvenueEditor()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -79,6 +79,7 @@
                     <MenuItem Header="Pokédex" Command="{Binding OpenPokedexCommand}" />
                     <MenuItem Header="Chatter" Command="{Binding OpenChatterCommand}" />
                     <MenuItem Header="Medal Rally (B2W2)" Command="{Binding OpenMedalCommand}" />
+                    <MenuItem Header="Join Avenue (B2W2)" Command="{Binding OpenJoinAvenueCommand}" />
                     <MenuItem Header="Unity Tower (BW/B2W2)" Command="{Binding OpenUnityTower5Command}" />
                     <MenuItem Header="Entralink Forest" Command="{Binding OpenEntralinkCommand}" />
                     <MenuItem Header="Global Link (Dream World)" Command="{Binding OpenGlobalLink5Command}" />

--- a/PKHeX.Presentation/ViewModels/JoinAvenueEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/JoinAvenueEditorViewModel.cs
@@ -1,0 +1,692 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Editor for the Join Avenue save block (<see cref="JoinAvenue5"/>) of <see cref="SAV5B2W2"/>,
+/// reachable as <see cref="SAV5B2W2.JoinAvenue"/>. Edits write through the live save buffer that the block wraps.
+/// </summary>
+/// <remarks>
+/// The block re-creates a fresh wrapper on each property access (and each nested entity slices the same
+/// underlying buffer), so struct/field writes over those slices persist. The Settings sub-structure, the
+/// visiting-player database, and the Self/Visitor/Fan/Occupant/Assistant entities are edited in place.
+/// Per-entity single-file import/export uses the raw byte window each entity exposes via
+/// <see cref="IJoinAvenueEntity5.Write"/> and the same-type <c>CopyFrom</c> path.
+/// </remarks>
+public partial class JoinAvenueEditorViewModel : ViewModelBase
+{
+    private readonly SAV5B2W2? _sav;
+    private readonly JoinAvenue5? _block;
+    private readonly ISpriteRenderer? _spriteRenderer;
+    private readonly IDialogService? _dialogService;
+    private readonly bool _loading;
+
+    public bool IsSupported { get; }
+
+    /// <summary>Human-readable description of the loaded game, or an unsupported notice.</summary>
+    public string GameInfo { get; } = "No Generation 5 B2W2 save loaded.";
+
+    /// <summary>Gate used by the host before constructing the editor.</summary>
+    public static bool IsSupportedSave(SaveFile sav) => sav is SAV5B2W2;
+
+    public JoinAvenueEditorViewModel(SAV5B2W2 sav) : this(sav, null, null) { }
+    public JoinAvenueEditorViewModel(SAV5B2W2 sav, ISpriteRenderer? spriteRenderer) : this(sav, spriteRenderer, null) { }
+
+    public JoinAvenueEditorViewModel(SAV5B2W2 sav, ISpriteRenderer? spriteRenderer, IDialogService? dialogService)
+    {
+        _loading = true;
+        _sav = sav;
+        _spriteRenderer = spriteRenderer;
+        _dialogService = dialogService;
+        _block = sav.JoinAvenue;
+        IsSupported = true;
+        GameInfo = $"{sav.Version} — Join Avenue (B2W2)";
+
+        var block = _block;
+        var settings = block.Settings;
+
+        // ---- Settings ----
+        _avenueName = settings.Name;
+        _playerTitle = settings.PlayerTitle;
+        _experience = settings.Experience;
+        _rank = settings.Rank;
+        _ceilingColorIndex = (int)settings.CeilingColor;
+        _flags = settings.Flags;
+        _seed = settings.Seed;
+        _scriptFlag = block.ScriptFlag;
+        _visitingPlayerCount = settings.VisitingPlayerDatabaseCount;
+        _visitingPlayerInsertIndex = settings.VistiingPlayerDatabaseInsertIndex;
+        _promotionDaysElapsed = settings.PromotionDaysElapsed;
+        _isPromotionActive = settings.IsPromotionActive;
+
+        for (int i = 0; i < JoinAvenueSettings5.CountVisitingPlayersRemembered; i++)
+            VisitingPlayers.Add(new JoinAvenueVisitingPlayerViewModel(this, i, settings.GetVisitingPlayerTrainerID(i)));
+
+        // ---- Self (a Visitor entity that won't always be filled out) ----
+        Self = new JoinAvenueVisitorEntryViewModel(this, "Self", () => _block!.Self, _spriteRenderer);
+
+        // ---- Visitors / Occupants (both Visitor entities) ----
+        for (int i = 0; i < JoinAvenue5.VisitorCount; i++)
+        {
+            int slot = i;
+            Visitors.Add(new JoinAvenueVisitorEntryViewModel(this, $"Visitor {slot + 1}", () => _block!.GetVisitor(slot), _spriteRenderer));
+        }
+        _selectedVisitor = Visitors[0];
+
+        for (int i = 0; i < JoinAvenue5.OccupantCount; i++)
+        {
+            int slot = i;
+            Occupants.Add(new JoinAvenueVisitorEntryViewModel(this, $"Occupant {slot + 1}", () => _block!.GetOccupant(slot), _spriteRenderer));
+        }
+        _selectedOccupant = Occupants[0];
+
+        // ---- Fans ----
+        for (int i = 0; i < JoinAvenue5.FanCount; i++)
+        {
+            int slot = i;
+            Fans.Add(new JoinAvenueFanEntryViewModel(this, $"Fan {slot + 1}", () => _block!.GetFan(slot), _spriteRenderer));
+        }
+        _selectedFan = Fans[0];
+
+        // ---- Assistants ----
+        for (int i = 0; i < JoinAvenue5.AssistantCount; i++)
+        {
+            int slot = i;
+            Assistants.Add(new JoinAvenueAssistantEntryViewModel(this, $"Assistant {slot + 1}", () => _block!.GetAssistant(slot), _spriteRenderer));
+        }
+        _selectedAssistant = Assistants[0];
+
+        _loading = false;
+    }
+
+    // ---------------- Settings ----------------
+
+    [ObservableProperty] private string _avenueName = string.Empty;
+    [ObservableProperty] private string _playerTitle = string.Empty;
+    [ObservableProperty] private long _experience;
+    [ObservableProperty] private int _rank;
+    [ObservableProperty] private int _ceilingColorIndex;
+    [ObservableProperty] private long _flags;
+    [ObservableProperty] private long _seed;
+    [ObservableProperty] private bool _scriptFlag;
+    [ObservableProperty] private int _visitingPlayerCount;
+    [ObservableProperty] private int _visitingPlayerInsertIndex;
+    [ObservableProperty] private int _promotionDaysElapsed;
+    [ObservableProperty] private bool _isPromotionActive;
+
+    public int MaxRank => JoinAvenueSettings5.MaxAvenueRank;
+    public int MaxVisitingPlayers => JoinAvenueSettings5.CountVisitingPlayersRemembered;
+    public int MaxPromotionDays => JoinAvenueSettings5.PromotionDaysMax;
+
+    public IReadOnlyList<ComboItem> CeilingColorList { get; } = BuildEnumList<JoinAvenueCeilingColor5>();
+
+    partial void OnAvenueNameChanged(string value) => Settings(s => s.Name = value ?? string.Empty);
+    partial void OnPlayerTitleChanged(string value) => Settings(s => s.PlayerTitle = value ?? string.Empty);
+    partial void OnExperienceChanged(long value) => Settings(s => s.Experience = (uint)value);
+    partial void OnRankChanged(int value) => Settings(s => s.Rank = (ushort)Math.Clamp(value, 0, JoinAvenueSettings5.MaxAvenueRank));
+    partial void OnCeilingColorIndexChanged(int value) => Settings(s => s.CeilingColor = (JoinAvenueCeilingColor5)value);
+    partial void OnFlagsChanged(long value) => Settings(s => s.Flags = (uint)value);
+    partial void OnSeedChanged(long value) => Settings(s => s.Seed = (uint)value);
+    partial void OnVisitingPlayerCountChanged(int value) => Settings(s => s.VisitingPlayerDatabaseCount = (ushort)Math.Max(0, value));
+    partial void OnVisitingPlayerInsertIndexChanged(int value) => Settings(s => s.VistiingPlayerDatabaseInsertIndex = (ushort)Math.Max(0, value));
+    partial void OnPromotionDaysElapsedChanged(int value) => Settings(s => s.PromotionDaysElapsed = (ushort)Math.Max(0, value));
+    partial void OnIsPromotionActiveChanged(bool value) => Settings(s => s.IsPromotionActive = value);
+
+    partial void OnScriptFlagChanged(bool value)
+    {
+        if (_loading || _block is null) return;
+        _block.ScriptFlag = value;
+        MarkEdited();
+    }
+
+    private void Settings(Action<JoinAvenueSettings5> write)
+    {
+        if (_loading || _block is null) return;
+        write(_block.Settings);
+        MarkEdited();
+    }
+
+    // ---------------- Visiting player database ----------------
+
+    public ObservableCollection<JoinAvenueVisitingPlayerViewModel> VisitingPlayers { get; } = [];
+
+    internal void SetVisitingPlayer(int index, uint value)
+    {
+        if (_loading || _block is null) return;
+        _block.Settings.SetVisitingPlayerTrainerID(index, value);
+        MarkEdited();
+    }
+
+    [RelayCommand]
+    private void ClearVisitingPlayers()
+    {
+        if (_loading || _block is null) return;
+        _block.Settings.ResetPlayerVisitList();
+        MarkEdited();
+
+        _suppressReload = true;
+        foreach (var p in VisitingPlayers)
+            p.ReloadFrom(JoinAvenueSettings5.VisitingPlayerDefaultNone);
+        VisitingPlayerCount = 0;
+        VisitingPlayerInsertIndex = 0;
+        _suppressReload = false;
+    }
+
+    private bool _suppressReload;
+    internal bool SuppressReload => _suppressReload;
+
+    // ---------------- Self ----------------
+
+    public JoinAvenueVisitorEntryViewModel Self { get; }
+
+    // ---------------- Visitors / Occupants / Fans / Assistants ----------------
+
+    public ObservableCollection<JoinAvenueVisitorEntryViewModel> Visitors { get; } = [];
+    public ObservableCollection<JoinAvenueVisitorEntryViewModel> Occupants { get; } = [];
+    public ObservableCollection<JoinAvenueFanEntryViewModel> Fans { get; } = [];
+    public ObservableCollection<JoinAvenueAssistantEntryViewModel> Assistants { get; } = [];
+
+    [ObservableProperty] private JoinAvenueVisitorEntryViewModel? _selectedVisitor;
+    [ObservableProperty] private JoinAvenueVisitorEntryViewModel? _selectedOccupant;
+    [ObservableProperty] private JoinAvenueFanEntryViewModel? _selectedFan;
+    [ObservableProperty] private JoinAvenueAssistantEntryViewModel? _selectedAssistant;
+
+    public uint CountVisitor => _block?.CountVisitor ?? 0;
+    public uint CountFan => _block?.CountFan ?? 0;
+
+    // ---------------- Import / export plumbing ----------------
+
+    internal IDialogService? DialogService => _dialogService;
+
+    internal async Task<byte[]?> PromptImportAsync(string title, string extension, int expectedLength)
+    {
+        if (_dialogService is null) return null;
+        var path = await _dialogService.OpenFileAsync(title, [extension]);
+        if (string.IsNullOrEmpty(path)) return null;
+        try
+        {
+            var data = await File.ReadAllBytesAsync(path);
+            if (data.Length != expectedLength)
+            {
+                await _dialogService.ShowErrorAsync("Import Error",
+                    $"Entity size mismatch. Expected {expectedLength} bytes, got {data.Length} bytes.");
+                return null;
+            }
+            return data;
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Import Error", ex.Message);
+            return null;
+        }
+    }
+
+    internal async Task ExportBytesAsync(string title, string extension, ReadOnlyMemory<byte> data)
+    {
+        if (_dialogService is null) return;
+        var defaultName = $"JoinAvenue.{extension}";
+        var path = await _dialogService.SaveFileAsync(title, defaultName, [extension]);
+        if (string.IsNullOrEmpty(path)) return;
+        try
+        {
+            await File.WriteAllBytesAsync(path, data.ToArray());
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Export Error", ex.Message);
+        }
+    }
+
+    // ---------------- Plumbing ----------------
+
+    internal SAV5B2W2? Save => _sav;
+    internal bool IsLoading => _loading;
+
+    internal void MarkEdited()
+    {
+        if (!_loading && _sav is not null)
+            _sav.State.Edited = true;
+    }
+
+    internal static IReadOnlyList<ComboItem> BuildEnumList<T>() where T : struct, Enum
+    {
+        var names = Enum.GetNames<T>();
+        var values = Enum.GetValues<T>();
+        var list = new List<ComboItem>(names.Length);
+        for (int i = 0; i < names.Length; i++)
+            list.Add(new ComboItem(names[i], Convert.ToInt32(values[i])));
+        return list;
+    }
+}
+
+/// <summary>One remembered visiting-player trainer ID (0xFFFFFFFF = empty), routed back to the owner on edit.</summary>
+public partial class JoinAvenueVisitingPlayerViewModel : ViewModelBase
+{
+    private readonly JoinAvenueEditorViewModel _parent;
+    private readonly int _index;
+    private bool _suppress;
+
+    public JoinAvenueVisitingPlayerViewModel(JoinAvenueEditorViewModel parent, int index, uint value)
+    {
+        _parent = parent;
+        _index = index;
+        _value = (long)value;
+    }
+
+    public int Slot => _index + 1;
+
+    [ObservableProperty]
+    private long _value;
+
+    partial void OnValueChanged(long value)
+    {
+        if (_suppress) return;
+        _parent.SetVisitingPlayer(_index, (uint)value);
+    }
+
+    internal void ReloadFrom(uint value)
+    {
+        _suppress = true;
+        Value = (long)value;
+        _suppress = false;
+    }
+}
+
+/// <summary>
+/// A reusable species + sprite sub-VM wrapping a single 16-bit species id (Gen 5 favorites / fan species).
+/// Exposes a Species combo and a live sprite preview via the renderer. The caller supplies a write-back
+/// delegate invoked whenever the species changes.
+/// </summary>
+public partial class JoinAvenueSpeciesViewModel : ViewModelBase
+{
+    private readonly ISpriteRenderer? _spriteRenderer;
+    private readonly Action<ushort>? _onChanged;
+    private bool _suppress;
+
+    public const int MaxSpeciesGen5 = 649; // Legal.MaxSpeciesID_5 (Genesect); the Core constant is internal.
+
+    public static IReadOnlyList<ComboItem> SpeciesSource { get; } = BuildSpeciesSource();
+
+    public JoinAvenueSpeciesViewModel(ushort species, ISpriteRenderer? spriteRenderer, Action<ushort>? onChanged)
+    {
+        _spriteRenderer = spriteRenderer;
+        _onChanged = onChanged;
+        _species = species;
+    }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Sprite))]
+    private int _species;
+
+    public byte[]? Sprite => _spriteRenderer?.GetSprite((ushort)Species, 0, 0, 0, false, EntityContext.Gen5);
+
+    partial void OnSpeciesChanged(int value)
+    {
+        if (_suppress) return;
+        _onChanged?.Invoke((ushort)value);
+    }
+
+    internal void Load(ushort species)
+    {
+        _suppress = true;
+        Species = species;
+        _suppress = false;
+        OnPropertyChanged(nameof(Sprite));
+    }
+
+    private static IReadOnlyList<ComboItem> BuildSpeciesSource()
+    {
+        var names = Core.GameInfo.Strings.Species;
+        var list = new List<ComboItem>(MaxSpeciesGen5 + 1);
+        for (int i = 0; i <= MaxSpeciesGen5 && i < names.Count; i++)
+            list.Add(new ComboItem(string.IsNullOrEmpty(names[i]) ? $"#{i}" : names[i], i));
+        return list;
+    }
+}
+
+/// <summary>
+/// Base view-model for the shared <see cref="IJoinAvenueEntity5"/> surface (name/country/shout/version/
+/// language/gender/TID/played-time/greeting-farewell/met-date/seed). Concrete subclasses add the
+/// type-specific fields and supply the entity accessor + import/export wiring.
+/// </summary>
+public abstract partial class JoinAvenueEntityViewModel : ViewModelBase
+{
+    protected readonly JoinAvenueEditorViewModel Parent;
+
+    protected JoinAvenueEntityViewModel(JoinAvenueEditorViewModel parent, string label)
+    {
+        Parent = parent;
+        Label = label;
+    }
+
+    public string Label { get; }
+
+    public IReadOnlyList<ComboItem> GenderList { get; } =
+    [
+        new ComboItem("Male", 0),
+        new ComboItem("Female", 1),
+        new ComboItem("Genderless", 2),
+    ];
+
+    public abstract IJoinAvenueEntity5 Entity { get; }
+
+    // ---- Shared entity fields ----
+    [ObservableProperty] private string _name = string.Empty;
+    [ObservableProperty] private int _country;
+    [ObservableProperty] private int _subregion;
+    [ObservableProperty] private string _shout = string.Empty;
+    [ObservableProperty] private int _version;
+    [ObservableProperty] private int _language;
+    [ObservableProperty] private int _gender;
+    [ObservableProperty] private int _tid16;
+    [ObservableProperty] private int _playedHours;
+    [ObservableProperty] private int _playedMinutes;
+    [ObservableProperty] private int _spriteId;
+    [ObservableProperty] private string _greeting = string.Empty;
+    [ObservableProperty] private string _farewell = string.Empty;
+    [ObservableProperty] private int _metYear;
+    [ObservableProperty] private int _metMonth;
+    [ObservableProperty] private int _metDay;
+    [ObservableProperty] private bool _isInteractedToday;
+    [ObservableProperty] private long _seed;
+
+    // Loads run with write-back suppressed (Suppress=true during Reload; Parent.IsLoading=true during ctor),
+    // so assigning the generated properties here never round-trips back into the live entity.
+    protected void LoadCommon()
+    {
+        var e = Entity;
+        Name = e.Name;
+        Country = e.Country;
+        Subregion = e.Subregion;
+        Shout = e.Shout;
+        Version = e.Version;
+        Language = e.Language;
+        Gender = e.Gender;
+        Tid16 = e.TID16;
+        PlayedHours = e.PlayedHours;
+        PlayedMinutes = e.PlayedMinutes;
+        SpriteId = e.Sprite;
+        Greeting = e.Greeting;
+        Farewell = e.Farewell;
+        MetYear = e.MetYear;
+        MetMonth = e.MetMonth;
+        MetDay = e.MetDay;
+        IsInteractedToday = e.IsInteractedToday;
+        Seed = e.Seed;
+    }
+
+    partial void OnNameChanged(string value) => Write(e => e.Name = value ?? string.Empty);
+    partial void OnCountryChanged(int value) => Write(e => e.Country = (byte)value);
+    partial void OnSubregionChanged(int value) => Write(e => e.Subregion = (byte)value);
+    partial void OnShoutChanged(string value) => Write(e => e.Shout = value ?? string.Empty);
+    partial void OnVersionChanged(int value) => Write(e => e.Version = (byte)value);
+    partial void OnLanguageChanged(int value) => Write(e => e.Language = (byte)value);
+    partial void OnGenderChanged(int value) => Write(e => e.Gender = (byte)value);
+    partial void OnTid16Changed(int value) => Write(e => e.TID16 = (ushort)value);
+    partial void OnPlayedHoursChanged(int value) => Write(e => e.PlayedHours = (ushort)value);
+    partial void OnPlayedMinutesChanged(int value) => Write(e => e.PlayedMinutes = (byte)value);
+    partial void OnSpriteIdChanged(int value) => Write(e => e.Sprite = (ushort)value);
+    partial void OnGreetingChanged(string value) => Write(e => e.Greeting = value ?? string.Empty);
+    partial void OnFarewellChanged(string value) => Write(e => e.Farewell = value ?? string.Empty);
+    partial void OnMetYearChanged(int value) => Write(e => e.MetYear = (byte)value);
+    partial void OnMetMonthChanged(int value) => Write(e => e.MetMonth = (byte)value);
+    partial void OnMetDayChanged(int value) => Write(e => e.MetDay = (byte)value);
+    partial void OnIsInteractedTodayChanged(bool value) => Write(e => e.IsInteractedToday = value);
+    partial void OnSeedChanged(long value) => Write(e => e.Seed = (uint)value);
+
+    protected bool Suppress;
+
+    protected void Write(Action<IJoinAvenueEntity5> apply)
+    {
+        if (Suppress || Parent.IsLoading) return;
+        apply(Entity);
+        Parent.MarkEdited();
+    }
+
+    /// <summary>Re-read every surfaced field from the live entity without writing back (used after import).</summary>
+    public void Reload()
+    {
+        Suppress = true;
+        LoadCommon();
+        LoadSpecific();
+        OnPropertyChanged(string.Empty); // refresh all bindings
+        Suppress = false;
+    }
+
+    protected abstract void LoadSpecific();
+}
+
+/// <summary>A Visitor (or Occupant, or Self) entity: the shared surface plus visitor-specific fields.</summary>
+public partial class JoinAvenueVisitorEntryViewModel : JoinAvenueEntityViewModel
+{
+    private readonly Func<JoinAvenueVisitor5> _accessor;
+    private readonly ISpriteRenderer? _spriteRenderer;
+
+    public JoinAvenueVisitorEntryViewModel(JoinAvenueEditorViewModel parent, string label, Func<JoinAvenueVisitor5> accessor, ISpriteRenderer? spriteRenderer)
+        : base(parent, label)
+    {
+        _accessor = accessor;
+        _spriteRenderer = spriteRenderer;
+
+        LoadCommon();
+        LoadSpecificFields();
+
+        var current = _accessor();
+        Favorite = new JoinAvenueSpeciesViewModel(current.FavoriteSpecies, spriteRenderer, sp => WriteVisitor(v => v.FavoriteSpecies = sp));
+    }
+
+    public JoinAvenueVisitor5 Visitor => _accessor();
+    public override IJoinAvenueEntity5 Entity => _accessor();
+
+    public IReadOnlyList<ComboItem> ShopTypeList { get; } = JoinAvenueEditorViewModel.BuildEnumList<JoinAvenueShopType5>();
+
+    public JoinAvenueSpeciesViewModel? Favorite { get; private set; }
+
+    // ---- Visitor-specific fields ----
+    [ObservableProperty] private int _joinAvenueLevel;
+    [ObservableProperty] private int _shopTypeIndex;
+    [ObservableProperty] private int _desiredShopType;
+    [ObservableProperty] private int _dexSeen;
+    [ObservableProperty] private int _medalRank;
+    [ObservableProperty] private int _medalHint;
+    [ObservableProperty] private int _medalCount;
+    [ObservableProperty] private int _shopLevel;
+    [ObservableProperty] private int _shopExperience;
+    [ObservableProperty] private int _joinAvenueRank;
+    [ObservableProperty] private int _origin;
+
+    public int ShopMaxLevel => JoinAvenueVisitor5.ShopMaxLevel;
+
+    protected override void LoadSpecific()
+    {
+        LoadSpecificFields();
+        Favorite?.Load(_accessor().FavoriteSpecies);
+    }
+
+    private void LoadSpecificFields()
+    {
+        var v = _accessor();
+        JoinAvenueLevel = v.JoinAvenueLevel;
+        ShopTypeIndex = (ushort)v.ShopType;
+        DesiredShopType = v.DesiredShopType;
+        DexSeen = v.DexSeen;
+        MedalRank = v.MedalRank;
+        MedalHint = v.MedalHint;
+        MedalCount = v.MedalCount;
+        ShopLevel = v.ShopLevel;
+        ShopExperience = v.ShopExperience;
+        JoinAvenueRank = v.JoinAvenueRank;
+        Origin = v.Origin;
+    }
+
+    partial void OnJoinAvenueLevelChanged(int value) => WriteVisitor(v => v.JoinAvenueLevel = (byte)value);
+    partial void OnShopTypeIndexChanged(int value) => WriteVisitor(v => v.ShopType = (JoinAvenueShopType5)(ushort)value);
+    partial void OnDesiredShopTypeChanged(int value) => WriteVisitor(v => v.DesiredShopType = (ushort)value);
+    partial void OnDexSeenChanged(int value) => WriteVisitor(v => v.DexSeen = (ushort)value);
+    partial void OnMedalRankChanged(int value) => WriteVisitor(v => v.MedalRank = (byte)value);
+    partial void OnMedalHintChanged(int value) => WriteVisitor(v => v.MedalHint = (byte)value);
+    partial void OnMedalCountChanged(int value) => WriteVisitor(v => v.MedalCount = (byte)value);
+    partial void OnShopLevelChanged(int value) => WriteVisitor(v => v.ShopLevel = (byte)value);
+    partial void OnShopExperienceChanged(int value) => WriteVisitor(v => v.ShopExperience = (ushort)value);
+    partial void OnJoinAvenueRankChanged(int value) => WriteVisitor(v => v.JoinAvenueRank = (byte)value);
+    partial void OnOriginChanged(int value) => WriteVisitor(v => v.Origin = (ushort)value);
+
+    private void WriteVisitor(Action<JoinAvenueVisitor5> apply)
+    {
+        if (Suppress || Parent.IsLoading) return;
+        apply(_accessor());
+        Parent.MarkEdited();
+    }
+
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        var data = await Parent.PromptImportAsync($"Import {Label}", "jav5", JoinAvenueVisitor5.SIZE);
+        if (data is null) return;
+        var temp = new JoinAvenueVisitor5(data);
+        _accessor().CopyFrom(temp);
+        Parent.MarkEdited();
+        Reload();
+    }
+
+    [RelayCommand]
+    private async Task ExportAsync()
+    {
+        await Parent.ExportBytesAsync($"Export {Label}", "jav5", _accessor().Write().ToArray());
+    }
+}
+
+/// <summary>A Fan entity: the shared surface plus fan-specific fields (species, bubble target, etc.).</summary>
+public partial class JoinAvenueFanEntryViewModel : JoinAvenueEntityViewModel
+{
+    private readonly Func<JoinAvenueFan5> _accessor;
+    private readonly ISpriteRenderer? _spriteRenderer;
+
+    public JoinAvenueFanEntryViewModel(JoinAvenueEditorViewModel parent, string label, Func<JoinAvenueFan5> accessor, ISpriteRenderer? spriteRenderer)
+        : base(parent, label)
+    {
+        _accessor = accessor;
+        _spriteRenderer = spriteRenderer;
+
+        LoadCommon();
+        LoadSpecificFields();
+
+        var current = _accessor();
+        FanSpecies = new JoinAvenueSpeciesViewModel(current.Species, spriteRenderer, sp => WriteFan(f => f.Species = sp));
+    }
+
+    public JoinAvenueFan5 Fan => _accessor();
+    public override IJoinAvenueEntity5 Entity => _accessor();
+
+    public JoinAvenueSpeciesViewModel? FanSpecies { get; private set; }
+
+    [ObservableProperty] private int _bubbleTarget;
+
+    protected override void LoadSpecific()
+    {
+        LoadSpecificFields();
+        FanSpecies?.Load(_accessor().Species);
+    }
+
+    private void LoadSpecificFields()
+    {
+        var f = _accessor();
+        BubbleTarget = f.BubbleTarget;
+    }
+
+    partial void OnBubbleTargetChanged(int value) => WriteFan(f => f.BubbleTarget = (byte)value);
+
+    private void WriteFan(Action<JoinAvenueFan5> apply)
+    {
+        if (Suppress || Parent.IsLoading) return;
+        apply(_accessor());
+        Parent.MarkEdited();
+    }
+
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        var data = await Parent.PromptImportAsync($"Import {Label}", "jah5", JoinAvenueFan5.SIZE);
+        if (data is null) return;
+        var temp = new JoinAvenueFan5(data);
+        _accessor().CopyFrom(temp);
+        Parent.MarkEdited();
+        Reload();
+    }
+
+    [RelayCommand]
+    private async Task ExportAsync()
+    {
+        await Parent.ExportBytesAsync($"Export {Label}", "jah5", _accessor().Write().ToArray());
+    }
+}
+
+/// <summary>An Assistant entity: the shared surface plus assistant-specific position fields.</summary>
+public partial class JoinAvenueAssistantEntryViewModel : JoinAvenueEntityViewModel
+{
+    private readonly Func<JoinAvenueAssistant5> _accessor;
+
+    public JoinAvenueAssistantEntryViewModel(JoinAvenueEditorViewModel parent, string label, Func<JoinAvenueAssistant5> accessor, ISpriteRenderer? spriteRenderer)
+        : base(parent, label)
+    {
+        _ = spriteRenderer;
+        _accessor = accessor;
+
+        LoadCommon();
+        LoadSpecificFields();
+    }
+
+    public JoinAvenueAssistant5 Assistant => _accessor();
+    public override IJoinAvenueEntity5 Entity => _accessor();
+
+    [ObservableProperty] private int _position0;
+    [ObservableProperty] private int _position1;
+    [ObservableProperty] private int _position2;
+
+    protected override void LoadSpecific() => LoadSpecificFields();
+
+    private void LoadSpecificFields()
+    {
+        var a = _accessor();
+        Position0 = a.Position0;
+        Position1 = a.Position1;
+        Position2 = a.Position2;
+    }
+
+    partial void OnPosition0Changed(int value) => WriteAssistant(a => a.Position0 = (byte)value);
+    partial void OnPosition1Changed(int value) => WriteAssistant(a => a.Position1 = (byte)value);
+    partial void OnPosition2Changed(int value) => WriteAssistant(a => a.Position2 = (byte)value);
+
+    private void WriteAssistant(Action<JoinAvenueAssistant5> apply)
+    {
+        if (Suppress || Parent.IsLoading) return;
+        apply(_accessor());
+        Parent.MarkEdited();
+    }
+
+    [RelayCommand]
+    private async Task ImportAsync()
+    {
+        var data = await Parent.PromptImportAsync($"Import {Label}", "jaa5", JoinAvenueAssistant5.SIZE);
+        if (data is null) return;
+        var temp = new JoinAvenueAssistant5(data);
+        _accessor().CopyFrom(temp);
+        Parent.MarkEdited();
+        Reload();
+    }
+
+    [RelayCommand]
+    private async Task ExportAsync()
+    {
+        await Parent.ExportBytesAsync($"Export {Label}", "jaa5", _accessor().Write().ToArray());
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -608,6 +608,15 @@ public partial class MainWindowViewModel
     }
 
     [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task OpenJoinAvenueAsync()
+    {
+        if (CurrentSave is not SAV5B2W2 sav) return;
+        await _windowService.ShowDialogAsync(
+            new JoinAvenueEditorViewModel(sav, _spriteRenderer, _dialogService),
+            "Join Avenue Editor (B2W2)");
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenMisc7Async()
     {
         if (CurrentSave is not SAV7 sav) return;

--- a/Tests/PKHeX.Avalonia.Tests/JoinAvenueEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/JoinAvenueEditorTests.cs
@@ -1,0 +1,159 @@
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class JoinAvenueEditorTests
+{
+    [Fact]
+    public void JoinAvenue_B2W2_LoadsAndIsSupported()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        Assert.True(vm.IsSupported);
+        Assert.Equal(JoinAvenue5.VisitorCount, vm.Visitors.Count);
+        Assert.Equal(JoinAvenue5.OccupantCount, vm.Occupants.Count);
+        Assert.Equal(JoinAvenue5.FanCount, vm.Fans.Count);
+        Assert.Equal(JoinAvenue5.AssistantCount, vm.Assistants.Count);
+        Assert.Equal(JoinAvenueSettings5.CountVisitingPlayersRemembered, vm.VisitingPlayers.Count);
+        Assert.NotNull(vm.Self);
+        Assert.NotEmpty(vm.CeilingColorList);
+    }
+
+    [Fact]
+    public void JoinAvenue_IsSupportedSave_GatesCorrectly()
+    {
+        Assert.True(JoinAvenueEditorViewModel.IsSupportedSave(new SAV5B2W2()));
+        Assert.False(JoinAvenueEditorViewModel.IsSupportedSave(new SAV5BW()));
+        Assert.False(JoinAvenueEditorViewModel.IsSupportedSave(new SAV4HGSS()));
+    }
+
+    [Fact]
+    public void JoinAvenue_ReflectsExistingSettings()
+    {
+        var sav = new SAV5B2W2();
+        var settings = sav.JoinAvenue.Settings;
+        settings.Rank = 1234;
+        settings.Experience = 555_000;
+        settings.CeilingColor = JoinAvenueCeilingColor5.Green;
+
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        Assert.Equal(1234, vm.Rank);
+        Assert.Equal(555_000, vm.Experience);
+        Assert.Equal((int)JoinAvenueCeilingColor5.Green, vm.CeilingColorIndex);
+    }
+
+    [Fact]
+    public void JoinAvenue_Settings_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        vm.Rank = 4321;
+        vm.Experience = 9000;
+        vm.CeilingColorIndex = (int)JoinAvenueCeilingColor5.Blue;
+        vm.IsPromotionActive = true;
+        vm.ScriptFlag = true;
+
+        Assert.Equal(4321, sav.JoinAvenue.Settings.Rank);
+        Assert.Equal(9000u, sav.JoinAvenue.Settings.Experience);
+        Assert.Equal(JoinAvenueCeilingColor5.Blue, sav.JoinAvenue.Settings.CeilingColor);
+        Assert.True(sav.JoinAvenue.Settings.IsPromotionActive);
+        Assert.True(sav.JoinAvenue.ScriptFlag);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void JoinAvenue_Rank_ClampsToMax()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        vm.Rank = 999_999;
+        Assert.Equal(JoinAvenueSettings5.MaxAvenueRank, sav.JoinAvenue.Settings.Rank);
+    }
+
+    [Fact]
+    public void JoinAvenue_VisitingPlayer_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        vm.VisitingPlayers[3].Value = 0x12345678;
+        Assert.Equal(0x12345678u, sav.JoinAvenue.Settings.GetVisitingPlayerTrainerID(3));
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void JoinAvenue_Visitor_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        var visitor = vm.Visitors[2];
+        visitor.Name = "Tester";
+        visitor.JoinAvenueLevel = 7;
+        visitor.ShopExperience = 250;
+        visitor.MedalCount = 13;
+        visitor.Favorite!.Species = (int)Species.Pikachu;
+
+        var live = sav.JoinAvenue.GetVisitor(2);
+        Assert.Equal("Tester", live.Name);
+        Assert.Equal(7, live.JoinAvenueLevel);
+        Assert.Equal(250, live.ShopExperience);
+        Assert.Equal(13, live.MedalCount);
+        Assert.Equal((ushort)Species.Pikachu, live.FavoriteSpecies);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void JoinAvenue_Fan_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        var fan = vm.Fans[1];
+        fan.Name = "FanGuy";
+        fan.BubbleTarget = 5;
+        fan.FanSpecies!.Species = (int)Species.Snivy;
+
+        var live = sav.JoinAvenue.GetFan(1);
+        Assert.Equal("FanGuy", live.Name);
+        Assert.Equal(5, live.BubbleTarget);
+        Assert.Equal((ushort)Species.Snivy, live.Species);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void JoinAvenue_Assistant_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        var assistant = vm.Assistants[0];
+        assistant.Name = "Helper";
+        assistant.Position0 = 9;
+
+        var live = sav.JoinAvenue.GetAssistant(0);
+        Assert.Equal("Helper", live.Name);
+        Assert.Equal(9, live.Position0);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void JoinAvenue_Self_WriteThroughToSave()
+    {
+        var sav = new SAV5B2W2();
+        var vm = new JoinAvenueEditorViewModel(sav);
+
+        vm.Self.Name = "Avenue";
+        vm.Self.JoinAvenueRank = 4;
+
+        Assert.Equal("Avenue", sav.JoinAvenue.Self.Name);
+        Assert.Equal(4, sav.JoinAvenue.Self.JoinAvenueRank);
+        Assert.True(sav.State.Edited);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new **Join Avenue editor** for Gen5 B2W2 (`SAV5B2W2.JoinAvenue`) — present upstream, missing from Avalonia. The largest of the ported editors. Binds the `JoinAvenue5` block; no `PKHeX.Core` changes.

### Tabs
- **Settings** — name, player title, rank (clamped), experience, ceiling color, flags, seed, script flag, promotion, plus the 32-entry visiting-player TID/SID database (grid).
- **Self** — the player's own avenue entity (visitor pane bound to `Avenue.Self`).
- **Visitors / Occupants** — `JoinAvenueVisitor5` list (selector + editor): general entity fields + avenue level, shop type/level, dex-seen, favorite species, medal rank/hint/count, origin.
- **Fans** — `JoinAvenueFan5` (species, bubble target).
- **Assistants** — `JoinAvenueAssistant5` (positions).

Shared `IJoinAvenueEntity5` fields (name, country/subregion, shout, version, language, gender, TID16, played time, greeting/farewell, met date, seed) via one reusable entity pane. Reusable species+form+sprite control (`EntityContext.Gen5`) for species fields. Per-entity `.jav5/.jah5/.jaa5` import/export via `IDialogService`. All edits write through the live block and mark the save edited.

Raw/unknown bytes (packed flag groups, trivia/activity arrays, record indices) are not surfaced as individual fields but remain round-trippable via per-entity import/export.

## Changes
- `PKHeX.Presentation/ViewModels/JoinAvenueEditorViewModel.cs` — new VM (+ entity/visitor/fan/assistant/species row VMs).
- `PKHeX.Avalonia/Views/JoinAvenueEditor.axaml` (+ .axaml.cs) — tabbed view.
- Wiring: `MainWindowViewModel.EditorDialogs.cs` (`OpenJoinAvenueAsync`, gated `SAV5B2W2`), `ViewLocator.cs`, `MainWindow.axaml` menu.
- `Tests/PKHeX.Avalonia.Tests/JoinAvenueEditorTests.cs` — 10 tests (load/counts, B2W2-only gating, settings + visiting-player + visitor/fan write-through, rank clamp).
- `Directory.Build.props` — UIVersion 1.1.36 → 1.1.37.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2321 passed, 1 skipped, 0 failed (+10 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
