### PR TITLE
chore(version): catch UIVersion up to SemVer (1.1.44 → 1.20.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.1.44</UIVersion>
+    <UIVersion>1.20.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ dotnet publish PKHeX.Avalonia -c Release -r osx-arm64 --self-contained -p:Publis
 
 ## Versioning
 
-PKHeX Avalonia uses **semantic versioning** (`1.0.0`, `1.1.0`, etc.) for the UI application.
-PKHeX.Core follows the upstream date-based versioning scheme.
+PKHeX Avalonia uses **semantic versioning** (`MAJOR.MINOR.PATCH`) for the UI application via `<UIVersion>` in `Directory.Build.props`. PKHeX.Core keeps the upstream date-based `<Version>`, in sync with kwsch/PKHeX.
 
-To create a release, bump the `<UIVersion>` value in `Directory.Build.props` and push to `main`. The release workflow detects the new version, creates the git tag, builds all 4 platforms, and publishes a GitHub release — no manual tagging required.
+Bump `<UIVersion>` according to the change the PR makes:
+- **MAJOR** — incompatible/breaking changes (e.g. dropped save-format support, removed features)
+- **MINOR** — new backward-compatible functionality (new editors, tools, capabilities)
+- **PATCH** — backward-compatible fixes, refactors, chores, dependency bumps, and routine upstream `PKHeX.Core` syncs
+
+To create a release, bump `<UIVersion>` and push to `main`. The release workflow detects the new version, creates the git tag, builds all 4 platforms, and publishes a GitHub release — no manual tagging required.
 
 ## Screenshots
 *Work in progress — the UI is changing fast.*


### PR DESCRIPTION
Brings `UIVersion` in line with **semantic versioning** and documents the policy.

## Why
`UIVersion` had taken **exactly one MINOR bump in its life** (1.0 → 1.1), then ran 1.1.1 → 1.1.44 as patch bumps under the old "+1 patch per PR" rule. But of the ~47 merged PRs, **~17 were features** (new editors, tools, capabilities) — under SemVer each is a MINOR bump. So `1.1.x` was effectively a build counter: it understated the work and didn't match the README's own "uses semantic versioning" claim.

## What
- **`UIVersion` 1.1.44 → 1.20.0** — a one-time MINOR catch-up reflecting the ~17 feature releases shipped since 1.1.0. No breaking changes were ever made, so **MAJOR stays at 1**.
- **README** — replaces the vague "bump the value" note with an explicit policy:
  - **MAJOR** — breaking changes
  - **MINOR** — new backward-compatible features
  - **PATCH** — fixes, refactors, chores, dependency bumps, routine `PKHeX.Core` syncs

## Going forward
Bump by change type, not "+1 patch every time." `PKHeX.Core`'s date-based `<Version>` (26.05.05) is unchanged — it stays in sync with upstream.

## Notes
- `v1.20.0` tag is free; the release workflow will publish v1.20.0 on merge.
- Verified: `dotnet build -c Release` succeeds (0 warnings/errors) with the new version as `AssemblyVersion`.