### PR TITLE
fix(ui): Donut editor crash on PLZA saves without the donut block

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.22.3</UIVersion>
+    <UIVersion>1.22.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/DonutEditor.axaml
+++ b/PKHeX.Avalonia/Views/DonutEditor.axaml
@@ -14,7 +14,7 @@
                            FontSize="18"
                            HorizontalAlignment="Center"
                            Opacity="0.7" />
-                <TextBlock Text="This save type does not support Donut Editor (PLZA only)."
+                <TextBlock Text="Donut data is not present in this save. Donuts appear after the feature is unlocked in-game (PLZA only)."
                            HorizontalAlignment="Center"
                            Opacity="0.5"
                            Margin="0,8,0,0" />

--- a/PKHeX.Presentation/ViewModels/DonutEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/DonutEditorViewModel.cs
@@ -16,7 +16,12 @@ public partial class DonutEditorViewModel : ViewModelBase
     {
         _sav = (SAV9ZA)sav;
         _pocket = _sav.Donuts;
-        IsSupported = true;
+
+        // The donut block only exists once the feature is unlocked in-game; on saves without it
+        // the accessor substitutes an empty dummy block, and reading any slot would throw.
+        IsSupported = _pocket.Data.Length >= DonutPocket9a.MaxCount * Donut9a.Size;
+        if (!IsSupported)
+            return;
 
         LoadDonuts();
         LoadFlavorOptions();

--- a/Tests/PKHeX.Avalonia.Tests/DonutEditorSupportTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/DonutEditorSupportTests.cs
@@ -1,0 +1,61 @@
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class DonutEditorSupportTests
+{
+    private static string? FindSaveFilesPath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var savePath = Path.Combine(dir.FullName, "savefiles");
+            if (Directory.Exists(savePath))
+                return savePath;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static SAV9ZA? LoadZASave()
+    {
+        var dir = FindSaveFilesPath();
+        if (dir is null) return null;
+        var path = Path.Combine(dir, "gen9a_legendsza.main");
+        if (!File.Exists(path)) return null;
+        return SaveUtil.GetSaveFile(File.ReadAllBytes(path)) as SAV9ZA;
+    }
+
+    [Fact]
+    public void DonutEditor_DoesNotCrash_WhenSaveHasNoDonutBlock()
+    {
+        // This save predates the in-game donut unlock: the KDonuts block is absent, so the
+        // accessor substitutes an empty dummy block and any GetDonut() slice throws.
+        var sav = LoadZASave();
+        if (sav is null)
+            return; // gen9a_legendsza.main not present — run Tests/savefiles/download_saves.sh
+
+        Assert.True(sav.Donuts.Data.Length < DonutPocket9a.MaxCount * Donut9a.Size,
+            "Test save unexpectedly has a full donut block; this regression test needs a save without one.");
+
+        var vm = new DonutEditorViewModel(sav); // used to throw ArgumentOutOfRangeException
+
+        Assert.False(vm.IsSupported);
+        Assert.Empty(vm.Donuts);
+    }
+
+    [Fact]
+    public void DonutEditor_IsSupported_WithFullSizeBlock()
+    {
+        // A blank SAV9ZA is constructed with all blocks present at full size.
+        var sav = new SAV9ZA();
+        if (sav.Donuts.Data.Length < DonutPocket9a.MaxCount * Donut9a.Size)
+            return; // supported path not constructible in-memory on this Core revision
+
+        var vm = new DonutEditorViewModel(sav);
+
+        Assert.True(vm.IsSupported);
+        Assert.Equal(DonutPocket9a.MaxCount, vm.Donuts.Count);
+    }
+}


### PR DESCRIPTION
## Root cause

Opening **Tools > Save Editors > Gen 9 > Donut Editor** on a Legends Z-A save crashed with `ArgumentOutOfRangeException`. The `KDonuts` block (`0xBE007476`, `donut[999] × 0x48` ≈ 72 KB) only exists in the save **after the donut feature is unlocked in-game**. For saves without it, `SaveBlockAccessor9ZA` uses `BlockSafe`, which silently substitutes an empty dummy block — and `DonutEditorViewModel`'s constructor eagerly reads all 999 slots, throwing on the first `Raw.Slice(0, 0x48)`.

Reproduced against `Tests/savefiles/gen9a_legendsza.main` (`HasBlock=False`).

## Fix

- `DonutEditorViewModel` now sets `IsSupported = Data.Length >= MaxCount * Size` and skips loading when false — the view's existing `!IsSupported` fallback panel (previously unreachable) now shows instead of crashing.
- Clarified the fallback text: the old message blamed the save *type*, but this happens on genuine PLZA saves before the unlock.
- No PKHeX.Core changes.
- UIVersion 1.22.3 → 1.22.4 (fix → patch).

## Verification

- New `DonutEditorSupportTests`: regression test fails on the old code (reproduces the exact crash on the real LZA save), passes with the fix; second test confirms the supported path still loads 999 slots on a blank `SAV9ZA`.
- Full suite: 2,357 tests passing (Core + Architecture + Avalonia), build clean.