### PR TITLE
feat(ui): modeless tool windows + detached box seek + batch search

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.20.2</UIVersion>
+    <UIVersion>1.21.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IWindowService.cs
+++ b/PKHeX.Application/Abstractions/IWindowService.cs
@@ -7,4 +7,15 @@ namespace PKHeX.Application.Abstractions;
 public interface IWindowService
 {
     Task ShowDialogAsync(object viewModel, string title);
+
+    /// <summary>
+    /// Shows a ViewModel as a modeless (non-modal) tool window the user can drag around and
+    /// operate while interacting with the main window. Re-invoking with the same ViewModel
+    /// instance focuses the existing window instead of opening a duplicate. The window remembers
+    /// its size/position for the session (keyed by ViewModel type).
+    /// </summary>
+    void ShowTool(object viewModel, string title);
+
+    /// <summary>Closes all open modeless tool windows (e.g. when the active save changes).</summary>
+    void CloseAllTools();
 }

--- a/PKHeX.Avalonia/Services/WindowService.cs
+++ b/PKHeX.Avalonia/Services/WindowService.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using PKHeX.Application.Abstractions;
@@ -8,12 +9,21 @@ namespace PKHeX.Avalonia.Services;
 /// Shows a ViewModel as a modal dialog. The matching View is resolved via <see cref="ViewLocator"/>,
 /// wrapped in a host <c>Window</c>, and shown over the main window — preserving the previous
 /// modal/centered behavior while keeping View resolution out of the Presentation layer.
