### PR TITLE
feat(box-viewer): in-save seek bar (issue #104)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.20.1</UIVersion>
+    <UIVersion>1.20.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/BoxViewer.axaml
+++ b/PKHeX.Avalonia/Views/BoxViewer.axaml
@@ -18,13 +18,16 @@
         <KeyBinding Gesture="End" Command="{Binding SelectLastSlotCommand}" />
         <KeyBinding Gesture="PageUp" Command="{Binding PreviousBoxCommand}" />
         <KeyBinding Gesture="PageDown" Command="{Binding NextBoxCommand}" />
+        <KeyBinding Gesture="Ctrl+F" Command="{Binding ToggleSeekBarCommand}" />
+        <KeyBinding Gesture="F3" Command="{Binding SeekNextCommand}" />
+        <KeyBinding Gesture="Shift+F3" Command="{Binding SeekPreviousCommand}" />
     </UserControl.KeyBindings>
 
     <Border Padding="16" Classes="view-container">
         <DockPanel>
             <!-- Box Navigation Header -->
             <Border DockPanel.Dock="Top" Classes="card" Padding="0" Margin="0,0,0,12">
-                <Grid ColumnDefinitions="48,*,48" Height="44">
+                <Grid ColumnDefinitions="48,*,48,44" Height="44">
                     <Button Grid.Column="0"
                             Content="◀"
                             Command="{Binding PreviousBoxCommand}"
@@ -57,9 +60,108 @@
                             HorizontalContentAlignment="Center"
                             VerticalContentAlignment="Center"
                             FontSize="16" />
+
+                    <Button Grid.Column="3"
+                            Content="🔍"
+                            Command="{Binding ToggleSeekBarCommand}"
+                            ToolTip.Tip="Search this save and seek to matching slots (Ctrl+F)"
+                            AutomationProperties.Name="Toggle Seek Bar"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            FontSize="16" />
                 </Grid>
             </Border>
-            
+
+            <!-- In-save Seek Bar (collapsible) -->
+            <Border DockPanel.Dock="Top" Classes="card" Padding="12" Margin="0,0,0,12"
+                    IsVisible="{Binding IsSeekBarVisible}">
+                <StackPanel Spacing="8">
+                    <WrapPanel ItemSpacing="8" LineSpacing="8">
+                        <ComboBox ItemsSource="{Binding Filter.SpeciesList}"
+                                  SelectedValue="{Binding Filter.Species}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="160"
+                                  ToolTip.Tip="Species" />
+                        <ComboBox ItemsSource="{Binding Filter.NatureList}"
+                                  SelectedValue="{Binding Filter.Nature}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="120"
+                                  ToolTip.Tip="Nature" />
+                        <ComboBox ItemsSource="{Binding Filter.AbilityList}"
+                                  SelectedValue="{Binding Filter.Ability}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="120"
+                                  ToolTip.Tip="Ability" />
+                        <ComboBox ItemsSource="{Binding Filter.ItemList}"
+                                  SelectedValue="{Binding Filter.Item}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="140"
+                                  ToolTip.Tip="Held Item" />
+                        <TextBox Text="{Binding Filter.Nickname}" Watermark="Nickname" MinWidth="120" />
+                        <ComboBox ItemsSource="{Binding Filter.HiddenPowerList}"
+                                  SelectedValue="{Binding Filter.HiddenPowerType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="120"
+                                  ToolTip.Tip="Hidden Power" />
+                        <ComboBox ItemsSource="{Binding Filter.LevelComparisonList}"
+                                  SelectedValue="{Binding Filter.LevelComparison}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="110"
+                                  ToolTip.Tip="Level comparison" />
+                        <NumericUpDown Value="{Binding Filter.Level}" Minimum="1" Maximum="100" Increment="1"
+                                       FormatString="0" MinWidth="100" ToolTip.Tip="Level" />
+                        <ComboBox ItemsSource="{Binding Filter.IvTypeList}"
+                                  SelectedValue="{Binding Filter.IvType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="120"
+                                  ToolTip.Tip="IV total" />
+                        <ComboBox ItemsSource="{Binding Filter.EvTypeList}"
+                                  SelectedValue="{Binding Filter.EvType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  MinWidth="120"
+                                  ToolTip.Tip="EV total" />
+                    </WrapPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                        <TextBlock Text="Shiny" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
+                        <RadioButton GroupName="SeekShiny" Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}" />
+                        <RadioButton GroupName="SeekShiny" Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}" />
+                        <RadioButton GroupName="SeekShiny" Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}" />
+
+                        <TextBlock Text="Egg" VerticalAlignment="Center" Opacity="0.7" FontSize="12" Margin="12,0,0,0" />
+                        <RadioButton GroupName="SeekEgg" Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}" />
+                        <RadioButton GroupName="SeekEgg" Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}" />
+                        <RadioButton GroupName="SeekEgg" Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}" />
+
+                        <TextBlock Text="Legality" VerticalAlignment="Center" Opacity="0.7" FontSize="12" Margin="12,0,0,0" />
+                        <RadioButton GroupName="SeekLegal" Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}" />
+                        <RadioButton GroupName="SeekLegal" Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}" />
+                        <RadioButton GroupName="SeekLegal" Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <Button Content="◀ Prev" Command="{Binding SeekPreviousCommand}"
+                                ToolTip.Tip="Seek previous match (Shift+F3)" />
+                        <Button Content="Next ▶" Command="{Binding SeekNextCommand}"
+                                ToolTip.Tip="Seek next match (F3)" />
+                        <TextBlock Text="{Binding SeekStatus}" VerticalAlignment="Center"
+                                   Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" Margin="8,0,0,0" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
             <!-- Footer -->
             <TextBlock DockPanel.Dock="Bottom" 
                        Text="Arrow keys: Navigate | Enter: Select | PageUp/Down: Switch Box"

