### PR TITLE
fix(ui): wire up missing Gen 3/4/5/7/9 Misc editor menu items

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.22.1</UIVersion>
+    <UIVersion>1.22.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -58,6 +58,7 @@
                         <MenuItem Header="Misc (GS Ball)" Command="{Binding OpenMisc2Command}" />
                     </MenuItem>
                     <MenuItem Header="Gen 3">
+                        <MenuItem Header="Misc" Command="{Binding OpenMisc3Command}" />
                         <MenuItem Header="Roamer" Command="{Binding OpenRoamer3Command}" />
                         <MenuItem Header="Secret Base" Command="{Binding OpenSecretBaseCommand}" />
                         <MenuItem Header="RTC (Clock)" Command="{Binding OpenRTC3Command}" />
@@ -65,6 +66,7 @@
                         <MenuItem Header="Hall of Fame" Command="{Binding OpenHallOfFame3Command}" />
                     </MenuItem>
                     <MenuItem Header="Gen 4">
+                    <MenuItem Header="Misc" Command="{Binding OpenMisc4Command}" />
                     <MenuItem Header="Poffins (DPPt)" Command="{Binding OpenPoffinCaseCommand}" />
                     <MenuItem Header="Pokétch (DPPt)" Command="{Binding OpenPoketchCommand}" />
                     <MenuItem Header="Block Layout" Command="{Binding OpenBoxLayoutCommand}" />
@@ -78,6 +80,7 @@
                     <MenuItem Header="Pokédex" Command="{Binding OpenPokedexCommand}" />
                 </MenuItem>
                 <MenuItem Header="Gen 5">
+                    <MenuItem Header="Misc" Command="{Binding OpenMisc5Command}" />
                     <MenuItem Header="Pokédex" Command="{Binding OpenPokedexCommand}" />
                     <MenuItem Header="Chatter" Command="{Binding OpenChatterCommand}" />
                     <MenuItem Header="Medal Rally (B2W2)" Command="{Binding OpenMedalCommand}" />
@@ -96,6 +99,7 @@
                     <MenuItem Header="Secret Base Editor" Command="{Binding OpenSecretBase6Command}" />
                 </MenuItem>
                 <MenuItem Header="Gen 7">
+                    <MenuItem Header="Misc" Command="{Binding OpenMisc7Command}" />
                     <MenuItem Header="Pokédex" Command="{Binding OpenPokedexCommand}" />
                     <MenuItem Header="Poké Beans" Command="{Binding OpenPokebeanCommand}" />
                     <MenuItem Header="Festival Plaza" Command="{Binding OpenFestivalPlazaCommand}" />
@@ -116,6 +120,7 @@
                     <MenuItem Header="Poffins (BDSP)" Command="{Binding OpenPoffin8bCommand}" />
                 </MenuItem>
                 <MenuItem Header="Gen 9">
+                    <MenuItem Header="Misc" Command="{Binding OpenMisc9Command}" />
                     <MenuItem Header="Pokédex" Command="{Binding OpenPokedexCommand}" />
                     <MenuItem Header="Tera Raids (SV)" Command="{Binding OpenRaid9Command}" />
                         <MenuItem Header="7-Star Raids (SV)" Command="{Binding OpenRaidSevenStar9Command}" />


### PR DESCRIPTION
## Summary
- `OpenMisc3Command`, `OpenMisc4Command`, `OpenMisc5Command`, `OpenMisc7Command`, and `OpenMisc9Command` had full ViewModel + View + ViewLocator wiring (and test coverage) but were never bound to a `<MenuItem>` in `MainWindow.axaml`, leaving those Misc editors unreachable from the UI.
- Added a `Misc` menu item under each generation's `Tools > Save Editors > Gen <N>` submenu, matching the existing pattern used by `OpenMisc2Command` ("Misc (GS Ball)") and `OpenMisc8bCommand` ("Misc (BDSP)").
- Bumped `UIVersion` 1.22.1 → 1.22.2 (patch, per SemVer-by-change-type convention).

## Test plan
- [x] `dotnet build` succeeds with no warnings/errors
- [x] Published the macOS `.app` bundle and manually verified each new menu item in the running app:
  - [x] Gen 3 Misc opens with `gen3_emerald.sav` loaded (Records/Currency/Other tabs populated)
  - [x] Gen 4 Misc opens with `gen4_diamond.sav` loaded (Currency/Fly Destinations populated)
  - [x] Gen 5 Misc opens with `gen5_black.sav` loaded (Fly Destinations/Roamers populated)
  - [x] Gen 7 Misc opens with `gen7_sun.main` loaded (Battle Tree/Poké Finder/Stamps tabs populated)
  - [x] Gen 9 Misc opens with `gen9_scarlet.main` loaded (Currency/Unlocks populated)