### PR TITLE
feat(database): richer PKM database search filters

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.41</UIVersion>
+    <UIVersion>1.1.42</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
@@ -57,6 +57,60 @@
                                 <RadioButton Content="Illegal" IsChecked="{Binding IsLegal, Converter={StaticResource ObjectFalseConverter}}"/>
                             </StackPanel>
                         </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Egg" Opacity="0.7" FontSize="12"/>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <RadioButton Content="Any" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectNullConverter}}"/>
+                                <RadioButton Content="Yes" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectTrueConverter}}"/>
+                                <RadioButton Content="No" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectFalseConverter}}"/>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Hidden Power" Opacity="0.7" FontSize="12"/>
+                            <ComboBox ItemsSource="{Binding HiddenPowerList}"
+                                      SelectedValue="{Binding HiddenPowerType}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      HorizontalAlignment="Stretch"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="Level" Opacity="0.7" FontSize="12"/>
+                            <ComboBox ItemsSource="{Binding LevelComparisonList}"
+                                      SelectedValue="{Binding LevelComparison}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      HorizontalAlignment="Stretch"/>
+                            <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" Increment="1"
+                                           FormatString="0" HorizontalAlignment="Stretch"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="IV Total" Opacity="0.7" FontSize="12"/>
+                            <ComboBox ItemsSource="{Binding IvTypeList}"
+                                      SelectedValue="{Binding IvType}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      HorizontalAlignment="Stretch"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="EV Total" Opacity="0.7" FontSize="12"/>
+                            <ComboBox ItemsSource="{Binding EvTypeList}"
+                                      SelectedValue="{Binding EvType}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      HorizontalAlignment="Stretch"/>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <CheckBox Content="ESV (requires Egg = Yes)" IsChecked="{Binding EsvEnabled}"/>
+                            <NumericUpDown Value="{Binding Esv}" Minimum="0" Maximum="4095" Increment="1"
+                                           FormatString="0" IsEnabled="{Binding EsvEnabled}"
+                                           HorizontalAlignment="Stretch"/>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </DockPanel>

--- a/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
@@ -36,12 +36,24 @@ public partial class PKMDatabaseViewModel : ViewModelBase
     [ObservableProperty] private string _nickname = string.Empty;
     [ObservableProperty] private bool? _isShiny;
     [ObservableProperty] private bool? _isLegal;
+    [ObservableProperty] private bool? _isEgg;
+    [ObservableProperty] private int _hiddenPowerType;
+    [ObservableProperty] private int _level;
+    [ObservableProperty] private int _levelComparison;
+    [ObservableProperty] private int _ivType;
+    [ObservableProperty] private int _evType;
+    [ObservableProperty] private bool _esvEnabled;
+    [ObservableProperty] private int _esv;
 
     // Data Sources for View
     [ObservableProperty] private IReadOnlyList<ComboItem> _speciesList = [];
     [ObservableProperty] private IReadOnlyList<ComboItem> _natureList = [];
     [ObservableProperty] private IReadOnlyList<ComboItem> _abilityList = [];
     [ObservableProperty] private IReadOnlyList<ComboItem> _itemList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _hiddenPowerList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _levelComparisonList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _ivTypeList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _evTypeList = [];
 
     public PKMDatabaseViewModel(SaveFile sav, ISpriteRenderer spriteRenderer, IDialogService dialogService)
     {
@@ -55,6 +67,15 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         Ability = -1;
         Item = -1;
 
+        // Extended filter defaults ("Any"/disabled)
+        HiddenPowerType = -1;       // -1 = any HP type
+        LevelComparison = (int)SearchComparison.None; // None = don't filter by level
+        Level = 0;
+        IvType = 0;                 // 0 = any IV total bucket
+        EvType = 0;                 // 0 = any EV total bucket
+        EsvEnabled = false;
+        Esv = 0;
+
         InitDataSources();
         WeakReferenceMessenger.Default.Register<LanguageChangedMessage>(this, (r, m) => RefreshLanguage());
     }
@@ -65,6 +86,44 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         NatureList = new List<ComboItem> { new("Any", 25) }.Concat(GameInfo.Sources.NatureDataSource).ToList();
         AbilityList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.AbilityDataSource).ToList();
         ItemList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.GetItemDataSource(_sav.Version, _sav.Context, _sav.HeldItems)).ToList();