--- a/PKHeX.Avalonia/Views/BoxViewer.axaml
+++ b/PKHeX.Avalonia/Views/BoxViewer.axaml
@@ -134,22 +134,28 @@
                                   ToolTip.Tip="EV total" />
                     </WrapPanel>
 
-                    <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
-                        <TextBlock Text="Shiny" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
-                        <RadioButton GroupName="SeekShiny" Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}" />
-                        <RadioButton GroupName="SeekShiny" Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}" />
-                        <RadioButton GroupName="SeekShiny" Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}" />
+                    <WrapPanel ItemSpacing="16" LineSpacing="8">
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Shiny" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
+                            <RadioButton GroupName="SeekShiny" Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}" />
+                            <RadioButton GroupName="SeekShiny" Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}" />
+                            <RadioButton GroupName="SeekShiny" Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}" />
+                        </StackPanel>
 
-                        <TextBlock Text="Egg" VerticalAlignment="Center" Opacity="0.7" FontSize="12" Margin="12,0,0,0" />
-                        <RadioButton GroupName="SeekEgg" Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}" />
-                        <RadioButton GroupName="SeekEgg" Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}" />
-                        <RadioButton GroupName="SeekEgg" Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}" />
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Egg" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
+                            <RadioButton GroupName="SeekEgg" Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}" />
+                            <RadioButton GroupName="SeekEgg" Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}" />
+                            <RadioButton GroupName="SeekEgg" Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}" />
+                        </StackPanel>
 
-                        <TextBlock Text="Legality" VerticalAlignment="Center" Opacity="0.7" FontSize="12" Margin="12,0,0,0" />
-                        <RadioButton GroupName="SeekLegal" Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}" />
-                        <RadioButton GroupName="SeekLegal" Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}" />
-                        <RadioButton GroupName="SeekLegal" Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}" />
-                    </StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                            <TextBlock Text="Legality" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
+                            <RadioButton GroupName="SeekLegal" Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}" />
+                            <RadioButton GroupName="SeekLegal" Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}" />
+                            <RadioButton GroupName="SeekLegal" Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}" />
+                        </StackPanel>
+                    </WrapPanel>
 
                     <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <Button Content="◀ Prev" Command="{Binding SeekPreviousCommand}"

--- a/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
@@ -19,8 +19,8 @@
                     <StackPanel Spacing="12">
                         <StackPanel Spacing="4">
                             <TextBlock Text="Species" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding SpeciesList}" 
-                                      SelectedValue="{Binding Species}"
+                            <ComboBox ItemsSource="{Binding Filter.SpeciesList}" 
+                                      SelectedValue="{Binding Filter.Species}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
@@ -28,8 +28,8 @@
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Nature" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding NatureList}" 
-                                      SelectedValue="{Binding Nature}"
+                            <ComboBox ItemsSource="{Binding Filter.NatureList}" 
+                                      SelectedValue="{Binding Filter.Nature}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
@@ -37,40 +37,40 @@
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Nickname" Opacity="0.7" FontSize="12"/>
-                            <TextBox Text="{Binding Nickname}" Watermark="Nickname" HorizontalAlignment="Stretch"/>
+                            <TextBox Text="{Binding Filter.Nickname}" Watermark="Nickname" HorizontalAlignment="Stretch"/>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Shiny" Opacity="0.7" FontSize="12"/>
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <RadioButton Content="Any" IsChecked="{Binding IsShiny, Converter={StaticResource ObjectNullConverter}}"/>
-                                <RadioButton Content="Yes" IsChecked="{Binding IsShiny, Converter={StaticResource ObjectTrueConverter}}"/>
-                                <RadioButton Content="No" IsChecked="{Binding IsShiny, Converter={StaticResource ObjectFalseConverter}}"/>
+                                <RadioButton Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}"/>
+                                <RadioButton Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}"/>
+                                <RadioButton Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}"/>
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Legality" Opacity="0.7" FontSize="12"/>
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <RadioButton Content="Any" IsChecked="{Binding IsLegal, Converter={StaticResource ObjectNullConverter}}"/>
-                                <RadioButton Content="Legal" IsChecked="{Binding IsLegal, Converter={StaticResource ObjectTrueConverter}}"/>
-                                <RadioButton Content="Illegal" IsChecked="{Binding IsLegal, Converter={StaticResource ObjectFalseConverter}}"/>
+                                <RadioButton Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}"/>
+                                <RadioButton Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}"/>
+                                <RadioButton Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}"/>
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Egg" Opacity="0.7" FontSize="12"/>
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <RadioButton Content="Any" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectNullConverter}}"/>
-                                <RadioButton Content="Yes" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectTrueConverter}}"/>
-                                <RadioButton Content="No" IsChecked="{Binding IsEgg, Converter={StaticResource ObjectFalseConverter}}"/>
+                                <RadioButton Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}"/>
+                                <RadioButton Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}"/>
+                                <RadioButton Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}"/>
                             </StackPanel>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Hidden Power" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding HiddenPowerList}"
