### PR TITLE
refactor(avalonia): migrate deprecated 11.3 drag/drop + clipboard APIs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.43</UIVersion>
+    <UIVersion>1.1.44</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Services/ClipboardService.cs
+++ b/PKHeX.Avalonia/Services/ClipboardService.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input.Platform;
 
 namespace PKHeX.Avalonia.Services;
 
@@ -25,7 +26,7 @@ public class ClipboardService : IClipboardService
     {
         var cb = GetClipboard();
         if (cb is null) return null;
-        return await cb.GetTextAsync();
+        return await cb.TryGetTextAsync();
     }
 
     public async Task SetTextAsync(string text)

--- a/PKHeX.Avalonia/Services/DialogService.cs
+++ b/PKHeX.Avalonia/Services/DialogService.cs
@@ -1,6 +1,7 @@
 using global::Avalonia;
 using global::Avalonia.Controls;
 using global::Avalonia.Controls.ApplicationLifetimes;
+using global::Avalonia.Input.Platform;
 using global::Avalonia.Layout;
 using global::Avalonia.Media;
 using global::Avalonia.Platform.Storage;
@@ -132,7 +133,7 @@ public sealed class DialogService : IDialogService
     {
         var window = GetMainWindow();
         if (window?.Clipboard is { } clipboard)
-            return await clipboard.GetTextAsync();
+            return await clipboard.TryGetTextAsync();
         return null;
     }
 

--- a/PKHeX.Avalonia/Services/SlotDragTransfer.cs
+++ b/PKHeX.Avalonia/Services/SlotDragTransfer.cs
@@ -1,0 +1,52 @@
+using Avalonia.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Presentation.Models;
+
+namespace PKHeX.Avalonia.Services;
+
+/// <summary>
+/// Builds and reads the <see cref="DataTransfer"/> payload used for Pokémon slot
+/// drag-and-drop. Avalonia 11.3's data-transfer model only supports byte/string
+/// application formats (it no longer carries arbitrary CLR objects), so the
+/// <see cref="SlotLocation"/> is serialized to a compact string.
+/// </summary>
+internal static class SlotDragTransfer
+{
+    private static readonly DataFormat<string> Format =
+        DataFormat.CreateStringApplicationFormat("PKHeX.SlotDragData");
+
+    /// <summary>Creates the drag payload for the given slot data.</summary>
+    public static DataTransfer Create(SlotDragData data)
+    {
+        var transfer = new DataTransfer();
+        transfer.Add(DataTransferItem.Create(Format, Serialize(data.Source)));
+        return transfer;
+    }
+
+    /// <summary>Reads the slot data back from a drop, or null if it isn't present/valid.</summary>
+    public static SlotDragData? TryGet(IDataTransfer? transfer)
+    {
+        if (transfer?.TryGetValue(Format) is { } raw && TryDeserialize(raw, out var source))
+            return new SlotDragData(source);
+        return null;
+    }
+
+    private static string Serialize(SlotLocation loc)
+        => $"{(loc.IsParty ? 1 : 0)}:{loc.Box}:{loc.Slot}";
+
+    private static bool TryDeserialize(string raw, out SlotLocation source)
+    {
+        source = default;
+        var parts = raw.Split(':');
+        if (parts.Length != 3
+            || !int.TryParse(parts[0], out var isParty)
+            || !int.TryParse(parts[1], out var box)
+            || !int.TryParse(parts[2], out var slot))
+        {
+            return false;
+        }
+
+        source = new SlotLocation { Box = box, Slot = slot, IsParty = isParty != 0 };
+        return true;
+    }
+}

--- a/PKHeX.Avalonia/Views/BoxViewer.axaml.cs
+++ b/PKHeX.Avalonia/Views/BoxViewer.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using PKHeX.Avalonia.Services;
 using PKHeX.Presentation.Models;
 using PKHeX.Presentation.ViewModels;
 
@@ -66,10 +67,9 @@ public partial class BoxViewer : UserControl
         if (button.Tag is not SlotData slot || slot.IsEmpty)
             return;
 
