### PR TITLE
feat(pkm-editor): interactive Experience bar

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.40</UIVersion>
+    <UIVersion>1.1.41</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -161,18 +161,41 @@
                                     <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Text="Growth" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
 
                                     <!-- Level & Exp -->
-                                    <Grid Grid.Row="1" Grid.Column="0" ColumnDefinitions="*,8,*">
-                                        <StackPanel Grid.Column="0">
-                                            <TextBlock Text="Level" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" FormatString="0" ShowButtonSpinner="False"
-                                                           AutomationProperties.Name="Level" />
-                                        </StackPanel>
-                                        <StackPanel Grid.Column="2">
-                                            <TextBlock Text="EXP" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <NumericUpDown Value="{Binding Exp}" Minimum="0" Maximum="10000000" FormatString="0" ShowButtonSpinner="False"
-                                                           AutomationProperties.Name="Experience Points" />
-                                        </StackPanel>
-                                    </Grid>
+                                    <StackPanel Grid.Row="1" Grid.Column="0">
+                                        <Grid ColumnDefinitions="*,8,*">
+                                            <StackPanel Grid.Column="0">
+                                                <TextBlock Text="Level" FontWeight="SemiBold" Margin="0,0,0,4" />
+                                                <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" FormatString="0" ShowButtonSpinner="False"
+                                                               AutomationProperties.Name="Level" />
+                                            </StackPanel>
+                                            <StackPanel Grid.Column="2">
+                                                <TextBlock Text="EXP" FontWeight="SemiBold" Margin="0,0,0,4" />
+                                                <NumericUpDown Value="{Binding Exp}" Minimum="0" Maximum="10000000" FormatString="0" ShowButtonSpinner="False"
+                                                               AutomationProperties.Name="Experience Points" />
+                                            </StackPanel>
+                                        </Grid>
+
+                                        <!-- Interactive Experience bar (click/drag to set EXP within the level; hold Shift/Ctrl to snap to the level's high edge). -->
+                                        <Border x:Name="ExpBar"
+                                                Height="14" Margin="0,8,0,0"
+                                                CornerRadius="7"
+                                                Background="{DynamicResource ThemeControlMidBrush}"
+                                                BorderBrush="{DynamicResource ThemeBorderMidBrush}"
+                                                BorderThickness="1"
+                                                Cursor="Hand"
+                                                ClipToBounds="True"
+                                                ToolTip.Tip="{Binding ExpPercent, StringFormat='Experience: {0:P0}'}"
+                                                AutomationProperties.Name="Experience"
+                                                PointerPressed="ExpBar_PointerPressed"
+                                                PointerMoved="ExpBar_PointerMoved">
+                                            <ProgressBar Minimum="0" Maximum="1" Value="{Binding ExpPercent}"
+                                                         IsHitTestVisible="False"
+                                                         Background="Transparent"
+                                                         Foreground="{DynamicResource ThemeAccentPrimaryBrush}"
+                                                         CornerRadius="7"
+                                                         MinHeight="0" />
+                                        </Border>
+                                    </StackPanel>
 
                                     <!-- Nature -->
                                     <StackPanel Grid.Row="1" Grid.Column="2">

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml.cs
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using PKHeX.Presentation.ViewModels;
 
 namespace PKHeX.Avalonia.Views;
 
@@ -7,5 +9,45 @@ public partial class PokemonEditor : UserControl
     public PokemonEditor()
     {
         InitializeComponent();
+    }
+
+    private void ExpBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Border bar)
+            return;
+        if (!e.GetCurrentPoint(bar).Properties.IsLeftButtonPressed)
+            return;
+        ApplyExpFromPointer(bar, e);
+    }
+
+    private void ExpBar_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (sender is not Border bar)
+            return;
+        // Only react while the left button is held (drag).
+        if (!e.GetCurrentPoint(bar).Properties.IsLeftButtonPressed)
+            return;
+        ApplyExpFromPointer(bar, e);
+    }
+
+    private void ApplyExpFromPointer(Border bar, PointerEventArgs e)
+    {
+        if (DataContext is not PokemonEditorViewModel vm)
+            return;
+
+        var width = bar.Bounds.Width;
+        if (width <= 0)
+            return;
+
+        // Holding Shift or Ctrl snaps to the current level's high edge (mirrors upstream's modifier behavior).
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) || e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            vm.SetExpToLevelEdgeHigh();
+            return;
+        }
+
+        var x = e.GetPosition(bar).X;
+        var fraction = x / width;
+        vm.SetExpFromFraction(fraction);
     }
 }

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
@@ -135,6 +135,58 @@ public partial class PokemonEditorViewModel
     [ObservableProperty]
     private int _happiness;
 