-                                      SelectedValue="{Binding HiddenPowerType}"
+                            <ComboBox ItemsSource="{Binding Filter.HiddenPowerList}"
+                                      SelectedValue="{Binding Filter.HiddenPowerType}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
@@ -78,19 +78,19 @@
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="Level" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding LevelComparisonList}"
-                                      SelectedValue="{Binding LevelComparison}"
+                            <ComboBox ItemsSource="{Binding Filter.LevelComparisonList}"
+                                      SelectedValue="{Binding Filter.LevelComparison}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
-                            <NumericUpDown Value="{Binding Level}" Minimum="1" Maximum="100" Increment="1"
+                            <NumericUpDown Value="{Binding Filter.Level}" Minimum="1" Maximum="100" Increment="1"
                                            FormatString="0" HorizontalAlignment="Stretch"/>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="IV Total" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding IvTypeList}"
-                                      SelectedValue="{Binding IvType}"
+                            <ComboBox ItemsSource="{Binding Filter.IvTypeList}"
+                                      SelectedValue="{Binding Filter.IvType}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
@@ -98,17 +98,17 @@
 
                         <StackPanel Spacing="4">
                             <TextBlock Text="EV Total" Opacity="0.7" FontSize="12"/>
-                            <ComboBox ItemsSource="{Binding EvTypeList}"
-                                      SelectedValue="{Binding EvType}"
+                            <ComboBox ItemsSource="{Binding Filter.EvTypeList}"
+                                      SelectedValue="{Binding Filter.EvType}"
                                       SelectedValueBinding="{Binding Value}"
                                       DisplayMemberBinding="{Binding Text}"
                                       HorizontalAlignment="Stretch"/>
                         </StackPanel>
 
                         <StackPanel Spacing="4">
-                            <CheckBox Content="ESV (requires Egg = Yes)" IsChecked="{Binding EsvEnabled}"/>
-                            <NumericUpDown Value="{Binding Esv}" Minimum="0" Maximum="4095" Increment="1"
-                                           FormatString="0" IsEnabled="{Binding EsvEnabled}"
+                            <CheckBox Content="ESV (requires Egg = Yes)" IsChecked="{Binding Filter.EsvEnabled}"/>
+                            <NumericUpDown Value="{Binding Filter.Esv}" Minimum="0" Maximum="4095" Increment="1"
+                                           FormatString="0" IsEnabled="{Binding Filter.EsvEnabled}"
                                            HorizontalAlignment="Stretch"/>
                         </StackPanel>
                     </StackPanel>

--- a/PKHeX.Presentation/ViewModels/BoxViewerViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/BoxViewerViewModel.cs
@@ -26,6 +26,17 @@ public partial class BoxViewerViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<SlotData> _slots = [];
 
+    /// <summary>Whether the in-save seek bar is expanded.</summary>
+    [ObservableProperty]
+    private bool _isSeekBarVisible;
+
+    /// <summary>Feedback text for the most recent seek (e.g. "Found in Box 2" / "No matches").</summary>
+    [ObservableProperty]
+    private string _seekStatus = string.Empty;
+
+    /// <summary>Shared filter inputs that build the in-save seek predicate (bound by the view).</summary>
+    public EntityFilterViewModel Filter { get; }
+
     public int BoxCount => _sav.BoxCount;
     public int SlotsPerBox => _sav.BoxSlotCount;
 
@@ -34,6 +45,7 @@ public partial class BoxViewerViewModel : ViewModelBase
         _sav = sav;
         _spriteRenderer = spriteRenderer;
         _slotService = slotService;
+        Filter = new EntityFilterViewModel(sav);
 
         LoadBox(0);
     }
@@ -114,6 +126,62 @@ public partial class BoxViewerViewModel : ViewModelBase
         if (newBox >= BoxCount)
             newBox = 0;
         LoadBox(newBox);