-        var data = new DataObject();
-        data.Set("SlotDragData", new SlotDragData(slot.Location));
+        var data = SlotDragTransfer.Create(new SlotDragData(slot.Location));
 
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Move | DragDropEffects.Copy);
+        await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Move | DragDropEffects.Copy);
     }
 
     private void OnSlotDrop(object? sender, DragEventArgs e)
@@ -77,7 +77,7 @@ public partial class BoxViewer : UserControl
         if (sender is not Button button || button.Tag is not SlotData destSlot || DataContext is not BoxViewerViewModel vm)
             return;
 
-        var data = e.Data.Get("SlotDragData") as SlotDragData;
+        var data = SlotDragTransfer.TryGet(e.DataTransfer);
         if (data == null) return;
 
         bool clone = e.KeyModifiers.HasFlag(KeyModifiers.Control);

--- a/PKHeX.Avalonia/Views/PartyViewer.axaml.cs
+++ b/PKHeX.Avalonia/Views/PartyViewer.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using PKHeX.Avalonia.Services;
 using PKHeX.Presentation.Models;
 using PKHeX.Presentation.ViewModels;
 
@@ -66,10 +67,9 @@ public partial class PartyViewer : UserControl
         if (button.Tag is not PartySlotData slot || slot.IsEmpty)
             return;
 
-        var data = new DataObject();
-        data.Set("SlotDragData", new SlotDragData(slot.Location));
+        var data = SlotDragTransfer.Create(new SlotDragData(slot.Location));
 
-        await DragDrop.DoDragDrop(e, data, DragDropEffects.Move | DragDropEffects.Copy);
+        await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Move | DragDropEffects.Copy);
     }
 
     private void OnSlotDrop(object? sender, DragEventArgs e)
@@ -77,7 +77,7 @@ public partial class PartyViewer : UserControl
         if (sender is not Button button || button.Tag is not PartySlotData destSlot || DataContext is not PartyViewerViewModel vm)
             return;
 
-        var data = e.Data.Get("SlotDragData") as SlotDragData;
+        var data = SlotDragTransfer.TryGet(e.DataTransfer);
         if (data == null) return;
 
         bool clone = e.KeyModifiers.HasFlag(KeyModifiers.Control);


### PR DESCRIPTION
Migrates the APIs deprecated by the Avalonia 11.2.3 → 11.3.18 upgrade ([#105](https://github.com/realgarit/PKHeX-Avalonia/pull/105)) to their supported replacements, eliminating all **8 `CS0618` warnings**. The Release build is now warning-free.

## Changes

**Clipboard** — `IClipboard.GetTextAsync()` → `ClipboardExtensions.TryGetTextAsync()`:
- `PKHeX.Avalonia/Services/ClipboardService.cs`
- `PKHeX.Avalonia/Services/DialogService.cs`

**Drag/drop** (`BoxViewer`, `PartyViewer`):
- `new DataObject()` / `.Set(...)` → `DataTransfer` + `DataTransferItem.Create(...)`
- `DragDrop.DoDragDrop(...)` → `DragDrop.DoDragDropAsync(...)`
- `e.Data.Get(...)` → `e.DataTransfer` via `TryGetValue(...)`

Avalonia 11.3's data-transfer model no longer carries arbitrary CLR objects — custom application formats are **byte/string only** ([`DataFormat.CreateStringApplicationFormat`](https://reference.avaloniaui.net/)). So the `SlotLocation` payload (Box/Slot/IsParty) is serialized to a compact string. The format identifier + (de)serialization live in a new **`SlotDragTransfer`** helper shared by both viewers, which previously duplicated the drag code.

## Verification
- ✅ `dotnet build -c Release` — **0 warnings** (was 8), 0 errors
- ✅ `dotnet test` — 2349 passed, 1 skipped (pre-existing), 0 failed
- ⏳ **Guided manual UI testing pending** — drag-and-drop and clipboard read are interactive and not covered by the headless suite. Needs a human to drive the app (computer-use can't inject clicks into Avalonia on macOS). Verifying: drag a Pokémon between box slots, between party slots, box↔party, and a clipboard paste/import path.

`PKHeX.Core` untouched (1:1 with upstream). Closes the follow-up flagged in #105.