### PR TITLE
chore(deps): update all dependencies to latest compatible versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.42</UIVersion>
+    <UIVersion>1.1.43</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/PKHeX.Application.csproj
+++ b/PKHeX.Application/PKHeX.Application.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <ProjectReference Include="..\PKHeX.Core\PKHeX.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/PKHeX.Avalonia/PKHeX.Avalonia.csproj
+++ b/PKHeX.Avalonia/PKHeX.Avalonia.csproj
@@ -26,30 +26,27 @@
 
   <ItemGroup>
     <!-- Avalonia UI -->
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.18" />
 
     <!-- MVVM -->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 
     <!-- DI -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 
     <!-- Rendering (for sprites) -->
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
-    
-    <!-- Explicitly upgrade transitive native assets to avoid version conflicts -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
 
-    <!-- Security: override vulnerable transitive dependency from Avalonia (NU1903 / GHSA-xrw6-gwf8-vvr9) -->
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <!-- Explicitly upgrade transitive native assets to avoid version conflicts -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
 
     <!-- Diagnostics (dev only) -->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.2.3" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PKHeX.Avalonia/Views/BatchEditor.axaml
+++ b/PKHeX.Avalonia/Views/BatchEditor.axaml
@@ -55,6 +55,7 @@
                 <StackPanel Spacing="8">
                     <TextBlock Text="Instruction Builder" FontWeight="SemiBold" />
                     <TextBlock FontSize="11" Opacity="0.6"
+                               TextWrapping="Wrap"
                                Text="Type a property name and click + Filter (condition) or + Modify (change). Each click adds one line. Run executes all lines together." />
                     <Grid ColumnDefinitions="*,Auto,*,Auto,Auto">
                         <AutoCompleteBox Grid.Column="0"

--- a/PKHeX.Infrastructure/PKHeX.Infrastructure.csproj
+++ b/PKHeX.Infrastructure/PKHeX.Infrastructure.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <ProjectReference Include="..\PKHeX.Application\PKHeX.Application.csproj" />
     <ProjectReference Include="..\PKHeX.Core\PKHeX.Core.csproj" />
   </ItemGroup>

--- a/PKHeX.Presentation/PKHeX.Presentation.csproj
+++ b/PKHeX.Presentation/PKHeX.Presentation.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <ProjectReference Include="..\PKHeX.Application\PKHeX.Application.csproj" />
     <ProjectReference Include="..\PKHeX.Core\PKHeX.Core.csproj" />
   </ItemGroup>

--- a/Tests/PKHeX.Architecture.Tests/PKHeX.Architecture.Tests.csproj
+++ b/Tests/PKHeX.Architecture.Tests/PKHeX.Architecture.Tests.csproj
@@ -6,10 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj
+++ b/Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.2.3" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Avalonia.Headless" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.18" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/PKHeX.Core.Tests/PKHeX.Core.Tests.csproj
+++ b/Tests/PKHeX.Core.Tests/PKHeX.Core.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updates every NuGet dependency to its newest version that keeps the solution building green on .NET 10. Bumps `UIVersion` 1.1.42 → 1.1.43.

## Updated packages

| Package | From | To |
|---|---|---|
| Avalonia, Desktop, Themes.Fluent, Fonts.Inter, Diagnostics, Headless(.XUnit) | 11.2.3 | **11.3.18** |
| Avalonia.Controls.DataGrid | 11.2.3 | **11.3.13** (latest 11.x; unifies with 11.3.18 core) |
| Microsoft.Extensions.DependencyInjection(.Abstractions) | 9.0.0 | **10.0.9** (align with .NET 10 runtime) |
| CommunityToolkit.Mvvm | 8.4.0 | **8.4.2** |
| SkiaSharp (+ Linux native assets) | 3.116.1 | **3.119.4** |
| FluentAssertions | 8.8.0 | **8.10.0** |
| Microsoft.NET.Test.Sdk | 17.14.1 / 18.0.1 | **18.7.0** (unified) |
| xunit.runner.visualstudio | 3.1.4 | **3.1.5** (unified) |
| coverlet.collector | 6.0.4 | **10.0.1** |

`xunit` (2.9.3), `Moq` (4.20.72), `NetArchTest.Rules` (1.3.2) are already latest. **PKHeX.Core is untouched** (kept 1:1 with upstream — it has no package references).

## Notable changes beyond version bumps

- **Removed the explicit `Tmds.DBus.Protocol` override.** It existed to patch a vulnerable transitive (GHSA-xrw6-gwf8-vvr9) that Avalonia 11.2.x pulled in (0.20.0). Avalonia 11.3.18 already references the patched 0.21.3 transitively, so the manual pin is now redundant. Verified with `dotnet list package --vulnerable`: **0 vulnerable packages** across all projects.
- **Fixed a latent layout bug in `BatchEditor.axaml`** — added `TextWrapping="Wrap"` to the Instruction Builder help text. Avalonia 11.3's more accurate `TextLayout` width measurement surfaced a pre-existing overflow (the hint exceeded its container and would clip in the real app), caught by `LayoutValidator` (`Verify_BatchEditor_Layout`). The fix matches the help-text pattern used across the other views (ChatterEditor, SettingsView, etc.).

## Intentionally deferred (major migrations, not routine bumps)

These need source changes **and guided UI testing**, so they belong in their own focused PRs:

- **Avalonia 12.0.5** — `Avalonia.Diagnostics` has **no 12.x release** (latest is 11.3.18), so a 12 bump would break the coherent package set / drop the dev inspector. Avalonia 11→12 also carries breaking API changes.
- **SkiaSharp 4.x** — major version tied to Avalonia's Skia backend and the project's sprite-rendering code (`SpriteLoader`, `AvaloniaSpriteRenderer`).

## Known follow-up

The Avalonia 11.3 bump introduces **8 `CS0618` deprecation warnings** (non-breaking) for drag/drop (`DataObject`, `DragDrop.DoDragDrop`, `DragEventArgs.Data`) and clipboard (`IClipboard.GetTextAsync`) APIs in `BoxViewer`, `PartyViewer`, `DialogService`, `ClipboardService`. Migrating to the new async/`DataTransfer` APIs touches interactive behavior and is left as a separate, UI-tested change.

## Verification

- ✅ `dotnet restore` — clean, no version conflicts
- ✅ `dotnet build -c Release` — 0 errors
- ✅ `dotnet build -c Debug` — 0 errors (exercises Avalonia.Diagnostics + Core's `TreatWarningsAsErrors`)
- ✅ `dotnet test` — **2349 passed, 1 skipped (pre-existing), 0 failed**
- ✅ `dotnet list package --vulnerable` — 0 vulnerable packages