+    }
+
+    [RelayCommand]
+    private void ToggleSeekBar()
+    {
+        IsSeekBarVisible = !IsSeekBarVisible;
+        if (!IsSeekBarVisible)
+            SeekStatus = string.Empty;
+    }
+
+    [RelayCommand]
+    private void SeekNext() => Seek(reverse: false);
+
+    [RelayCommand]
+    private void SeekPrevious() => Seek(reverse: true);
+
+    /// <summary>
+    /// Jumps to and highlights the next/previous box slot matching the current filter,
+    /// wrapping across boxes (party slots are excluded — they live in a separate viewer).
+    /// Mirrors upstream's EntitySearchControl in-place seek behaviour.
+    /// </summary>
+    private void Seek(bool reverse)
+    {
+        var predicate = Filter.CreateSearchPredicate();
+        int boxCount = _sav.BoxCount;
+        int perBox = _sav.BoxSlotCount;
+        int totalBoxSlots = boxCount * perBox;
+        if (totalBoxSlots == 0)
+        {
+            SeekStatus = "No box slots.";
+            return;
+        }
+
+        int step = reverse ? -1 : 1;
+        int current = (CurrentBox * perBox) + SelectedIndex;
+
+        for (int i = 1; i <= totalBoxSlots; i++)
+        {
+            int index = ((current + (i * step)) % totalBoxSlots + totalBoxSlots) % totalBoxSlots;
+            int box = index / perBox;
+            int slot = index % perBox;
+
+            var pk = _sav.GetBoxSlotAtIndex(box, slot);
+            if (pk.Species == 0)
+                continue;
+            if (!predicate(pk))
+                continue;
+
+            if (box != CurrentBox)
+                LoadBox(box);
+            SelectedIndex = slot;
+            SeekStatus = $"Found in {BoxName} (slot {slot + 1}).";
+            return;
+        }
+
+        SeekStatus = "No matches.";
     }
 
     [RelayCommand]

--- a/PKHeX.Presentation/ViewModels/EntityFilterViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/EntityFilterViewModel.cs
@@ -1,0 +1,138 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+using PKHeX.Core;
+using PKHeX.Core.Searching;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Reusable entity filter model shared by the PKM Database view and the box-viewer
+/// seek bar. Holds the filter inputs, their combo data sources, and converts them into
+/// a <see cref="SearchSettings"/> / search predicate.
+/// </summary>
+public partial class EntityFilterViewModel : ViewModelBase
+{
+    private readonly SaveFile _sav;
+
+    // Filtering properties (mapped to SearchSettings)
+    [ObservableProperty] private int _species;
+    [ObservableProperty] private int _nature;
+    [ObservableProperty] private int _ability;
+    [ObservableProperty] private int _item;
+    [ObservableProperty] private string _nickname = string.Empty;
+    [ObservableProperty] private bool? _isShiny;
+    [ObservableProperty] private bool? _isLegal;
+    [ObservableProperty] private bool? _isEgg;
+    [ObservableProperty] private int _hiddenPowerType;
+    [ObservableProperty] private int _level;
+    [ObservableProperty] private int _levelComparison;
+    [ObservableProperty] private int _ivType;
+    [ObservableProperty] private int _evType;
+    [ObservableProperty] private bool _esvEnabled;
+    [ObservableProperty] private int _esv;
+
+    // Data Sources for View
+    [ObservableProperty] private IReadOnlyList<ComboItem> _speciesList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _natureList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _abilityList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _itemList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _hiddenPowerList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _levelComparisonList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _ivTypeList = [];
+    [ObservableProperty] private IReadOnlyList<ComboItem> _evTypeList = [];
+
+    public EntityFilterViewModel(SaveFile sav)
+    {
+        _sav = sav;
+
+        // Wildcard values: Species=0, Nature=25 (Random), Ability=-1, Item=-1
+        Species = 0;
+        Nature = 25;
+        Ability = -1;
+        Item = -1;
+
+        // Extended filter defaults ("Any"/disabled)
+        HiddenPowerType = -1;       // -1 = any HP type
+        LevelComparison = (int)SearchComparison.None; // None = don't filter by level
+        Level = 0;
+        IvType = 0;                 // 0 = any IV total bucket
+        EvType = 0;                 // 0 = any EV total bucket
+        EsvEnabled = false;
+        Esv = 0;
+
+        InitDataSources();
+        WeakReferenceMessenger.Default.Register<LanguageChangedMessage>(this, (r, m) => RefreshLanguage());
+    }
+
+    private void InitDataSources()
+    {
+        SpeciesList = new List<ComboItem> { new("Any", 0) }.Concat(GameInfo.Sources.SpeciesDataSource).ToList();
+        NatureList = new List<ComboItem> { new("Any", 25) }.Concat(GameInfo.Sources.NatureDataSource).ToList();
+        AbilityList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.AbilityDataSource).ToList();
+        ItemList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.GetItemDataSource(_sav.Version, _sav.Context, _sav.HeldItems)).ToList();
+
+        // Hidden Power type: value is the 0-based HP type index (matches PKM.HPType); -1 = any.
+        var hpTypes = new List<ComboItem> { new("Any", -1) };
+        var hpNames = GameInfo.Strings.HiddenPowerTypes;
+        for (int i = 0; i < hpNames.Length; i++)
+            hpTypes.Add(new ComboItem(hpNames[i], i));
+        HiddenPowerList = hpTypes;
+
+        // Level comparison operands (mirrors SearchUtil.SatisfiesFilterLevel).
+        LevelComparisonList = new List<ComboItem>
+        {
+            new("Any", (int)SearchComparison.None),
+            new("= (equal)", (int)SearchComparison.Equals),
+            new(">= (at least)", (int)SearchComparison.GreaterThanEquals),
+            new("<= (at most)", (int)SearchComparison.LessThanEquals),
+        };
+
+        // IV total buckets (mirrors SearchUtil.SatisfiesFilterIVs); 0 = any.
+        IvTypeList = new List<ComboItem>
+        {
+            new("Any", 0),
+            new("<= 90", 1),
+            new("91-120", 2),
+            new("121-150", 3),
+            new("151-179", 4),
+            new("180+", 5),
+            new("Flawless (186)", 6),
+        };
+
+        // EV total buckets (mirrors SearchUtil.SatisfiesFilterEVs); 0 = any.
+        EvTypeList = new List<ComboItem>
+        {
+            new("Any", 0),
+            new("None (0)", 1),
+            new("Some (1-127)", 2),
+            new("Half (128-507)", 3),
+            new("Full (508+)", 4),
+        };
+    }
+
+    public SearchSettings GetSearchSettings() => new()
+    {
+        Species = (ushort)Species,
+        Nature = (Nature)Nature,
+        Ability = Ability,
+        Item = Item,
+        Nickname = Nickname,
+        SearchShiny = IsShiny,
+        SearchLegal = IsLegal,
+        SearchEgg = IsEgg,
+        HiddenPowerType = HiddenPowerType,
+        // Only filter by level when a comparison operand is selected; otherwise leave null.
+        Level = (SearchComparison)LevelComparison == SearchComparison.None ? null : (byte)Level,
+        SearchLevel = (SearchComparison)LevelComparison,
+        IVType = IvType,
+        EVType = EvType,
+        // ESV is only meaningful alongside Egg=Yes (see SearchSettings.FilterResultEgg).
+        ESV = EsvEnabled ? Esv : null,
+        Context = _sav.Context
+    };
+
+    /// <summary>Builds a predicate from the current filter inputs for in-place seeking.</summary>
+    public Func<PKM, bool> CreateSearchPredicate() => GetSearchSettings().CreateSearchPredicate();
+
+    public void RefreshLanguage() => InitDataSources();
+}