+    /// <summary>
+    /// Progress through the current level as a fraction in [0,1], used to fill the Experience bar.
+    /// At <see cref="Experience.MaxLevel"/> the bar is full.
+    /// </summary>
+    public double ExpPercent => Level >= Experience.MaxLevel
+        ? 1.0
+        : Experience.GetEXPToLevelUpPercentage((byte)Level, (uint)Exp, _pk.PersonalInfo.EXPGrowth);
+
+    partial void OnExpChanged(long value)
+    {
+        if (_isLoading) return;
+        OnPropertyChanged(nameof(ExpPercent));
+    }
+
+    /// <summary>
+    /// Sets <see cref="Exp"/> from a horizontal fraction [0,1) along the Experience bar, staying within the
+    /// current level (mirrors upstream's left-click/drag behavior, which never changes the level).
+    /// </summary>
+    /// <param name="fraction">Fractional position along the bar; clamped to [0,1).</param>
+    public void SetExpFromFraction(double fraction)
+    {
+        if (Level >= Experience.MaxLevel)
+            return;
+
+        fraction = Math.Clamp(fraction, 0.0, 1.0);
+        var growth = _pk.PersonalInfo.EXPGrowth;
+        var start = Experience.GetEXP((byte)Level, growth);
+        var range = Experience.GetEXPToLevelUp((byte)Level, growth);
+        if (range == 0)
+            return;
+
+        // Stay strictly below the next level's threshold (range-1 is the level's high edge).
+        var progress = Math.Min(range - 1, (uint)(range * fraction));
+        Exp = start + progress;
+    }
+
+    /// <summary>
+    /// Snaps <see cref="Exp"/> to the high edge of the current level (one EXP below the next level-up),
+    /// mirroring upstream's modifier-click behavior.
+    /// </summary>
+    public void SetExpToLevelEdgeHigh()
+    {
+        if (Level >= Experience.MaxLevel)
+            return;
+
+        var growth = _pk.PersonalInfo.EXPGrowth;
+        var range = Experience.GetEXPToLevelUp((byte)Level, growth);
+        if (range == 0)
+            return;
+        Exp = Experience.GetEXP((byte)Level, growth) + range - 1;
+    }
+
     // Pokerus
     [ObservableProperty]
     private int _pkrsStrain;

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -324,6 +324,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
 
         OnPropertyChanged(nameof(IVTotal));
         OnPropertyChanged(nameof(EVTotal));
+        OnPropertyChanged(nameof(ExpPercent));
         UpdateSprite();
         Validate();
         LoadRibbons();
@@ -377,7 +378,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
     }
 
     partial void OnNicknameChanged(string value) { if (!_isLoading) Validate(); }
-    partial void OnLevelChanged(int value) { if (!_isLoading) { RecalculateStats(); Validate(); } }
+    partial void OnLevelChanged(int value) { if (!_isLoading) { RecalculateStats(); OnPropertyChanged(nameof(ExpPercent)); Validate(); } }
     partial void OnNatureChanged(int value) { if (!_isLoading) { RecalculateStats(); Validate(); } }
     partial void OnAbilityChanged(int value) { if (!_isLoading) Validate(); }
     partial void OnHeldItemChanged(int value) { if (!_isLoading) Validate(); }
@@ -613,8 +614,9 @@ public partial class PokemonEditorViewModel : ViewModelBase
         UpdateFormList();
         UpdateAbilityList();
         UpdateFormArgument();
-        UpdateSprite();
+        UpdateSprite(); // sets _pk.Species so the new growth rate is used below
         UpdateTitle();
+        OnPropertyChanged(nameof(ExpPercent));
         OnPropertyChanged(nameof(CanOpenTechRecord));
     }
 }

