### PR TITLE
feat(gen6): Battle Chateau rank/points (XY trainer)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.37</UIVersion>
+    <UIVersion>1.1.38</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/TrainerEditor.axaml
+++ b/PKHeX.Avalonia/Views/TrainerEditor.axaml
@@ -181,6 +181,31 @@
                     </StackPanel>
                 </Border>
                 
+                <!-- Battle Chateau (Gen 6 XY) -->
+                <Border IsVisible="{Binding HasBattleChateau}" Classes="section-card" Padding="12">
+                    <StackPanel Spacing="12">
+                        <TextBlock Text="Battle Chateau" FontWeight="SemiBold" Opacity="0.6" />
+                        <Grid ColumnDefinitions="*,12,*,12,Auto" RowDefinitions="Auto,4,Auto">
+                            <TextBlock Grid.Row="0" Grid.Column="0" Text="Rank" FontSize="11" FontWeight="SemiBold" Opacity="0.7" />
+                            <ComboBox Grid.Row="2" Grid.Column="0"
+                                      ItemsSource="{Binding ChateauRankList}"
+                                      SelectedValue="{Binding ChateauRank}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      HorizontalAlignment="Stretch" />
+
+                            <TextBlock Grid.Row="0" Grid.Column="2" Text="Points" FontSize="11" FontWeight="SemiBold" Opacity="0.7" />
+                            <NumericUpDown Grid.Row="2" Grid.Column="2" Value="{Binding ChateauPoints}" Minimum="0" Maximum="4095" FormatString="0" ShowButtonSpinner="False" />
+
+                            <Button Grid.Row="2" Grid.Column="4"
+                                    Content="Set points for rank"
+                                    Command="{Binding SetChateauPointsForRankCommand}"
+                                    VerticalAlignment="Bottom"
+                                    Padding="12,6" FontSize="12" />
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
                 <!-- Adventure & Coordinates (2 Columns) -->
                 <Grid ColumnDefinitions="*,16,*" IsVisible="{Binding HasAdventureInfo}">
                     <Border Grid.Column="0" Classes="section-card" Padding="12">

--- a/PKHeX.Presentation/ViewModels/TrainerEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/TrainerEditorViewModel.cs
@@ -150,6 +150,23 @@ public partial class TrainerEditorViewModel : ViewModelBase
 
     [ObservableProperty] private bool _anyCurrencyVisible;
 
+    // Battle Chateau (Gen 6 XY)
+    [ObservableProperty] private bool _hasBattleChateau;
+    [ObservableProperty] private int _chateauRank;
+    [ObservableProperty] private int _chateauPoints;
+
+    public IReadOnlyList<ComboItem> ChateauRankList { get; } = BuildChateauRankList();
+
+    private static IReadOnlyList<ComboItem> BuildChateauRankList()
+    {
+        var names = Enum.GetNames<BattleChateauRank6>();
+        var values = Enum.GetValues<BattleChateauRank6>();
+        var list = new List<ComboItem>(names.Length);
+        for (int i = 0; i < names.Length; i++)
+            list.Add(new ComboItem(names[i], Convert.ToInt32(values[i])));
+        return list;
+    }
+
     private void LoadFromSave()
     {
         TrainerName = _sav.OT;
@@ -172,6 +189,22 @@ public partial class TrainerEditorViewModel : ViewModelBase
         LoadAdventureInfo();
         LoadCoordinates();
         LoadCurrencies();
+        LoadBattleChateau();
+    }
+
+    private void LoadBattleChateau()
+    {
+        if (_sav is SAV6XY xy)
+        {
+            HasBattleChateau = true;
+            var sube = xy.SUBE;
+            ChateauRank = sube.ChateauRank;
+            ChateauPoints = sube.ChateauPoints;
+        }
+        else
+        {
+            HasBattleChateau = false;
+        }
     }
 
     private void LoadCurrencies()
@@ -345,6 +378,26 @@ public partial class TrainerEditorViewModel : ViewModelBase
         SaveAdventureInfo();
         SaveCoordinates();
         SaveCurrencies();
+        SaveBattleChateau();
+    }
+
+    private void SaveBattleChateau()
+    {
+        if (!HasBattleChateau) return;
+
+        if (_sav is SAV6XY xy)
+        {
+            xy.SUBE.SetChateau((ushort)ChateauRank, (ushort)ChateauPoints);
+        }
+    }
+
+    [RelayCommand]
+    private void SetChateauPointsForRank()
+    {
+        // GetChateauPointsForRank only defines values for the named ranks (Baron..GrandDuke).
+        // Guard against higher raw rank values (ChateauRankMax is 0xF) which would throw.
+        if (ChateauRank <= (int)BattleChateauRank6.GrandDuke)
+            ChateauPoints = SubEventLog6XY.GetChateauPointsForRank((ushort)ChateauRank);
     }
 
     private void SaveCurrencies()