--- a/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PKMDatabaseViewModel.cs
@@ -28,32 +28,8 @@ public partial class PKMDatabaseViewModel : ViewModelBase
     [ObservableProperty]
     private PKMDatabaseEntry? _selectedResult;
 
-    // Filtering properties (mapped to SearchSettings)
-    [ObservableProperty] private int _species;
-    [ObservableProperty] private int _nature;
-    [ObservableProperty] private int _ability;
-    [ObservableProperty] private int _item;
-    [ObservableProperty] private string _nickname = string.Empty;
-    [ObservableProperty] private bool? _isShiny;
-    [ObservableProperty] private bool? _isLegal;
-    [ObservableProperty] private bool? _isEgg;
-    [ObservableProperty] private int _hiddenPowerType;
-    [ObservableProperty] private int _level;
-    [ObservableProperty] private int _levelComparison;
-    [ObservableProperty] private int _ivType;
-    [ObservableProperty] private int _evType;
-    [ObservableProperty] private bool _esvEnabled;
-    [ObservableProperty] private int _esv;
-
-    // Data Sources for View
-    [ObservableProperty] private IReadOnlyList<ComboItem> _speciesList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _natureList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _abilityList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _itemList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _hiddenPowerList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _levelComparisonList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _ivTypeList = [];
-    [ObservableProperty] private IReadOnlyList<ComboItem> _evTypeList = [];
+    /// <summary>Shared entity filter inputs + combo data sources (bound by the view).</summary>
+    public EntityFilterViewModel Filter { get; }
 
     public PKMDatabaseViewModel(SaveFile sav, ISpriteRenderer spriteRenderer, IDialogService dialogService)
     {
@@ -61,69 +37,9 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         _spriteRenderer = spriteRenderer;
         _dialogService = dialogService;
 
-        // Wildcard values: Species=0, Nature=25 (Random), Ability=-1, Item=-1
-        Species = 0;
-        Nature = 25;
-        Ability = -1;
-        Item = -1;
+        Filter = new EntityFilterViewModel(sav);
 
-        // Extended filter defaults ("Any"/disabled)
-        HiddenPowerType = -1;       // -1 = any HP type
-        LevelComparison = (int)SearchComparison.None; // None = don't filter by level
-        Level = 0;
-        IvType = 0;                 // 0 = any IV total bucket
-        EvType = 0;                 // 0 = any EV total bucket
-        EsvEnabled = false;
-        Esv = 0;
-
-        InitDataSources();
         WeakReferenceMessenger.Default.Register<LanguageChangedMessage>(this, (r, m) => RefreshLanguage());
-    }
-
-    private void InitDataSources()
-    {
-        SpeciesList = new List<ComboItem> { new("Any", 0) }.Concat(GameInfo.Sources.SpeciesDataSource).ToList();
-        NatureList = new List<ComboItem> { new("Any", 25) }.Concat(GameInfo.Sources.NatureDataSource).ToList();
-        AbilityList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.AbilityDataSource).ToList();
-        ItemList = new List<ComboItem> { new("Any", -1) }.Concat(GameInfo.Sources.GetItemDataSource(_sav.Version, _sav.Context, _sav.HeldItems)).ToList();
-
-        // Hidden Power type: value is the 0-based HP type index (matches PKM.HPType); -1 = any.
-        var hpTypes = new List<ComboItem> { new("Any", -1) };
-        var hpNames = GameInfo.Strings.HiddenPowerTypes;
-        for (int i = 0; i < hpNames.Length; i++)
-            hpTypes.Add(new ComboItem(hpNames[i], i));
-        HiddenPowerList = hpTypes;
-
-        // Level comparison operands (mirrors SearchUtil.SatisfiesFilterLevel).
-        LevelComparisonList = new List<ComboItem>
-        {
-            new("Any", (int)SearchComparison.None),
-            new("= (equal)", (int)SearchComparison.Equals),
-            new(">= (at least)", (int)SearchComparison.GreaterThanEquals),
-            new("<= (at most)", (int)SearchComparison.LessThanEquals),
-        };
-
-        // IV total buckets (mirrors SearchUtil.SatisfiesFilterIVs); 0 = any.
-        IvTypeList = new List<ComboItem>
-        {
-            new("Any", 0),
-            new("<= 90", 1),
-            new("91-120", 2),
-            new("121-150", 3),
-            new("151-179", 4),
-            new("180+", 5),
-            new("Flawless (186)", 6),
-        };
-
-        // EV total buckets (mirrors SearchUtil.SatisfiesFilterEVs); 0 = any.
-        EvTypeList = new List<ComboItem>
-        {
-            new("Any", 0),
-            new("None (0)", 1),
-            new("Some (1-127)", 2),
-            new("Half (128-507)", 3),
-            new("Full (508+)", 4),
-        };
     }
 
     [RelayCommand]