+/// Also hosts modeless tool windows (see <see cref="ShowTool"/>).
 /// </summary>
 public sealed class WindowService : IWindowService
 {
+    // Open modeless tool windows, keyed by their ViewModel instance, so re-invoking focuses
+    // the existing window instead of opening a duplicate.
+    private readonly Dictionary<object, Window> _tools = new();
+
+    // Remembered size/position per tool ViewModel type, so a reopened tool (even after the VM
+    // is rebuilt on save change) returns to where the user last left it for this session.
+    private static readonly Dictionary<string, (PixelPoint Position, double Width, double Height)> ToolBounds = new();
+
     public async Task ShowDialogAsync(object viewModel, string title)
     {
-        var owner = (global::Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
+        var owner = MainWindow;
         if (owner is null) return;
 
         var dialog = new Window
@@ -32,4 +42,65 @@ public sealed class WindowService : IWindowService
 
         await dialog.ShowDialog(owner);
     }
+
+    public void ShowTool(object viewModel, string title)
+    {
+        // Already open for this ViewModel? Bring it forward instead of duplicating.
+        if (_tools.TryGetValue(viewModel, out var existing))
+        {
+            existing.Activate();
+            return;
+        }
+
+        var owner = MainWindow;
+        if (owner is null) return;
+
+        var key = viewModel.GetType().FullName ?? viewModel.GetType().Name;
+        var window = new Window
+        {
+            Title = title,
+            Content = ViewLocator.Build(viewModel),
+            CanResize = true,
+            MaxWidth = 1400,
+            MaxHeight = 820,
+        };
+
+        if (ToolBounds.TryGetValue(key, out var bounds))
+        {
+            window.WindowStartupLocation = WindowStartupLocation.Manual;
+            window.Position = bounds.Position;
+            window.Width = bounds.Width;
+            window.Height = bounds.Height;
+        }
+        else
+        {
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            window.SizeToContent = SizeToContent.WidthAndHeight;
+        }
+
+        if (viewModel is ICloseableDialog closeable)
+            closeable.CloseRequested = window.Close;
+
+        window.Closed += (_, _) =>
+        {
+            // Remember where the user left it (skip if minimized/zeroed).
+            if (window.Width > 0 && window.Height > 0)
+                ToolBounds[key] = (window.Position, window.Width, window.Height);
+            _tools.Remove(viewModel);
+        };
+
+        _tools[viewModel] = window;
+        window.Show(owner);
+    }
+
+    public void CloseAllTools()
+    {
+        // Copy first: Close fires Closed handlers that mutate _tools.
+        foreach (var window in _tools.Values.ToList())
+            window.Close();
+        _tools.Clear();
+    }
+
+    private static Window? MainWindow =>
+        (global::Avalonia.Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.MainWindow;
 }

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -64,6 +64,7 @@ public static class ViewLocator
         [typeof(MysteryGiftDatabaseViewModel)] = () => new MysteryGiftDatabaseView(),
         [typeof(OPowerEditorViewModel)] = () => new OPowerEditor(),
         [typeof(PKMDatabaseViewModel)] = () => new PKMDatabaseView(),
+        [typeof(EntitySeekViewModel)] = () => new EntitySeekView(),
         [typeof(Poffin8bEditorViewModel)] = () => new Poffin8bEditor(),
         [typeof(PoffinCaseEditorViewModel)] = () => new PoffinCaseEditorView(),
         [typeof(PokeBlock3CaseEditorViewModel)] = () => new PokeBlock3CaseEditorView(),

--- a/PKHeX.Avalonia/Views/BoxViewer.axaml
+++ b/PKHeX.Avalonia/Views/BoxViewer.axaml
@@ -18,9 +18,9 @@
         <KeyBinding Gesture="End" Command="{Binding SelectLastSlotCommand}" />
         <KeyBinding Gesture="PageUp" Command="{Binding PreviousBoxCommand}" />
         <KeyBinding Gesture="PageDown" Command="{Binding NextBoxCommand}" />
-        <KeyBinding Gesture="Ctrl+F" Command="{Binding ToggleSeekBarCommand}" />
-        <KeyBinding Gesture="F3" Command="{Binding SeekNextCommand}" />
-        <KeyBinding Gesture="Shift+F3" Command="{Binding SeekPreviousCommand}" />
+        <KeyBinding Gesture="Ctrl+F" Command="{Binding OpenSeekToolCommand}" />
+        <KeyBinding Gesture="F3" Command="{Binding Seek.SeekNextCommand}" />
+        <KeyBinding Gesture="Shift+F3" Command="{Binding Seek.SeekPreviousCommand}" />
     </UserControl.KeyBindings>
 
     <Border Padding="16" Classes="view-container">
@@ -63,9 +63,9 @@
 
                     <Button Grid.Column="3"
                             Content="🔍"
-                            Command="{Binding ToggleSeekBarCommand}"
+                            Command="{Binding OpenSeekToolCommand}"
                             ToolTip.Tip="Search this save and seek to matching slots (Ctrl+F)"
-                            AutomationProperties.Name="Toggle Seek Bar"
+                            AutomationProperties.Name="Open Seek Tool"
                             Background="Transparent"
                             BorderThickness="0"
                             HorizontalAlignment="Stretch"
@@ -74,98 +74,6 @@
                             VerticalContentAlignment="Center"
                             FontSize="16" />
                 </Grid>
-            </Border>
-
-            <!-- In-save Seek Bar (collapsible) -->
-            <Border DockPanel.Dock="Top" Classes="card" Padding="12" Margin="0,0,0,12"
-                    IsVisible="{Binding IsSeekBarVisible}">
-                <StackPanel Spacing="8">
-                    <WrapPanel ItemSpacing="8" LineSpacing="8">
-                        <ComboBox ItemsSource="{Binding Filter.SpeciesList}"
-                                  SelectedValue="{Binding Filter.Species}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="160"
-                                  ToolTip.Tip="Species" />
-                        <ComboBox ItemsSource="{Binding Filter.NatureList}"
-                                  SelectedValue="{Binding Filter.Nature}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="120"
-                                  ToolTip.Tip="Nature" />
-                        <ComboBox ItemsSource="{Binding Filter.AbilityList}"
-                                  SelectedValue="{Binding Filter.Ability}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="120"
-                                  ToolTip.Tip="Ability" />
-                        <ComboBox ItemsSource="{Binding Filter.ItemList}"
-                                  SelectedValue="{Binding Filter.Item}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="140"
-                                  ToolTip.Tip="Held Item" />
-                        <TextBox Text="{Binding Filter.Nickname}" Watermark="Nickname" MinWidth="120" />
-                        <ComboBox ItemsSource="{Binding Filter.HiddenPowerList}"
-                                  SelectedValue="{Binding Filter.HiddenPowerType}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="120"
-                                  ToolTip.Tip="Hidden Power" />
-                        <ComboBox ItemsSource="{Binding Filter.LevelComparisonList}"
-                                  SelectedValue="{Binding Filter.LevelComparison}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="110"
-                                  ToolTip.Tip="Level comparison" />
-                        <NumericUpDown Value="{Binding Filter.Level}" Minimum="1" Maximum="100" Increment="1"
-                                       FormatString="0" MinWidth="100" ToolTip.Tip="Level" />
-                        <ComboBox ItemsSource="{Binding Filter.IvTypeList}"
-                                  SelectedValue="{Binding Filter.IvType}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="120"
-                                  ToolTip.Tip="IV total" />
-                        <ComboBox ItemsSource="{Binding Filter.EvTypeList}"
-                                  SelectedValue="{Binding Filter.EvType}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  MinWidth="120"
-                                  ToolTip.Tip="EV total" />
-                    </WrapPanel>
-
-                    <WrapPanel ItemSpacing="16" LineSpacing="8">
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                            <TextBlock Text="Shiny" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
-                            <RadioButton GroupName="SeekShiny" Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}" />
-                            <RadioButton GroupName="SeekShiny" Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}" />
-                            <RadioButton GroupName="SeekShiny" Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}" />
-                        </StackPanel>
-
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                            <TextBlock Text="Egg" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
-                            <RadioButton GroupName="SeekEgg" Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}" />
-                            <RadioButton GroupName="SeekEgg" Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}" />
-                            <RadioButton GroupName="SeekEgg" Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}" />
-                        </StackPanel>
-
-                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                            <TextBlock Text="Legality" VerticalAlignment="Center" Opacity="0.7" FontSize="12" />
-                            <RadioButton GroupName="SeekLegal" Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}" />
-                            <RadioButton GroupName="SeekLegal" Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}" />
-                            <RadioButton GroupName="SeekLegal" Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}" />
-                        </StackPanel>
-                    </WrapPanel>
-
-                    <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                        <Button Content="◀ Prev" Command="{Binding SeekPreviousCommand}"
-                                ToolTip.Tip="Seek previous match (Shift+F3)" />
-                        <Button Content="Next ▶" Command="{Binding SeekNextCommand}"
-                                ToolTip.Tip="Seek next match (F3)" />
-                        <TextBlock Text="{Binding SeekStatus}" VerticalAlignment="Center"
-                                   Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" Margin="8,0,0,0" />
-                    </StackPanel>
-                </StackPanel>
             </Border>
 
             <!-- Footer -->