--- a/Tests/PKHeX.Avalonia.Tests/ExperienceBarTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ExperienceBarTests.cs
@@ -1,0 +1,133 @@
+using PKHeX.Core;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Tests for the interactive Experience bar wiring on <see cref="PKHeX.Presentation.ViewModels.PokemonEditorViewModel"/>.
+/// Ports upstream's <c>ExperienceBar</c> behavior: the bar fills to the current level's progress, and clicking/dragging
+/// sets EXP within the current level (never changing the level).
+/// </summary>
+public class ExperienceBarTests
+{
+    private static (PKHeX.Presentation.ViewModels.PokemonEditorViewModel VM, byte Growth) CreateVm(byte level)
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SL);
+        var pkm = new PK9 { Species = 906 }; // Sprigatito
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        var growth = pkm.PersonalInfo.EXPGrowth;
+        vm.Level = level;
+        // Seat EXP at the start of the level so we have a deterministic baseline.
+        vm.Exp = Experience.GetEXP(level, growth);
+        return (vm, growth);
+    }
+
+    [Fact]
+    public void ExpPercent_ReflectsKnownLevelExpGrowth()
+    {
+        const byte level = 50;
+        var (vm, growth) = CreateVm(level);
+
+        var start = Experience.GetEXP(level, growth);
+        var range = Experience.GetEXPToLevelUp(level, growth);
+
+        // Place EXP roughly mid-level and confirm the bar percent matches the Core formula.
+        var exp = start + (range / 2);
+        vm.Exp = exp;
+
+        var expected = Experience.GetEXPToLevelUpPercentage(level, exp, growth);
+        Assert.Equal(expected, vm.ExpPercent, 6);
+        Assert.InRange(vm.ExpPercent, 0.0, 1.0);
+    }
+
+    [Fact]
+    public void ExpPercent_AtStartOfLevel_IsZero()
+    {
+        const byte level = 50;
+        var (vm, _) = CreateVm(level);
+        Assert.Equal(0.0, vm.ExpPercent, 6);
+    }
+
+    [Fact]
+    public void SetExpFromFraction_Zero_SetsExpToLevelStart()
+    {
+        const byte level = 42;
+        var (vm, growth) = CreateVm(level);
+
+        // Move off the start first, then snap back to 0.
+        var range = Experience.GetEXPToLevelUp(level, growth);
+        vm.Exp = Experience.GetEXP(level, growth) + (range / 2);
+
+        vm.SetExpFromFraction(0.0);
+
+        Assert.Equal(Experience.GetEXP(level, growth), (uint)vm.Exp);
+        Assert.Equal(0.0, vm.ExpPercent, 6);
+    }
+
+    [Fact]
+    public void SetExpFromFraction_NearOne_SetsNearLevelHighEdge()
+    {
+        const byte level = 42;
+        var (vm, growth) = CreateVm(level);
+
+        var start = Experience.GetEXP(level, growth);
+        var range = Experience.GetEXPToLevelUp(level, growth);
+        var highEdge = start + range - 1; // one EXP below the next level-up
+
+        vm.SetExpFromFraction(0.999999);
+
+        // Must stay within the current level (strictly below the next level threshold)...
+        Assert.True((uint)vm.Exp < start + range);
+        Assert.Equal(level, Experience.GetLevel((uint)vm.Exp, growth));
+        // ...and land at (or essentially at) the high edge.
+        Assert.True((uint)vm.Exp <= highEdge);
+        Assert.True(highEdge - (uint)vm.Exp <= 1);
+    }
+
+    [Fact]
+    public void SetExpFromFraction_ClampsAboveOne_StaysWithinLevel()
+    {
+        const byte level = 30;
+        var (vm, growth) = CreateVm(level);
+
+        var start = Experience.GetEXP(level, growth);
+        var range = Experience.GetEXPToLevelUp(level, growth);
+
+        vm.SetExpFromFraction(5.0); // out of range, should clamp to the high edge of the level
+
+        Assert.Equal(start + range - 1, (uint)vm.Exp);
+        Assert.Equal(level, Experience.GetLevel((uint)vm.Exp, growth));
+    }
+
+    [Fact]
+    public void SetExpToLevelEdgeHigh_SetsHighEdge()
+    {
+        const byte level = 30;
+        var (vm, growth) = CreateVm(level);
+
+        var start = Experience.GetEXP(level, growth);
+        var range = Experience.GetEXPToLevelUp(level, growth);
+
+        vm.SetExpToLevelEdgeHigh();
+
+        Assert.Equal(start + range - 1, (uint)vm.Exp);
+        Assert.Equal(level, Experience.GetLevel((uint)vm.Exp, growth));
+    }
+
+    [Fact]
+    public void SetExpFromFraction_AtMaxLevel_IsNoOp()
+    {
+        const byte level = 100;
+        var (vm, _) = CreateVm(level);
+        var before = vm.Exp;
+
+        vm.SetExpFromFraction(0.0);
+        vm.SetExpFromFraction(0.5);
+        vm.SetExpToLevelEdgeHigh();
+
+        Assert.Equal(before, vm.Exp);
+        // At MaxLevel the bar reads as full.
+        Assert.Equal(1.0, vm.ExpPercent, 6);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an interactive **Experience bar** to the Pokémon editor, porting upstream's `ExperienceBar` control. The Level/EXP numeric inputs are kept; the bar is an additional visual that shows progress to the next level and lets you set EXP by clicking/dragging. No `PKHeX.Core` changes.

### Behavior
- Fill = `Experience.GetEXPToLevelUpPercentage(level, exp, growth)` (full at max level).
- **Click / drag** along the bar sets EXP within the current level (`GetEXP(level) + range × fraction`) — never changes the level, matching upstream.
- **Shift/Ctrl-click** snaps to the level's high edge.
- Stays in lockstep with the EXP NumericUpDown (shared `Exp` property) and recomputes on Level/Species change (growth-rate aware).

## Changes
- `PKHeX.Presentation/ViewModels/PokemonEditorViewModel.{Misc,}.cs` — `ExpPercent`, `SetExpFromFraction`, `SetExpToLevelEdgeHigh`, change notifications.
- `PKHeX.Avalonia/Views/PokemonEditor.axaml` (+ .axaml.cs) — the bar + pointer interaction.
- `Tests/PKHeX.Avalonia.Tests/ExperienceBarTests.cs` — 7 tests (percent vs Core formula, fraction→EXP mapping, level-boundary, max-level no-op).
- `Directory.Build.props` — UIVersion 1.1.40 → 1.1.41.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2342 passed, 1 skipped, 0 failed (+7 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window.
