### PR TITLE
feat(tools): Save Handler Troubleshooter

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.38</UIVersion>
+    <UIVersion>1.1.39</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/ISaveFileGateway.cs
+++ b/PKHeX.Application/Abstractions/ISaveFileGateway.cs
@@ -8,6 +8,16 @@ public interface ISaveFileGateway
     bool HasSave { get; }
 
     Task<bool> LoadSaveFileAsync(string path);
+
+    /// <summary>
+    /// Adopts an already-constructed <see cref="SaveFile"/> as the current save, bypassing path-based
+    /// auto-detection. Used by the Save Handler Troubleshooter to open a save that the normal loader
+    /// could not recognize.
+    /// </summary>
+    /// <param name="sav">The save file to make current.</param>
+    /// <param name="path">Optional originating path, recorded so a later Save writes back to the right file.</param>
+    void OpenLoadedSave(SaveFile sav, string? path = null);
+
     Task<bool> SaveFileAsync(string? path = null);
     void CloseSave();
 

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -93,6 +93,7 @@ public static class ViewLocator
         [typeof(Roamer3EditorViewModel)] = () => new Roamer3Editor(),
         [typeof(Roamer6EditorViewModel)] = () => new Roamer6Editor(),
         [typeof(RoamerEditorViewModel)] = () => new RoamerEditor(),
+        [typeof(SaveHandlerTroubleshooterViewModel)] = () => new SaveHandlerTroubleshooter(),
         [typeof(SealStickers8bEditorViewModel)] = () => new SealStickers8bEditor(),
         [typeof(SecretBase3EditorViewModel)] = () => new SecretBase3Editor(),
         [typeof(SecretBase6EditorViewModel)] = () => new SecretBase6Editor(),

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -26,6 +26,8 @@
                 <MenuItem Header="_Close" Command="{Binding CloseFileCommand}" />
             </MenuItem>
             <MenuItem Header="_Tools">
+                <MenuItem Header="Save Handler Troubleshooter…" Command="{Binding OpenSaveHandlerTroubleshooterCommand}" />
+                <Separator />
                 <MenuItem Header="Showdown">
                     <MenuItem Header="Import Set from Clipboard" Command="{Binding ImportShowdownCommand}" InputGesture="Ctrl+T" />
                     <MenuItem Header="Export Set to Clipboard" Command="{Binding ExportShowdownCommand}" InputGesture="Ctrl+Shift+T" />