--- a/PKHeX.Avalonia/Views/EntitySeekView.axaml
+++ b/PKHeX.Avalonia/Views/EntitySeekView.axaml
@@ -1,0 +1,164 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             x:Class="PKHeX.Avalonia.Views.EntitySeekView"
+             x:DataType="vm:EntitySeekViewModel"
+             MinWidth="360" Width="420">
+
+    <UserControl.KeyBindings>
+        <KeyBinding Gesture="F3" Command="{Binding SeekNextCommand}" />
+        <KeyBinding Gesture="Shift+F3" Command="{Binding SeekPreviousCommand}" />
+        <KeyBinding Gesture="Enter" Command="{Binding SeekNextCommand}" />
+    </UserControl.KeyBindings>
+
+    <Border Padding="16" Classes="view-container">
+        <DockPanel>
+            <!-- Seek actions (pinned to bottom so they're always reachable) -->
+            <Border DockPanel.Dock="Bottom" Classes="card" Padding="12" Margin="0,12,0,0">
+                <StackPanel Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                        <Button Content="◀ Prev" Command="{Binding SeekPreviousCommand}"
+                                ToolTip.Tip="Seek previous match (Shift+F3)" />
+                        <Button Content="Next ▶" Classes="accent" Command="{Binding SeekNextCommand}"
+                                ToolTip.Tip="Seek next match (F3 / Enter)" />
+                    </StackPanel>
+                    <TextBlock Text="{Binding SeekStatus}" HorizontalAlignment="Center"
+                               Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <!-- Filters -->
+            <ScrollViewer>
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Search &amp; Seek" Classes="header-accent" FontSize="16" FontWeight="SemiBold" />
+                    <TextBlock Text="Jumps the box view to the next/previous matching Pokémon, across all boxes."
+                               Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" TextWrapping="Wrap" />
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Species" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.SpeciesList}"
+                                  SelectedValue="{Binding Filter.Species}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Nature" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.NatureList}"
+                                  SelectedValue="{Binding Filter.Nature}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Ability" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.AbilityList}"
+                                  SelectedValue="{Binding Filter.Ability}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Held Item" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.ItemList}"
+                                  SelectedValue="{Binding Filter.Item}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Nickname" Opacity="0.7" FontSize="12"/>
+                        <TextBox Text="{Binding Filter.Nickname}" Watermark="Nickname" HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Shiny" Opacity="0.7" FontSize="12"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <RadioButton GroupName="SeekShiny" Content="Any" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectNullConverter}}"/>
+                            <RadioButton GroupName="SeekShiny" Content="Yes" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectTrueConverter}}"/>
+                            <RadioButton GroupName="SeekShiny" Content="No" IsChecked="{Binding Filter.IsShiny, Converter={StaticResource ObjectFalseConverter}}"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Egg" Opacity="0.7" FontSize="12"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <RadioButton GroupName="SeekEgg" Content="Any" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectNullConverter}}"/>
+                            <RadioButton GroupName="SeekEgg" Content="Yes" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectTrueConverter}}"/>
+                            <RadioButton GroupName="SeekEgg" Content="No" IsChecked="{Binding Filter.IsEgg, Converter={StaticResource ObjectFalseConverter}}"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Legality" Opacity="0.7" FontSize="12"/>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <RadioButton GroupName="SeekLegal" Content="Any" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectNullConverter}}"/>
+                            <RadioButton GroupName="SeekLegal" Content="Legal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectTrueConverter}}"/>
+                            <RadioButton GroupName="SeekLegal" Content="Illegal" IsChecked="{Binding Filter.IsLegal, Converter={StaticResource ObjectFalseConverter}}"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Hidden Power" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.HiddenPowerList}"
+                                  SelectedValue="{Binding Filter.HiddenPowerType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Level" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.LevelComparisonList}"
+                                  SelectedValue="{Binding Filter.LevelComparison}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                        <NumericUpDown Value="{Binding Filter.Level}" Minimum="1" Maximum="100" Increment="1"
+                                       FormatString="0" HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="IV Total" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.IvTypeList}"
+                                  SelectedValue="{Binding Filter.IvType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="EV Total" Opacity="0.7" FontSize="12"/>
+                        <ComboBox ItemsSource="{Binding Filter.EvTypeList}"
+                                  SelectedValue="{Binding Filter.EvType}"
+                                  SelectedValueBinding="{Binding Value}"
+                                  DisplayMemberBinding="{Binding Text}"
+                                  HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <CheckBox Content="ESV (requires Egg = Yes)" IsChecked="{Binding Filter.EsvEnabled}"/>
+                        <NumericUpDown Value="{Binding Filter.Esv}" Minimum="0" Maximum="4095" Increment="1"
+                                       FormatString="0" IsEnabled="{Binding Filter.EsvEnabled}"
+                                       HorizontalAlignment="Stretch"/>
+                    </StackPanel>
+
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Batch instructions" Opacity="0.7" FontSize="12"/>
+                        <TextBox Text="{Binding Filter.BatchInstructions}"
+                                 Watermark="One per line, e.g. IVs=31&#x0a;Move1=33"
+                                 AcceptsReturn="True" TextWrapping="Wrap" MinHeight="64"
+                                 HorizontalAlignment="Stretch"/>
+                        <TextBlock Text="Batch-editor filter syntax (Property=Value). Combined with the filters above."
+                                   Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="11" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/PKHeX.Avalonia/Views/EntitySeekView.axaml.cs
+++ b/PKHeX.Avalonia/Views/EntitySeekView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class EntitySeekView : UserControl
+{
+    public EntitySeekView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Presentation/ViewModels/BoxViewerViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/BoxViewerViewModel.cs
@@ -6,11 +6,12 @@ using System.Collections.ObjectModel;
 
 namespace PKHeX.Presentation.ViewModels;
 
-public partial class BoxViewerViewModel : ViewModelBase
+public partial class BoxViewerViewModel : ViewModelBase, IBoxNavigator
 {
     private readonly SaveFile _sav;
     private readonly ISpriteRenderer _spriteRenderer;
     private readonly ISlotService? _slotService;
+    private readonly IWindowService? _windowService;
 
     private const int Columns = 6;
 
@@ -26,29 +27,38 @@ public partial class BoxViewerViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<SlotData> _slots = [];
 
-    /// <summary>Whether the in-save seek bar is expanded.</summary>
-    [ObservableProperty]
-    private bool _isSeekBarVisible;
-
-    /// <summary>Feedback text for the most recent seek (e.g. "Found in Box 2" / "No matches").</summary>
-    [ObservableProperty]
-    private string _seekStatus = string.Empty;
-
-    /// <summary>Shared filter inputs that build the in-save seek predicate (bound by the view).</summary>
-    public EntityFilterViewModel Filter { get; }
+    /// <summary>
+    /// The detached "search and seek" tool. Operated from a modeless window so it can
+    /// drive this box viewer (jump + highlight) without crowding the box grid.
+    /// </summary>
+    public EntitySeekViewModel Seek { get; }
 
     public int BoxCount => _sav.BoxCount;
     public int SlotsPerBox => _sav.BoxSlotCount;
 
-    public BoxViewerViewModel(SaveFile sav, ISpriteRenderer spriteRenderer, ISlotService? slotService = null)
+    // IBoxNavigator
+    int IBoxNavigator.CurrentSlot => SelectedIndex;
+    void IBoxNavigator.NavigateTo(int box, int slot)
+    {
+        if (box != CurrentBox)
+            LoadBox(box);
+        SelectedIndex = slot;
+    }
+
+    public BoxViewerViewModel(SaveFile sav, ISpriteRenderer spriteRenderer, ISlotService? slotService = null, IWindowService? windowService = null)
     {
         _sav = sav;
         _spriteRenderer = spriteRenderer;
         _slotService = slotService;
-        Filter = new EntityFilterViewModel(sav);
+        _windowService = windowService;
+        Seek = new EntitySeekViewModel(sav, this);
 
         LoadBox(0);
     }
+
+    /// <summary>Opens (or focuses) the modeless seek tool window.</summary>
+    [RelayCommand]
+    private void OpenSeekTool() => _windowService?.ShowTool(Seek, "Search & Seek");
 
     partial void OnSelectedIndexChanged(int value)
     {
@@ -126,62 +136,6 @@ public partial class BoxViewerViewModel : ViewModelBase
         if (newBox >= BoxCount)
             newBox = 0;
         LoadBox(newBox);
-    }
-
-    [RelayCommand]
-    private void ToggleSeekBar()
-    {
-        IsSeekBarVisible = !IsSeekBarVisible;
-        if (!IsSeekBarVisible)
-            SeekStatus = string.Empty;
-    }
-
-    [RelayCommand]
-    private void SeekNext() => Seek(reverse: false);
-
-    [RelayCommand]
-    private void SeekPrevious() => Seek(reverse: true);
-
-    /// <summary>
-    /// Jumps to and highlights the next/previous box slot matching the current filter,
-    /// wrapping across boxes (party slots are excluded — they live in a separate viewer).
-    /// Mirrors upstream's EntitySearchControl in-place seek behaviour.
-    /// </summary>
-    private void Seek(bool reverse)
-    {
-        var predicate = Filter.CreateSearchPredicate();
-        int boxCount = _sav.BoxCount;
-        int perBox = _sav.BoxSlotCount;
-        int totalBoxSlots = boxCount * perBox;
-        if (totalBoxSlots == 0)
-        {
-            SeekStatus = "No box slots.";
-            return;
-        }
-
-        int step = reverse ? -1 : 1;
-        int current = (CurrentBox * perBox) + SelectedIndex;
-
-        for (int i = 1; i <= totalBoxSlots; i++)
-        {
-            int index = ((current + (i * step)) % totalBoxSlots + totalBoxSlots) % totalBoxSlots;
-            int box = index / perBox;
-            int slot = index % perBox;
-
-            var pk = _sav.GetBoxSlotAtIndex(box, slot);
-            if (pk.Species == 0)
-                continue;
-            if (!predicate(pk))
-                continue;
-
-            if (box != CurrentBox)
-                LoadBox(box);
-            SelectedIndex = slot;
-            SeekStatus = $"Found in {BoxName} (slot {slot + 1}).";
-            return;
-        }
-
-        SeekStatus = "No matches.";
     }
 
     [RelayCommand]

--- a/PKHeX.Presentation/ViewModels/EntityFilterViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/EntityFilterViewModel.cs
@@ -31,6 +31,12 @@ public partial class EntityFilterViewModel : ViewModelBase
     [ObservableProperty] private bool _esvEnabled;
     [ObservableProperty] private int _esv;
 
+    /// <summary>
+    /// Batch-editor instruction filter lines (e.g. <c>IVs=31</c>, <c>Move1=33</c>), one per line.
+    /// Parsed by Core into a search predicate via <see cref="SearchSettings.BatchInstructions"/>.
+    /// </summary>
+    [ObservableProperty] private string _batchInstructions = string.Empty;
+
     // Data Sources for View
     [ObservableProperty] private IReadOnlyList<ComboItem> _speciesList = [];
     [ObservableProperty] private IReadOnlyList<ComboItem> _natureList = [];
@@ -128,6 +134,8 @@ public partial class EntityFilterViewModel : ViewModelBase
         EVType = EvType,
         // ESV is only meaningful alongside Egg=Yes (see SearchSettings.FilterResultEgg).
         ESV = EsvEnabled ? Esv : null,
+        // Batch-editor instruction filter lines; Core parses and applies these in the predicate.
+        BatchInstructions = BatchInstructions ?? string.Empty,
         Context = _sav.Context
     };
 

--- a/PKHeX.Presentation/ViewModels/EntitySeekViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/EntitySeekViewModel.cs
@@ -1,0 +1,75 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Drives an in-save "search and seek" tool: builds a predicate from <see cref="Filter"/>
+/// and jumps the associated box viewer to the next/previous matching slot, wrapping across
+/// boxes. Hosted in a modeless tool window so it can be operated while the box grid updates
+/// live. The cross-platform equivalent of upstream's <c>EntitySearchControl</c>.
+/// </summary>
+public partial class EntitySeekViewModel : ViewModelBase
+{
+    private readonly SaveFile _sav;
+    private readonly IBoxNavigator _navigator;
+
+    /// <summary>Shared entity filter inputs + combo data sources (bound by the view).</summary>
+    public EntityFilterViewModel Filter { get; }
+
+    /// <summary>Feedback text for the most recent seek (e.g. "Found in Box 2" / "No matches").</summary>
+    [ObservableProperty]
+    private string _seekStatus = string.Empty;
+
+    public EntitySeekViewModel(SaveFile sav, IBoxNavigator navigator)
+    {
+        _sav = sav;
+        _navigator = navigator;
+        Filter = new EntityFilterViewModel(sav);
+    }
+
+    [RelayCommand]
+    private void SeekNext() => Seek(reverse: false);
+
+    [RelayCommand]
+    private void SeekPrevious() => Seek(reverse: true);
+
+    /// <summary>
+    /// Jumps to and highlights the next/previous box slot matching the current filter,
+    /// wrapping across boxes. Party slots are excluded — they live in a separate viewer.
+    /// </summary>
+    private void Seek(bool reverse)
+    {
+        var predicate = Filter.CreateSearchPredicate();
+        int perBox = _navigator.SlotsPerBox;
+        int totalBoxSlots = _navigator.BoxCount * perBox;
+        if (totalBoxSlots == 0)
+        {
+            SeekStatus = "No box slots.";
+            return;
+        }
+
+        int step = reverse ? -1 : 1;
+        int current = (_navigator.CurrentBox * perBox) + _navigator.CurrentSlot;
+
+        for (int i = 1; i <= totalBoxSlots; i++)
+        {
+            int index = (((current + (i * step)) % totalBoxSlots) + totalBoxSlots) % totalBoxSlots;
+            int box = index / perBox;
+            int slot = index % perBox;
+
+            var pk = _sav.GetBoxSlotAtIndex(box, slot);
+            if (pk.Species == 0)
+                continue;
+            if (!predicate(pk))
+                continue;
+
+            _navigator.NavigateTo(box, slot);
+            SeekStatus = $"Found in Box {box + 1} (slot {slot + 1}).";
+            return;
+        }
+
+        SeekStatus = "No matches.";
+    }
+}

--- a/PKHeX.Presentation/ViewModels/IBoxNavigator.cs
+++ b/PKHeX.Presentation/ViewModels/IBoxNavigator.cs
@@ -1,0 +1,25 @@
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Abstraction over a box viewer that the seek tool drives: it reads the current
+/// position and asks the viewer to jump to a matching slot. Keeps
+/// <see cref="EntitySeekViewModel"/> decoupled from the box viewer's internals
+/// (and independently testable with a stub).
+/// </summary>
+public interface IBoxNavigator
+{
+    /// <summary>Number of boxes in the save.</summary>
+    int BoxCount { get; }
+
+    /// <summary>Slots per box in the save.</summary>
+    int SlotsPerBox { get; }
+
+    /// <summary>The currently displayed box index.</summary>
+    int CurrentBox { get; }
+
+    /// <summary>The currently selected slot index within the current box.</summary>
+    int CurrentSlot { get; }
+
+    /// <summary>Selects the given box/slot, loading the box if needed and highlighting the slot.</summary>
+    void NavigateTo(int box, int slot);
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -104,6 +104,9 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private void OnSaveFileChanged(SaveFile? sav)
     {
+        // Dismiss any modeless tool windows (e.g. the box seek tool) bound to the previous save.
+        _windowService.CloseAllTools();
+
         CurrentSave = sav;
         if (sav is not null)
         {
@@ -115,7 +118,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
                 CurrentPokemonEditor = new PokemonEditorViewModel(sav.BlankPKM, sav, _spriteRenderer, _dialogService, _windowService);
 
-                var boxViewer = new BoxViewerViewModel(sav, _spriteRenderer, _slotService);
+                var boxViewer = new BoxViewerViewModel(sav, _spriteRenderer, _slotService, _windowService);
                 boxViewer.SlotActivated += OnBoxSlotActivated;
                 boxViewer.ViewSlotRequested += OnBoxViewSlot;
                 boxViewer.SetSlotRequested += OnBoxSetSlot;

--- a/Tests/PKHeX.Avalonia.Tests/BoxViewerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/BoxViewerTests.cs
@@ -142,70 +142,25 @@ public class BoxViewerTests(ITestOutputHelper output)
     }
 
     // -----------------------------------------------------------------------
-    // In-save seek (EntityFilter-driven)
+    // In-save seek (detached tool, driven through BoxViewerViewModel.Seek)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void BoxViewer_SeekNext_JumpsToMatchInLaterBox()
+    public void BoxViewer_Seek_DrivesBoxNavigationToMatch()
     {
         var sav = new SAV6XY();
         // Pikachu sits in box 2, slot 5; nothing else matches.
         sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 2, 5);
 
         var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
-        vm.Filter.Species = 25;
+        vm.Seek.Filter.Species = 25;
 
-        vm.SeekNextCommand.Execute(null);
+        vm.Seek.SeekNextCommand.Execute(null);
 
+        // The seek tool navigated the box viewer to the matching slot.
         Assert.Equal(2, vm.CurrentBox);
         Assert.Equal(5, vm.SelectedIndex);
-        output.WriteLine($"SeekNext: jumped to box {vm.CurrentBox}, slot {vm.SelectedIndex} ✓");
-    }
-
-    [Fact]
-    public void BoxViewer_SeekNext_NoMatch_ReportsStatus()
-    {
-        var sav = new SAV6XY();
-        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
-        vm.Filter.Species = 25; // no Pikachu anywhere
-
-        vm.SeekNextCommand.Execute(null);
-
-        Assert.Equal("No matches.", vm.SeekStatus);
-        output.WriteLine("SeekNext with no match: reports 'No matches.' ✓");
-    }
-
-    [Fact]
-    public void BoxViewer_SeekNext_WrapsAroundToEarlierBox()
-    {
-        var sav = new SAV6XY();
-        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 0, 0); // only match is behind the cursor
-
-        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
-        vm.Filter.Species = 25;
-        // Move cursor past the only match.
-        vm.NextBoxCommand.Execute(null); // box 1
-        vm.SelectedIndex = 3;
-
-        vm.SeekNextCommand.Execute(null);
-
-        Assert.Equal(0, vm.CurrentBox);
-        Assert.Equal(0, vm.SelectedIndex);
-        output.WriteLine("SeekNext wraps around to box 0 ✓");
-    }
-
-    [Fact]
-    public void BoxViewer_ToggleSeekBar_FlipsVisibility()
-    {
-        var sav = new SAV6XY();
-        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
-
-        Assert.False(vm.IsSeekBarVisible);
-        vm.ToggleSeekBarCommand.Execute(null);
-        Assert.True(vm.IsSeekBarVisible);
-        vm.ToggleSeekBarCommand.Execute(null);
-        Assert.False(vm.IsSeekBarVisible);
-        output.WriteLine("ToggleSeekBar flips visibility ✓");
+        output.WriteLine($"Seek drove box view to box {vm.CurrentBox}, slot {vm.SelectedIndex} ✓");
     }
 
     // -----------------------------------------------------------------------

--- a/Tests/PKHeX.Avalonia.Tests/EntitySeekTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/EntitySeekTests.cs
@@ -1,0 +1,110 @@
+using PKHeX.Presentation.ViewModels;
+using PKHeX.Core;
+using Xunit.Abstractions;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="EntitySeekViewModel"/> using a stub <see cref="IBoxNavigator"/>,
+/// so seek logic is verified independently of the box viewer / Avalonia.
+/// </summary>
+public class EntitySeekTests(ITestOutputHelper output)
+{
+    private sealed class StubNavigator(int boxCount, int slotsPerBox) : IBoxNavigator
+    {
+        public int BoxCount { get; } = boxCount;
+        public int SlotsPerBox { get; } = slotsPerBox;
+        public int CurrentBox { get; set; }
+        public int CurrentSlot { get; set; }
+        public (int Box, int Slot)? LastNavigation { get; private set; }
+
+        public void NavigateTo(int box, int slot)
+        {
+            CurrentBox = box;
+            CurrentSlot = slot;
+            LastNavigation = (box, slot);
+        }
+    }
+
+    [Fact]
+    public void Seek_JumpsToMatchInLaterBox()
+    {
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 2, 5);
+        var nav = new StubNavigator(sav.BoxCount, sav.BoxSlotCount);
+        var vm = new EntitySeekViewModel(sav, nav);
+        vm.Filter.Species = 25;
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal((2, 5), nav.LastNavigation);
+        Assert.Contains("Box 3", vm.SeekStatus); // 1-based display
+        output.WriteLine($"Seek -> {nav.LastNavigation}, status '{vm.SeekStatus}' ✓");
+    }
+
+    [Fact]
+    public void Seek_NoMatch_ReportsStatus_AndDoesNotNavigate()
+    {
+        var sav = new SAV6XY();
+        var nav = new StubNavigator(sav.BoxCount, sav.BoxSlotCount);
+        var vm = new EntitySeekViewModel(sav, nav);
+        vm.Filter.Species = 25; // none present
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal("No matches.", vm.SeekStatus);
+        Assert.Null(nav.LastNavigation);
+        output.WriteLine("No match: status set, no navigation ✓");
+    }
+
+    [Fact]
+    public void Seek_WrapsAroundToEarlierBox()
+    {
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 0, 0); // only match is behind the cursor
+        var nav = new StubNavigator(sav.BoxCount, sav.BoxSlotCount) { CurrentBox = 1, CurrentSlot = 3 };
+        var vm = new EntitySeekViewModel(sav, nav);
+        vm.Filter.Species = 25;
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal((0, 0), nav.LastNavigation);
+        output.WriteLine("Seek wrapped around to box 0 ✓");
+    }
+
+    [Fact]
+    public void Seek_Previous_FindsMatchBehindCursor()
+    {
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, 0, 0);
+        var nav = new StubNavigator(sav.BoxCount, sav.BoxSlotCount) { CurrentBox = 1, CurrentSlot = 0 };
+        var vm = new EntitySeekViewModel(sav, nav);
+        vm.Filter.Species = 25;
+
+        vm.SeekPreviousCommand.Execute(null);
+
+        Assert.Equal((0, 0), nav.LastNavigation);
+        output.WriteLine("SeekPrevious found the earlier match ✓");
+    }
+
+    [Fact]
+    public void Seek_BatchInstruction_FiltersByProperty()
+    {
+        var sav = new SAV6XY();
+        // Two Pikachu: one flawless IVs, one zero IVs. Batch filter should pick only the flawless one.
+        var flawless = new PK6 { Species = 25, IV_HP = 31, IV_ATK = 31, IV_DEF = 31, IV_SPA = 31, IV_SPD = 31, IV_SPE = 31 };
+        var weak = new PK6 { Species = 25 };
+        sav.SetBoxSlotAtIndex(weak, 0, 0);
+        sav.SetBoxSlotAtIndex(flawless, 1, 0);
+
+        var nav = new StubNavigator(sav.BoxCount, sav.BoxSlotCount);
+        var vm = new EntitySeekViewModel(sav, nav);
+        vm.Filter.Species = 25;
+        vm.Filter.BatchInstructions = "IV_HP=31"; // batch-editor filter syntax
+
+        vm.SeekNextCommand.Execute(null);
+
+        Assert.Equal((1, 0), nav.LastNavigation); // skipped the weak one in box 0
+        output.WriteLine($"Batch instruction filtered to {nav.LastNavigation} ✓");
+    }
+}