+
+        // Hidden Power type: value is the 0-based HP type index (matches PKM.HPType); -1 = any.
+        var hpTypes = new List<ComboItem> { new("Any", -1) };
+        var hpNames = GameInfo.Strings.HiddenPowerTypes;
+        for (int i = 0; i < hpNames.Length; i++)
+            hpTypes.Add(new ComboItem(hpNames[i], i));
+        HiddenPowerList = hpTypes;
+
+        // Level comparison operands (mirrors SearchUtil.SatisfiesFilterLevel).
+        LevelComparisonList = new List<ComboItem>
+        {
+            new("Any", (int)SearchComparison.None),
+            new("= (equal)", (int)SearchComparison.Equals),
+            new(">= (at least)", (int)SearchComparison.GreaterThanEquals),
+            new("<= (at most)", (int)SearchComparison.LessThanEquals),
+        };
+
+        // IV total buckets (mirrors SearchUtil.SatisfiesFilterIVs); 0 = any.
+        IvTypeList = new List<ComboItem>
+        {
+            new("Any", 0),
+            new("<= 90", 1),
+            new("91-120", 2),
+            new("121-150", 3),
+            new("151-179", 4),
+            new("180+", 5),
+            new("Flawless (186)", 6),
+        };
+
+        // EV total buckets (mirrors SearchUtil.SatisfiesFilterEVs); 0 = any.
+        EvTypeList = new List<ComboItem>
+        {
+            new("Any", 0),
+            new("None (0)", 1),
+            new("Some (1-127)", 2),
+            new("Half (128-507)", 3),
+            new("Full (508+)", 4),
+        };
     }
 
     [RelayCommand]
@@ -159,7 +218,7 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         }
     }
 
-    private SearchSettings GetSearchSettings() => new()
+    public SearchSettings GetSearchSettings() => new()
     {
         Species = (ushort)Species,
         Nature = (Nature)Nature,
@@ -168,6 +227,15 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         Nickname = Nickname,
         SearchShiny = IsShiny,
         SearchLegal = IsLegal,
+        SearchEgg = IsEgg,
+        HiddenPowerType = HiddenPowerType,
+        // Only filter by level when a comparison operand is selected; otherwise leave null.
+        Level = (SearchComparison)LevelComparison == SearchComparison.None ? null : (byte)Level,
+        SearchLevel = (SearchComparison)LevelComparison,
+        IVType = IvType,
+        EVType = EvType,
+        // ESV is only meaningful alongside Egg=Yes (see SearchSettings.FilterResultEgg).
+        ESV = EsvEnabled ? Esv : null,
         Context = _sav.Context
     };
 

--- a/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
@@ -229,4 +229,139 @@ public class DatabaseTests : IDisposable
         var name = strings.Species[1];
         Assert.Equal("Bulbizarre", name);
     }