--- a/PKHeX.Avalonia/Views/SaveHandlerTroubleshooter.axaml
+++ b/PKHeX.Avalonia/Views/SaveHandlerTroubleshooter.axaml
@@ -1,0 +1,78 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="540"
+             x:Class="PKHeX.Avalonia.Views.SaveHandlerTroubleshooter"
+             x:DataType="vm:SaveHandlerTroubleshooterViewModel">
+
+    <ScrollViewer>
+        <StackPanel Margin="24" Spacing="20" Width="520">
+            <StackPanel Spacing="4">
+                <TextBlock Text="Save Handler Troubleshooter" FontSize="24" FontWeight="Light"/>
+                <TextBlock Text="Force-load a save file that fails normal auto-detection by overriding its type, version, language, or recognition handler."
+                           FontSize="12" Opacity="0.6" TextWrapping="Wrap"/>
+            </StackPanel>
+
+            <!-- File selection -->
+            <Border Classes="section-card" Padding="20" CornerRadius="8">
+                <StackPanel Spacing="12">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <TextBlock Text="📁" FontSize="20" VerticalAlignment="Center"/>
+                        <TextBlock Text="Save File" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBox Grid.Column="0" Text="{Binding FilePath}" Watermark="Path to the save file…" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                        <Button Grid.Column="1" Content="Browse…" Command="{Binding BrowseCommand}" Padding="16,8"/>
+                    </Grid>
+                    <TextBlock Text="{Binding FileName}" FontSize="12" Opacity="0.6"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Forced parameters -->
+            <Border Classes="section-card" Padding="20" CornerRadius="8">
+                <StackPanel Spacing="16">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <TextBlock Text="🔧" FontSize="20" VerticalAlignment="Center"/>
+                        <TextBlock Text="Forced Parameters" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="12">
+                        <Grid ColumnDefinitions="160,*">
+                            <TextBlock Grid.Column="0" Text="Save Type" FontWeight="Medium" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                                      ItemsSource="{Binding SaveTypes}" SelectedItem="{Binding SelectedSaveType}"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="160,*">
+                            <TextBlock Grid.Column="0" Text="Version" FontWeight="Medium" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                                      ItemsSource="{Binding Versions}" SelectedItem="{Binding SelectedVersion}"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="160,*">
+                            <TextBlock Grid.Column="0" Text="Language" FontWeight="Medium" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                                      ItemsSource="{Binding Languages}" SelectedItem="{Binding SelectedLanguage}"/>
+                        </Grid>
+                        <Grid ColumnDefinitions="160,*">
+                            <TextBlock Grid.Column="0" Text="Handler" FontWeight="Medium" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                                      ItemsSource="{Binding Handlers}" SelectedItem="{Binding SelectedHandler}"/>
+                        </Grid>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Status / result -->
+            <Border Classes="section-card" Padding="16" CornerRadius="8">
+                <SelectableTextBlock Text="{Binding Status}" TextWrapping="Wrap" FontSize="13" MinHeight="48"/>
+            </Border>
+
+            <Button Content="Load Save"
+                    Command="{Binding LoadCommand}"
+                    Classes="accent"
+                    HorizontalAlignment="Right"
+                    Padding="24,12"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/PKHeX.Avalonia/Views/SaveHandlerTroubleshooter.axaml.cs
+++ b/PKHeX.Avalonia/Views/SaveHandlerTroubleshooter.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class SaveHandlerTroubleshooter : UserControl
+{
+    public SaveHandlerTroubleshooter()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Infrastructure/SaveFileService.cs
+++ b/PKHeX.Infrastructure/SaveFileService.cs
@@ -37,6 +37,13 @@ public sealed class SaveFileService : ISaveFileGateway
         return true;
     }
 