@@ -135,7 +51,7 @@ public partial class PKMDatabaseViewModel : ViewModelBase
 
         try
         {
-            var settings = GetSearchSettings();
+            var settings = Filter.GetSearchSettings();
             var allPkms = _sav.BoxData.Concat(_sav.PartyData).ToList();
 
             int totalMons = allPkms.Count(p => p.Species != 0);
@@ -175,7 +91,7 @@ public partial class PKMDatabaseViewModel : ViewModelBase
 
         try 
         {
-            var settings = GetSearchSettings();
+            var settings = Filter.GetSearchSettings();
             var files = Directory.GetFiles(path, "*", SearchOption.AllDirectories);
             
             var matches = await Task.Run(() => 
@@ -218,32 +134,11 @@ public partial class PKMDatabaseViewModel : ViewModelBase
         }
     }
 
-    public SearchSettings GetSearchSettings() => new()
-    {
-        Species = (ushort)Species,
-        Nature = (Nature)Nature,
-        Ability = Ability,
-        Item = Item,
-        Nickname = Nickname,
-        SearchShiny = IsShiny,
-        SearchLegal = IsLegal,
-        SearchEgg = IsEgg,
-        HiddenPowerType = HiddenPowerType,
-        // Only filter by level when a comparison operand is selected; otherwise leave null.
-        Level = (SearchComparison)LevelComparison == SearchComparison.None ? null : (byte)Level,
-        SearchLevel = (SearchComparison)LevelComparison,
-        IVType = IvType,
-        EVType = EvType,
-        // ESV is only meaningful alongside Egg=Yes (see SearchSettings.FilterResultEgg).
-        ESV = EsvEnabled ? Esv : null,
-        Context = _sav.Context
-    };
-
     public event Action<PKM>? PokemonSelected;
 
     public void RefreshLanguage()
     {
-        InitDataSources();
+        Filter.RefreshLanguage();
         foreach (var entry in Results)
             entry.Refresh();
     }

--- a/Tests/PKHeX.Avalonia.Tests/BoxViewerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/BoxViewerTests.cs
@@ -142,6 +142,73 @@ public class BoxViewerTests(ITestOutputHelper output)
     }
 
     // -----------------------------------------------------------------------