### PR DESCRIPTION
Supersedes #111 (auto-closed when its stacked base branch #110 was deleted on merge). Same work, now targeting main.

## Summary
1. **Reusable modeless tool-window framework** — fixes the box seek crowding the box grid and gives the app a consistent pattern for "operate-while-watching" tools.
2. **Batch-instruction search** — closes acceptance item #2 of #104. Not actually Core-blocked: the missing `EntityInstructionBuilder` is just upstream's WinForms property-picker helper; `SearchSettings.BatchInstructions` already flows into the predicate via `SearchUtil.SatisfiesFilterBatchInstruction`.

## Why a modeless window (not flyout/context menu)
The seek is an operate-while-watching tool: hit Next, watch the box grid jump/highlight. A Flyout/Popup auto-dismisses on click-away; a context menu is for per-item actions. A draggable, non-modal Window is the correct Avalonia pattern, and it stops the inline bar reflowing the grid.

## Changes
**Framework — `IWindowService`:** `ShowTool(vm,title)` (modeless `Show()`, owned by main window, singleton-per-VM, remembers session size/position) + `CloseAllTools()` (called on save change to dismiss stale tool windows).
**Box seek:** new `EntitySeekViewModel` + `IBoxNavigator` (seek logic out of `BoxViewerViewModel`, which now implements the interface); new `EntitySeekView`; `BoxViewer.axaml` inline bar removed; 🔍 / Ctrl+F open the window, F3 / Shift+F3 drive it.
**Batch search:** `EntityFilterViewModel.BatchInstructions` → `SearchSettings.BatchInstructions`; multi-line textbox in the seek view. Shared filter VM → DB view can adopt later.

## Testing
Build clean (0 warnings). `dotnet test` — **1901 pass**, incl. new `EntitySeekTests` (stub navigator: match / no-match / wrap / previous / batch-instruction) + BoxViewer integration test. Manual run (osx-arm64): 🔍 opens a draggable modeless window; Shiny=Yes → Next jumped Box 1 → Box 23 slot 29, highlighted live behind the window; box grid full-size; clean relaunch doesn't auto-open; dismissed on save change.

## Versioning / deferred
UIVersion 1.20.2 → **1.21.0** (feat → minor). Database-view filter rails (`PKMDatabaseView`/`MysteryGiftDatabaseView` → collapsible/resizable `GridSplitter`) deferred to a follow-up; this establishes the shared filter VM + window pattern.

Refs #104.