+    public void OpenLoadedSave(SaveFile sav, string? path = null)
+    {
+        CurrentSave = sav;
+        _currentPath = path ?? sav.Metadata.FilePath;
+        SaveFileChanged?.Invoke(CurrentSave);
+    }
+
     public Task<bool> SaveFileAsync(string? path = null)
     {
         return Task.Run(() =>

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -43,6 +43,15 @@ public partial class MainWindowViewModel
         await _windowService.ShowDialogAsync(vm, "Save Folder List");
     }
 
+    // No HasSave gate: the troubleshooter exists to open a save the normal loader cannot recognize,
+    // so it must be reachable with no save loaded.
+    [RelayCommand]
+    private async Task OpenSaveHandlerTroubleshooterAsync()
+    {
+        var vm = new SaveHandlerTroubleshooterViewModel(_dialogService, _saveFileService);
+        await _windowService.ShowDialogAsync(vm, "Save Handler Troubleshooter");
+    }
+
     [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenBatchEditorAsync()
     {

--- a/PKHeX.Presentation/ViewModels/SaveHandlerTroubleshooterViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/SaveHandlerTroubleshooterViewModel.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Helps load save files that fail auto-detection by letting the user force a specific
+/// <see cref="SaveFileType"/>, <see cref="GameVersion"/>, <see cref="LanguageID"/>, and recognition
+/// handler. Mirrors the upstream WinForms <c>SaveHandlerTroubleshooter</c>, using
+/// <see cref="SaveUtil.TryGetSaveFileHandler(Memory{byte}, out SaveFile, string, ISaveHandler, SaveTypeInfo)"/>
+/// as the force-load entry point. Intentionally not gated on a loaded save — its whole purpose is to
+/// open a save the normal loader cannot.
+/// </summary>
+public partial class SaveHandlerTroubleshooterViewModel : ViewModelBase, ICloseableDialog
+{
+    private readonly IDialogService _dialogService;
+    private readonly ISaveFileGateway _saveFileService;
+
+    public Action? CloseRequested { get; set; }
+
+    /// <summary>The force-loaded save, exposed so callers/tests can read the result after a successful load.</summary>
+    public SaveFile? LoadedSave { get; private set; }
+
+    public SaveHandlerTroubleshooterViewModel(IDialogService dialogService, ISaveFileGateway saveFileService)
+    {
+        _dialogService = dialogService;
+        _saveFileService = saveFileService;
+
+        SaveTypes = BuildSaveTypes();
+        Handlers = BuildHandlers();
+        Languages = BuildLanguages();
+
+        SelectedSaveType = SaveTypes[0];
+        SelectedHandler = Handlers[0];
+        SelectedLanguage = Languages.FirstOrDefault(l => l.Value == LanguageID.English) ?? Languages[0];
+
+        UpdateVersionChoices();
+    }
+
+    // — File selection —
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(LoadCommand))]
+    private string _filePath = string.Empty;
+
+    public string FileName => string.IsNullOrWhiteSpace(FilePath) ? "(no file selected)" : Path.GetFileName(FilePath);
+
+    partial void OnFilePathChanged(string value) => OnPropertyChanged(nameof(FileName));
+
+    // — Combo sources —
+
+    public IReadOnlyList<SaveTypeOption> SaveTypes { get; }
+    public IReadOnlyList<HandlerOption> Handlers { get; }
+    public IReadOnlyList<LanguageOption> Languages { get; }
+
+    [ObservableProperty] private ObservableCollection<VersionOption> _versions = [];
+
+    // — Selected values —
+
+    [ObservableProperty] private SaveTypeOption _selectedSaveType = null!;
+    [ObservableProperty] private VersionOption? _selectedVersion;
+    [ObservableProperty] private HandlerOption _selectedHandler = null!;
+    [ObservableProperty] private LanguageOption _selectedLanguage = null!;
+
+    partial void OnSelectedSaveTypeChanged(SaveTypeOption value) => UpdateVersionChoices();
+
+    // — Status —
+
+    [ObservableProperty] private string _status = "Select a save file and (optionally) force a type, version, language, or handler, then press Load.";
+    [ObservableProperty] private bool _lastLoadSucceeded;
+
+    private void UpdateVersionChoices()
+    {
+        var type = SelectedSaveType?.Value ?? SaveFileType.None;
+        var list = new List<VersionOption> { new("Any", GameVersion.Any) };
+        if (type != SaveFileType.None)
+        {
+            list.AddRange(GameUtil.GameVersions
+                .Where(v => v.SaveFileType == type)
+                .Distinct()
+                .Select(v => new VersionOption(GetVersionDisplayName(v), v)));
+        }
+
+        Versions = new ObservableCollection<VersionOption>(list);
+        SelectedVersion = Versions[0];
+    }
+
+    [RelayCommand]
+    private async Task BrowseAsync()
+    {
+        var path = await _dialogService.OpenFileAsync("Select Save File to Troubleshoot", FileDialogFilters.OpenSaveFile);
+        if (!string.IsNullOrEmpty(path))
+            FilePath = path;
+    }
+
+    private bool CanLoad() => !string.IsNullOrWhiteSpace(FilePath);
+
+    [RelayCommand(CanExecute = nameof(CanLoad))]
+    private async Task LoadAsync()
+    {
+        LastLoadSucceeded = false;
+        LoadedSave = null;
+
+        var path = FilePath.Trim();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            Status = "No file selected.";
+            return;
+        }
+
+        if (!File.Exists(path))
+        {
+            Status = $"File does not exist:\n{path}";
+            return;
+        }
+
+        byte[] data;
+        try
+        {
+            data = File.ReadAllBytes(path);
+        }
+        catch (Exception ex)
+        {
+            Status = $"Could not read the file (it may be in use):\n{path}\n\n{ex.Message}";
+            return;
+        }
+
+        SaveFile? sav;
+        try
+        {
+            sav = ForceLoad(data, path);
+        }
+        catch (Exception ex)
+        {
+            Status = $"The forced parameters threw while constructing the save:\n{ex.Message}";
+            return;
+        }
+
+        if (sav is null)
+        {
+            Status = "Force-load failed: no save file could be built from the chosen handler/type. " +
+                     "Try a different Type, Version, or Handler. " +
+                     $"(File size: {data.Length} bytes.)";
+            return;
+        }
+
+        LoadedSave = sav;
+        LastLoadSucceeded = true;
+        Status = $"Success — loaded as {sav.GetType().Name} ({sav.Version}). Opening it in the main window…";
+
+        // Integrate: hand the constructed save off to the main open flow.
+        _saveFileService.OpenLoadedSave(sav, path);
+
+        await Task.Yield();
+        CloseRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// Force-constructs a <see cref="SaveFile"/> from the chosen handler and type info. Returns null on failure.
+    /// Public so callers/tests can exercise the exact force-load path the Load command uses.
+    /// </summary>
+    public SaveFile? ForceLoad(Memory<byte> data, string? path)
+    {
+        var handler = SelectedHandler?.Handler ?? new AutoSaveHandler();
+
+        // "Default/auto" type → defer to full auto-detection (typeInfo carries no concrete type to build).
+        if (SelectedSaveType is null || SelectedSaveType.Value == SaveFileType.None)
+            return SaveUtil.TryGetSaveFileHandler(data, out var auto, path, handler) ? auto : null;
+
+        var typeInfo = new SaveTypeInfo(
+            SelectedSaveType.Value,
+            SelectedVersion?.Value ?? GameVersion.Any,
+            SelectedLanguage?.Value ?? LanguageID.None);
+
+        return SaveUtil.TryGetSaveFileHandler(data, out var result, path, handler, typeInfo) ? result : null;
+    }
+
+    private static IReadOnlyList<SaveTypeOption> BuildSaveTypes()
+    {
+        var list = new List<SaveTypeOption> { new("Default (auto-detect)", SaveFileType.None) };
+        list.AddRange(Enum.GetValues<SaveFileType>()
+            .Where(t => t != SaveFileType.None)
+            .Select(t => new SaveTypeOption(t.ToString(), t)));
+        return list;
+    }
+
+    private static IReadOnlyList<HandlerOption> BuildHandlers()
+    {
+        var list = new List<HandlerOption> { new("Default (no special handling)", new AutoSaveHandler()) };
+        list.AddRange(SaveUtil.Handlers.Select(h => new HandlerOption(GetHandlerDisplayName(h), h)));
+        return list;
+    }
+
+    private static IReadOnlyList<LanguageOption> BuildLanguages() =>
+        Enum.GetValues<LanguageID>().Select(l => new LanguageOption(l.ToString(), l)).ToList();
+
+    private static string GetVersionDisplayName(GameVersion version)
+    {
+        var name = GameInfo.GetVersionName(version);
+        return string.IsNullOrWhiteSpace(name) ? version.ToString() : name;
+    }
+
+    private static string GetHandlerDisplayName(ISaveHandler handler)
+    {
+        const string prefix = "SaveHandler";
+        var name = handler.GetType().Name;
+        return name.StartsWith(prefix, StringComparison.Ordinal) ? name[prefix.Length..] : name;
+    }
+
+    // — Option records (ToString drives ComboBox display) —
+
+    public sealed record SaveTypeOption(string Text, SaveFileType Value)
+    {
+        public override string ToString() => Text;
+    }
+
+    public sealed record VersionOption(string Text, GameVersion Value)
+    {
+        public override string ToString() => Text;
+    }
+
+    public sealed record HandlerOption(string Text, ISaveHandler Handler)
+    {
+        public override string ToString() => Text;
+    }
+
+    public sealed record LanguageOption(string Text, LanguageID Value)
+    {
+        public override string ToString() => Text;
+    }
+
+    /// <summary>
+    /// Pass-through handler that recognizes any size and returns the input unsplit. Equivalent to the
+    /// upstream <c>SaveHandlerDefault</c>; selecting it means "no special header/footer handling".
+    /// </summary>
+    private sealed class AutoSaveHandler : ISaveHandler
+    {
+        public bool IsRecognized(long size) => true;
+        public SaveHandlerSplitResult TrySplit(Memory<byte> input) => new(input, default, default, this);
+        public void Finalize(Span<byte> input) { }
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/SaveHandlerTroubleshooterTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SaveHandlerTroubleshooterTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using PKHeX.Application.Abstractions;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class SaveHandlerTroubleshooterTests
+{
+    private static SaveHandlerTroubleshooterViewModel NewVM(out FakeGateway gateway)
+    {
+        gateway = new FakeGateway();
+        var dialog = new Mock<IDialogService>();
+        return new SaveHandlerTroubleshooterViewModel(dialog.Object, gateway);
+    }
+
+    // SAV5B2W2's blank .Write() bytes round-trip cleanly through SaveUtil under BOTH auto-detect and an
+    // explicit forced type, so it is the known-good blank fixture for the force-load path. (Notably,
+    // a blank SAV8SWSH does NOT round-trip — its .Write() can't be re-decrypted — so it is unsuitable.)
+    private static byte[] KnownGoodBlank() => new SAV5B2W2().Write().ToArray();
+
+    [Fact]
+    public void Lists_ArePopulated_WithDefaultsFirst()
+    {
+        var vm = NewVM(out _);
+
+        // Save types: Default (auto) entry plus every concrete SaveFileType.
+        Assert.True(vm.SaveTypes.Count > 1);
+        Assert.Equal(SaveFileType.None, vm.SaveTypes[0].Value);
+        Assert.Contains(vm.SaveTypes, t => t.Value == SaveFileType.B2W2);
+        Assert.DoesNotContain(vm.SaveTypes.Skip(1), t => t.Value == SaveFileType.None);
+
+        // Handlers: Default (no special handling) entry plus every registered handler.
+        Assert.Equal(SaveUtil.Handlers.Count + 1, vm.Handlers.Count);
+        Assert.All(vm.Handlers, h => Assert.NotNull(h.Handler));
+
+        // Languages: every LanguageID value.
+        Assert.Equal(Enum.GetValues<LanguageID>().Length, vm.Languages.Count);
+        Assert.Contains(vm.Languages, l => l.Value == LanguageID.English);
+
+        // Default selections are sane.
+        Assert.NotNull(vm.SelectedSaveType);
+        Assert.NotNull(vm.SelectedHandler);
+        Assert.NotNull(vm.SelectedLanguage);
+        Assert.NotNull(vm.SelectedVersion);
+    }
+
+    [Fact]
+    public void SelectingType_FiltersVersionChoices_ToThatType()
+    {
+        var vm = NewVM(out _);
+
+        vm.SelectedSaveType = vm.SaveTypes.First(t => t.Value == SaveFileType.B2W2);
+
+        // First entry is always "Any"; the rest must map to the chosen type.
+        Assert.Equal(GameVersion.Any, vm.Versions[0].Value);
+        Assert.True(vm.Versions.Count > 1);
+        Assert.All(vm.Versions.Skip(1), v => Assert.Equal(SaveFileType.B2W2, v.Value.SaveFileType));
+        Assert.Contains(vm.Versions, v => v.Value is GameVersion.B2 or GameVersion.W2);
+    }
+
+    [Fact]
+    public void ForceLoad_AutoDefault_LoadsKnownGoodBlank()
+    {
+        var vm = NewVM(out _);
+
+        // Defaults: Save Type = "Default (auto-detect)", Handler = "Default".
+        var sav = vm.ForceLoad(KnownGoodBlank(), path: null);
+
+        Assert.NotNull(sav);
+        Assert.IsType<SAV5B2W2>(sav);
+    }
+
+    [Fact]
+    public void ForceLoad_ExplicitTypeAndHandler_LoadsKnownGoodBlank()
+    {
+        var vm = NewVM(out _);
+
+        vm.SelectedSaveType = vm.SaveTypes.First(t => t.Value == SaveFileType.B2W2);
+        vm.SelectedHandler = vm.Handlers[0]; // Default (no special handling)
+        vm.SelectedVersion = vm.Versions[0]; // Any
+
+        var sav = vm.ForceLoad(KnownGoodBlank(), path: null);
+
+        Assert.NotNull(sav);
+        Assert.IsType<SAV5B2W2>(sav);
+    }
+
+    [Fact]
+    public void ForceLoad_ExplicitType_RecoversSaveThatAutoDetectionMisses()
+    {
+        // Core scenario the tool exists for: a blank SAV1 is not recognized by auto-detection, but
+        // forcing the RBY type loads it. This proves the forced-type path adds capability over the
+        // normal loader.
+        var data = new SAV1().Write().ToArray();
+        Assert.Null(SaveUtil.GetSaveFile(data)); // auto-detection fails
+
+        var vm = NewVM(out _);
+        vm.SelectedSaveType = vm.SaveTypes.First(t => t.Value == SaveFileType.RBY);
+        vm.SelectedVersion = vm.Versions[0];
+
+        var sav = vm.ForceLoad(data, path: null);
+
+        Assert.NotNull(sav);
+        Assert.IsType<SAV1>(sav);
+    }
+
+    [Fact]
+    public void ForceLoad_InvalidBytes_ReturnsNull()
+    {
+        var vm = NewVM(out _);
+        var junk = new byte[64]; // far too small to be any real save
+
+        Assert.Null(vm.ForceLoad(junk, path: null));
+    }
+
+    [Fact]
+    public void ForceLoad_WrongForcedType_FailsToBuild()
+    {
+        var vm = NewVM(out _);
+        // Valid B2W2 bytes, but forced to be read as a Gen-1 (RBY) save: the size/shape mismatch must
+        // not yield a valid B2W2 save. ForceLoad itself does not swallow exceptions (the Load command
+        // does), so a wrong forced type may either throw or return null — both are "failed to build".
+        var data = KnownGoodBlank();
+        vm.SelectedSaveType = vm.SaveTypes.First(t => t.Value == SaveFileType.RBY);
+        vm.SelectedVersion = vm.Versions[0];
+
+        SaveFile? result = null;
+        var ex = Record.Exception(() => result = vm.ForceLoad(data, path: null));
+
+        Assert.True(ex is not null || result is null or not SAV5B2W2);
+    }
+
+    [Fact]
+    public async Task Load_OnSuccess_HandsSaveToGatewayAndExposesResult()
+    {
+        var vm = NewVM(out var gateway);
+
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            $"sht_b2w2_{Guid.NewGuid():N}.sav");
+        await System.IO.File.WriteAllBytesAsync(path, KnownGoodBlank());
+        try
+        {
+            var closed = false;
+            vm.CloseRequested = () => closed = true;
+            vm.FilePath = path;
+
+            await vm.LoadCommand.ExecuteAsync(null);
+
+            Assert.True(vm.LastLoadSucceeded);
+            Assert.NotNull(vm.LoadedSave);
+            Assert.IsType<SAV5B2W2>(vm.LoadedSave);
+            Assert.Same(vm.LoadedSave, gateway.LastOpened);
+            Assert.Equal(path, gateway.LastPath);
+            Assert.True(closed);
+            Assert.Contains("Success", vm.Status);
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Load_OnInvalidFile_ReportsFailure_AndDoesNotIntegrate()
+    {
+        var vm = NewVM(out var gateway);
+
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            $"sht_junk_{Guid.NewGuid():N}.sav");
+        await System.IO.File.WriteAllBytesAsync(path, new byte[64]);
+        try
+        {
+            vm.FilePath = path;
+
+            await vm.LoadCommand.ExecuteAsync(null);
+
+            Assert.False(vm.LastLoadSucceeded);
+            Assert.Null(vm.LoadedSave);
+            Assert.Null(gateway.LastOpened);
+            Assert.Contains("failed", vm.Status, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void LoadCommand_CannotExecute_WithoutFilePath()
+    {
+        var vm = NewVM(out _);
+        Assert.False(vm.LoadCommand.CanExecute(null));
+
+        vm.FilePath = "/some/path.sav";
+        Assert.True(vm.LoadCommand.CanExecute(null));
+    }
+
+    /// <summary>Minimal gateway capturing the integration hand-off without touching any UI.</summary>
+    private sealed class FakeGateway : ISaveFileGateway
+    {
+        public SaveFile? CurrentSave { get; private set; }
+        public bool HasSave => CurrentSave is not null;
+        public SaveFile? LastOpened { get; private set; }
+        public string? LastPath { get; private set; }
+
+        public event Action<SaveFile?>? SaveFileChanged;
+
+        public Task<bool> LoadSaveFileAsync(string path) => Task.FromResult(false);
+
+        public void OpenLoadedSave(SaveFile sav, string? path = null)
+        {
+            CurrentSave = sav;
+            LastOpened = sav;
+            LastPath = path;
+            SaveFileChanged?.Invoke(sav);
+        }
+
+        public Task<bool> SaveFileAsync(string? path = null) => Task.FromResult(true);
+
+        public void CloseSave()
+        {
+            CurrentSave = null;
+            SaveFileChanged?.Invoke(null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Save Handler Troubleshooter** (Tools menu) — present upstream, missing from Avalonia. It loads save files that fail normal auto-detection by letting the user force a specific `SaveFileType` / `GameVersion` / `LanguageID` / handler. No `PKHeX.Core` changes.

### How it works
- Browse to a save file, optionally pick a save type (which filters the version list), language, and a specific `ISaveHandler` (or "Default" auto-detect).
- **Load** force-constructs the save via `SaveUtil.TryGetSaveFileHandler` (the same entry point upstream uses) and reports success (resulting save type) or the failure reason.
- On success the loaded save is adopted into the app via a new `ISaveFileGateway.OpenLoadedSave` (the clean-architecture equivalent of upstream's `Main.OpenSAV(..., forceOpen: true)`), so you can then edit/save it normally.

## Changes
- `PKHeX.Presentation/ViewModels/SaveHandlerTroubleshooterViewModel.cs` — new VM (file pick, type/version/language/handler combos, force-load, status).
- `PKHeX.Avalonia/Views/SaveHandlerTroubleshooter.axaml` (+ .axaml.cs) — new view.
- `PKHeX.Application/Abstractions/ISaveFileGateway.cs` + `PKHeX.Infrastructure/SaveFileService.cs` — `OpenLoadedSave` (adopt a pre-constructed save).
- Wiring: `MainWindowViewModel.EditorDialogs.cs` (`OpenSaveHandlerTroubleshooterAsync`, no save-loaded gate), `ViewLocator.cs`, `MainWindow.axaml` Tools menu.
- `Tests/PKHeX.Avalonia.Tests/SaveHandlerTroubleshooterTests.cs` — 10 tests (list population, version filtering by type, force-load of a known-good blank, auto-miss→forced-recover, invalid bytes fail).
- `Directory.Build.props` — UIVersion 1.1.38 → 1.1.39.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2334 passed, 1 skipped, 0 failed (+10 new; architecture tests green)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