+    // In-save seek (EntityFilter-driven)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void BoxViewer_SeekNext_JumpsToMatchInLaterBox()
+    {
+        var sav = new SAV6XY();
+        // Pikachu sits in box 2, slot 5; nothing else matches.
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 2, 5);
+
+        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
+        vm.Filter.Species = 25;
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal(2, vm.CurrentBox);
+        Assert.Equal(5, vm.SelectedIndex);
+        output.WriteLine($"SeekNext: jumped to box {vm.CurrentBox}, slot {vm.SelectedIndex} ✓");
+    }
+
+    [Fact]
+    public void BoxViewer_SeekNext_NoMatch_ReportsStatus()
+    {
+        var sav = new SAV6XY();
+        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
+        vm.Filter.Species = 25; // no Pikachu anywhere
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal("No matches.", vm.SeekStatus);
+        output.WriteLine("SeekNext with no match: reports 'No matches.' ✓");
+    }
+
+    [Fact]
+    public void BoxViewer_SeekNext_WrapsAroundToEarlierBox()
+    {
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 0, 0); // only match is behind the cursor
+
+        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
+        vm.Filter.Species = 25;
+        // Move cursor past the only match.
+        vm.NextBoxCommand.Execute(null); // box 1
+        vm.SelectedIndex = 3;
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal(0, vm.CurrentBox);
+        Assert.Equal(0, vm.SelectedIndex);
+        output.WriteLine("SeekNext wraps around to box 0 ✓");
+    }
+
+    [Fact]
+    public void BoxViewer_ToggleSeekBar_FlipsVisibility()
+    {
+        var sav = new SAV6XY();
+        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
+
+        Assert.False(vm.IsSeekBarVisible);
+        vm.ToggleSeekBarCommand.Execute(null);
+        Assert.True(vm.IsSeekBarVisible);
+        vm.ToggleSeekBarCommand.Execute(null);
+        Assert.False(vm.IsSeekBarVisible);
+        output.WriteLine("ToggleSeekBar flips visibility ✓");
+    }
+
+    // -----------------------------------------------------------------------
     // BoxListEditorViewModel
     // -----------------------------------------------------------------------
 

--- a/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/DatabaseTests.cs
@@ -162,7 +162,7 @@ public class DatabaseTests : IDisposable
         var dialogMock = new Mock<IDialogService>();
 
         var vm = new PKMDatabaseViewModel(sav, spriteMock.Object, dialogMock.Object);
-        string initialText = vm.SpeciesList.First(x => x.Value == 1).Text;
+        string initialText = vm.Filter.SpeciesList.First(x => x.Value == 1).Text;
         Assert.Equal("Bulbasaur", initialText);
 
         GameInfo.CurrentLanguage = "de";
@@ -171,7 +171,7 @@ public class DatabaseTests : IDisposable
 
         WeakReferenceMessenger.Default.Send(new LanguageChangedMessage("de"));
 
-        string newText = vm.SpeciesList.First(x => x.Value == 1).Text;
+        string newText = vm.Filter.SpeciesList.First(x => x.Value == 1).Text;
         Assert.Equal("Bisasam", newText);
     }
 
@@ -242,7 +242,7 @@ public class DatabaseTests : IDisposable
     public void Verify_Database_Default_Filters_Map_To_Any()
     {
         var vm = CreateDatabaseVm();
-        var settings = vm.GetSearchSettings();
+        var settings = vm.Filter.GetSearchSettings();
 
         // Existing wildcard expectations.
         Assert.Equal(0, settings.Species);
@@ -268,11 +268,11 @@ public class DatabaseTests : IDisposable
         var vm = CreateDatabaseVm();
 
         // "Any" sentinel is present and selected by default.
-        Assert.Contains(vm.HiddenPowerList, x => x.Value == -1);
-        Assert.Equal(PKHeX.Core.HiddenPower.TypeCount, vm.HiddenPowerList.Count - 1);
+        Assert.Contains(vm.Filter.HiddenPowerList, x => x.Value == -1);
+        Assert.Equal(PKHeX.Core.HiddenPower.TypeCount, vm.Filter.HiddenPowerList.Count - 1);
 
-        vm.HiddenPowerType = 3; // arbitrary HP type index
-        Assert.Equal(3, vm.GetSearchSettings().HiddenPowerType);
+        vm.Filter.HiddenPowerType = 3; // arbitrary HP type index
+        Assert.Equal(3, vm.Filter.GetSearchSettings().HiddenPowerType);
     }
 
     [Fact]
@@ -280,14 +280,14 @@ public class DatabaseTests : IDisposable
     {
         var vm = CreateDatabaseVm();
 
-        vm.IsEgg = true;
-        Assert.True(vm.GetSearchSettings().SearchEgg);
+        vm.Filter.IsEgg = true;
+        Assert.True(vm.Filter.GetSearchSettings().SearchEgg);
 
-        vm.IsEgg = false;
-        Assert.False(vm.GetSearchSettings().SearchEgg);
+        vm.Filter.IsEgg = false;
+        Assert.False(vm.Filter.GetSearchSettings().SearchEgg);
 
-        vm.IsEgg = null;
-        Assert.Null(vm.GetSearchSettings().SearchEgg);
+        vm.Filter.IsEgg = null;
+        Assert.Null(vm.Filter.GetSearchSettings().SearchEgg);
     }
 
     [Fact]
@@ -296,15 +296,15 @@ public class DatabaseTests : IDisposable
         var vm = CreateDatabaseVm();
 
         // With no comparison selected, Level is not applied even if a value is set.