+
+    private static PKMDatabaseViewModel CreateDatabaseVm()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SL);
+        var spriteMock = new Mock<ISpriteRenderer>();
+        var dialogMock = new Mock<IDialogService>();
+        return new PKMDatabaseViewModel(sav, spriteMock.Object, dialogMock.Object);
+    }
+
+    [Fact]
+    public void Verify_Database_Default_Filters_Map_To_Any()
+    {
+        var vm = CreateDatabaseVm();
+        var settings = vm.GetSearchSettings();
+
+        // Existing wildcard expectations.
+        Assert.Equal(0, settings.Species);
+        Assert.Equal(PKHeX.Core.Nature.Random, settings.Nature);
+        Assert.Equal(-1, settings.Ability);
+        Assert.Equal(-1, settings.Item);
+        Assert.Null(settings.SearchShiny);
+        Assert.Null(settings.SearchLegal);
+
+        // New filters default to "any"/disabled.
+        Assert.Null(settings.SearchEgg);
+        Assert.Equal(-1, settings.HiddenPowerType);
+        Assert.Null(settings.Level);
+        Assert.Equal(PKHeX.Core.Searching.SearchComparison.None, settings.SearchLevel);
+        Assert.Equal(0, settings.IVType);
+        Assert.Equal(0, settings.EVType);
+        Assert.Null(settings.ESV);
+    }
+
+    [Fact]
+    public void Verify_Database_HiddenPower_Filter_Maps()
+    {
+        var vm = CreateDatabaseVm();
+
+        // "Any" sentinel is present and selected by default.
+        Assert.Contains(vm.HiddenPowerList, x => x.Value == -1);
+        Assert.Equal(PKHeX.Core.HiddenPower.TypeCount, vm.HiddenPowerList.Count - 1);
+
+        vm.HiddenPowerType = 3; // arbitrary HP type index
+        Assert.Equal(3, vm.GetSearchSettings().HiddenPowerType);
+    }
+
+    [Fact]
+    public void Verify_Database_Egg_Tristate_Maps()
+    {
+        var vm = CreateDatabaseVm();
+
+        vm.IsEgg = true;
+        Assert.True(vm.GetSearchSettings().SearchEgg);
+
+        vm.IsEgg = false;
+        Assert.False(vm.GetSearchSettings().SearchEgg);
+
+        vm.IsEgg = null;
+        Assert.Null(vm.GetSearchSettings().SearchEgg);
+    }
+
+    [Fact]
+    public void Verify_Database_Level_Filter_Maps()
+    {
+        var vm = CreateDatabaseVm();
+
+        // With no comparison selected, Level is not applied even if a value is set.
+        vm.Level = 50;
+        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.None;
+        var none = vm.GetSearchSettings();
+        Assert.Null(none.Level);
+        Assert.Equal(PKHeX.Core.Searching.SearchComparison.None, none.SearchLevel);
+
+        // With a comparison selected, Level + SearchLevel flow through.
+        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
+        var ge = vm.GetSearchSettings();
+        Assert.Equal((byte)50, ge.Level);
+        Assert.Equal(PKHeX.Core.Searching.SearchComparison.GreaterThanEquals, ge.SearchLevel);
+    }
+
+    [Fact]
+    public void Verify_Database_IV_EV_Type_Filters_Map()
+    {
+        var vm = CreateDatabaseVm();
+
+        vm.IvType = 6; // Flawless (186)
+        vm.EvType = 1; // None (0)
+        var settings = vm.GetSearchSettings();
+        Assert.Equal(6, settings.IVType);
+        Assert.Equal(1, settings.EVType);
+    }
+
+    [Fact]
+    public void Verify_Database_ESV_Filter_Maps()
+    {
+        var vm = CreateDatabaseVm();
+
+        // Disabled => null regardless of value.
+        vm.Esv = 1234;
+        vm.EsvEnabled = false;
+        Assert.Null(vm.GetSearchSettings().ESV);
+
+        // Enabled => value flows through.
+        vm.EsvEnabled = true;
+        Assert.Equal(1234, vm.GetSearchSettings().ESV);
+    }
+
+    [Fact]
+    public void Verify_Database_New_Filters_Actually_Search()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SL);
+        var spriteMock = new Mock<ISpriteRenderer>();
+        var dialogMock = new Mock<IDialogService>();
+
+        var pkm = sav.BlankPKM;
+        pkm.Species = 25;
+        pkm.CurrentLevel = 50;
+        sav.SetBoxSlotAtIndex(pkm, 0, 0);
+
+        var vm = new PKMDatabaseViewModel(sav, spriteMock.Object, dialogMock.Object);
+        var allPkms = sav.BoxData.Concat(sav.PartyData);
+
+        // Level >= 50 should match the level-50 Pikachu.
+        vm.Level = 50;
+        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
+        var hit = vm.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
+        Assert.Single(hit);
+        Assert.Equal(25, hit[0].Species);
+
+        // Level <= 10 should exclude it.
+        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.LessThanEquals;
+        vm.Level = 10;
+        var miss = vm.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
+        Assert.Empty(miss);
+    }
 }


### PR DESCRIPTION
## Summary

Broadens the **PKM Database search filters** to surface more of what Core's `SearchSettings` already supports — the buildable part of the Entity-Search parity gap (upstream's `EntitySearchControl` filters on far more than the previous Species/Nature/Ability/Item/Nickname/Shiny/Legal set). No `PKHeX.Core` changes.

### New filters
| Filter | `SearchSettings` field |
|---|---|
| Hidden Power type | `HiddenPowerType` |
| Level + comparison (=, ≥, ≤) | `Level` + `SearchLevel` |
| Egg (Any/Yes/No) | `SearchEgg` |
| ESV (toggle + value) | `ESV` |
| IV total bucket | `IVType` |
| EV total bucket | `EVType` |

IV/EV bucket labels match Core's `SearchUtil.SatisfiesFilterIVs/EVs` ranges (not invented). All default to "Any".

## Changes
- `PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs` — new filter properties + `GetSearchSettings()` mapping (made `public` for testing).
- `PKHeX.Avalonia/Views/PKMDatabaseView.axaml` — filter controls.
- `Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs` — 7 tests (defaults map to "any"; each filter flows to the right `SearchSettings` value; a behavioral `Search()` for Level ≥ 50 / ≤ 10).
- `Directory.Build.props` — UIVersion 1.1.41 → 1.1.42.

## Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2349 passed, 1 skipped, 0 failed (+7 new)
- ✅ No `PKHeX.Core` edits

Part of the frontend-parity backfill from the Jan–Jun 2026 upstream sync window. The remaining Entity-Search parity (in-save seek/highlight navigation, and batch-instruction search which needs the not-yet-mirrored Core `EntityInstructionBuilder`) is tracked separately.