--- a/Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs
@@ -165,6 +165,63 @@ public class TrainerEditorTests
     }
 
     [AvaloniaFact]
+    public void BattleChateau_ShouldPersist_RoundTrip()
+    {
+        // 1. Setup SaveFile (SAV6XY exposes SUBE chateau data)
+        var sav = new SAV6XY();
+
+        // 2. Load ViewModel
+        var vm = new TrainerEditorViewModel(sav);
+
+        // Assert detected for XY
+        Assert.True(vm.HasBattleChateau);
+        Assert.NotEmpty(vm.ChateauRankList);
+
+        // 3. Modify
+        vm.ChateauRank = (int)BattleChateauRank6.Duke; // 4
+        vm.ChateauPoints = 1234;
+
+        // 4. Save
+        vm.SaveCommand.Execute(null);
+
+        // 5. Verify persistence in SaveFile
+        Assert.Equal((ushort)BattleChateauRank6.Duke, sav.SUBE.ChateauRank);
+        Assert.Equal((ushort)1234, sav.SUBE.ChateauPoints);
+
+        // 6. Verify reload
+        var reloadedVm = new TrainerEditorViewModel(sav);
+        Assert.Equal((int)BattleChateauRank6.Duke, reloadedVm.ChateauRank);
+        Assert.Equal(1234, reloadedVm.ChateauPoints);
+    }
+
+    [AvaloniaFact]
+    public void BattleChateau_SetPointsForRank_UsesRankTable()
+    {
+        var sav = new SAV6XY();
+        var vm = new TrainerEditorViewModel(sav);
+
+        vm.ChateauRank = (int)BattleChateauRank6.GrandDuke; // 5 -> 1000 points
+        vm.SetChateauPointsForRankCommand.Execute(null);
+
+        Assert.Equal((int)SubEventLog6XY.GetChateauPointsForRank((ushort)BattleChateauRank6.GrandDuke), vm.ChateauPoints);
+        Assert.Equal(1000, vm.ChateauPoints);
+    }
+
+    [AvaloniaFact]
+    public void BattleChateau_ShouldHide_ForNonXYSave()
+    {
+        // ORAS (SAV6AO) does not expose chateau data
+        var ao = new SAV6AO();
+        var vmAo = new TrainerEditorViewModel(ao);
+        Assert.False(vmAo.HasBattleChateau);
+
+        // A later-gen save also lacks it
+        var swsh = new SAV8SWSH();
+        var vmSwsh = new TrainerEditorViewModel(swsh);
+        Assert.False(vmSwsh.HasBattleChateau);
+    }
+
+    [AvaloniaFact]
     public void Badges_ShouldHide_ForUnsupportedSave()
     {
         // 1. Setup generic SaveFile without Badges property (mock or base)


### PR DESCRIPTION
## Summary

Adds **Battle Chateau Rank + Points** editing to the Gen6 (XY) trainer editor — present upstream, missing from Avalonia. Binds `SAV6XY.SUBE` (`SubEventLog6`); no `PKHeX.Core` changes.

### What's new
A "Battle Chateau" section (visible only for X/Y saves) with:
- a **Rank** combo from the `BattleChateauRank6` enum (Baron → Grand Duke …),
- a **Points** field (0–4095),
- a "Set points for rank" button using `GetChateauPointsForRank`.

Loaded from `SUBE.ChateauRank/ChateauPoints` and persisted via the editor's existing Apply/Save command (`SUBE.SetChateau`), matching how the other trainer fields work.

## Changes
- `PKHeX.Presentation/ViewModels/TrainerEditorViewModel.cs` — `HasBattleChateau`, `ChateauRank/Points`, `ChateauRankList`, load/save wiring, `SetChateauPointsForRank`.
- `PKHeX.Avalonia/Views/TrainerEditor.axaml` — Battle Chateau section-card.
- `Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs` — 3 tests (round-trip persist, set-points-for-rank, hidden for non-XY: SAV6AO + SAV8SWSH).
- `Directory.Build.props` — UIVersion 1.1.37 → 1.1.38.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2324 passed, 1 skipped, 0 failed (+3 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