-        vm.Level = 50;
-        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.None;
-        var none = vm.GetSearchSettings();
+        vm.Filter.Level = 50;
+        vm.Filter.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.None;
+        var none = vm.Filter.GetSearchSettings();
         Assert.Null(none.Level);
         Assert.Equal(PKHeX.Core.Searching.SearchComparison.None, none.SearchLevel);
 
         // With a comparison selected, Level + SearchLevel flow through.
-        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
-        var ge = vm.GetSearchSettings();
+        vm.Filter.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
+        var ge = vm.Filter.GetSearchSettings();
         Assert.Equal((byte)50, ge.Level);
         Assert.Equal(PKHeX.Core.Searching.SearchComparison.GreaterThanEquals, ge.SearchLevel);
     }
@@ -314,9 +314,9 @@ public class DatabaseTests : IDisposable
     {
         var vm = CreateDatabaseVm();
 
-        vm.IvType = 6; // Flawless (186)
-        vm.EvType = 1; // None (0)
-        var settings = vm.GetSearchSettings();
+        vm.Filter.IvType = 6; // Flawless (186)
+        vm.Filter.EvType = 1; // None (0)
+        var settings = vm.Filter.GetSearchSettings();
         Assert.Equal(6, settings.IVType);
         Assert.Equal(1, settings.EVType);
     }
@@ -327,13 +327,13 @@ public class DatabaseTests : IDisposable
         var vm = CreateDatabaseVm();
 
         // Disabled => null regardless of value.
-        vm.Esv = 1234;
-        vm.EsvEnabled = false;
-        Assert.Null(vm.GetSearchSettings().ESV);
+        vm.Filter.Esv = 1234;
+        vm.Filter.EsvEnabled = false;
+        Assert.Null(vm.Filter.GetSearchSettings().ESV);
 
         // Enabled => value flows through.
-        vm.EsvEnabled = true;
-        Assert.Equal(1234, vm.GetSearchSettings().ESV);
+        vm.Filter.EsvEnabled = true;
+        Assert.Equal(1234, vm.Filter.GetSearchSettings().ESV);
     }
 
     [Fact]
@@ -352,16 +352,16 @@ public class DatabaseTests : IDisposable
         var allPkms = sav.BoxData.Concat(sav.PartyData);
 
         // Level >= 50 should match the level-50 Pikachu.
-        vm.Level = 50;
-        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
-        var hit = vm.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
+        vm.Filter.Level = 50;
+        vm.Filter.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.GreaterThanEquals;
+        var hit = vm.Filter.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
         Assert.Single(hit);
         Assert.Equal(25, hit[0].Species);
 
         // Level <= 10 should exclude it.
-        vm.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.LessThanEquals;
-        vm.Level = 10;
-        var miss = vm.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
+        vm.Filter.LevelComparison = (int)PKHeX.Core.Searching.SearchComparison.LessThanEquals;
+        vm.Filter.Level = 10;
+        var miss = vm.Filter.GetSearchSettings().Search(allPkms).Where(p => p.Species != 0).ToList();
         Assert.Empty(miss);
     }
 }


### PR DESCRIPTION
## Summary

Implements the in-save **seek & highlight** tool for the box viewer — acceptance item #1 of #104. This is the cross-platform equivalent of upstream's `EntitySearchControl`: a collapsible filter bar on the box view that jumps to and highlights the next/previous matching slot **in place**, wrapping across boxes — rather than the separate filtered list the PKM Database view uses.

Closes the "in-save seek/highlight navigation" half of #104. Batch-instruction search (`EntityInstructionBuilder`) remains **Core-blocked** and out of scope until a future upstream sync mirrors that type.

## What changed
- **New `EntityFilterViewModel`** (Presentation): extracts the filter inputs + combo data sources + `GetSearchSettings()` that were inline in `PKMDatabaseViewModel`, plus a `CreateSearchPredicate()` helper. `PKMDatabaseViewModel` now delegates to it, so the database view and the new seek bar share one filter definition.
- **`BoxViewerViewModel`**: adds `Filter`, `SeekNext`/`SeekPrevious` (predicate-driven via `SearchUtil`-style box-slot scan, wrap-around), a `ToggleSeekBar`, and a `SeekStatus` feedback string. Seek is constrained to box slots (party has its own viewer).
- **`BoxViewer.axaml`**: collapsible seek bar (🔍 button + Ctrl+F), full filter controls, ◀ Prev / Next ▶ (F3 / Shift+F3), status text. Default-collapsed.
- Bumped `UIVersion` 1.20.1 → 1.20.2.

## Testing
- `dotnet build` clean (0 warnings).
- `dotnet test` — **1899 passed**, including 4 new `BoxViewerViewModel` seek tests (jump-to-match across boxes, no-match status, wrap-around, toggle).
- Manual run (osx-arm64): opened a W2 save, set Shiny = Yes, Next ▶ jumped Box 1 → Box 23 slot 29, highlighted the slot, and showed "Found in BOX 23 (slot 29)." Verified the tri-state filter groups wrap (Legality no longer clipped).

Refs #104.