### PR TITLE
feat(ui): bulk Showdown import/export (box / all boxes)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-<UIVersion>1.23.0</UIVersion>
+<UIVersion>1.24.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/UseCases/ExportShowdownBoxUseCase.cs
+++ b/PKHeX.Application/UseCases/ExportShowdownBoxUseCase.cs
@@ -1,0 +1,39 @@
+using System.Text;
+using PKHeX.Core;
+
+namespace PKHeX.Application.UseCases;
+
+/// <summary>
+/// Serializes every non-empty slot of a box (or all boxes) as blank-line-separated Showdown sets,
+/// in box/slot order. Returns an empty string when no Pokémon are present.
+/// </summary>
+public sealed class ExportShowdownBoxUseCase
+{
+    public string Execute(SaveFile sav, int box)
+    {
+        var sb = new StringBuilder();
+        AppendBox(sb, sav, box);
+        return sb.ToString();
+    }
+
+    public string ExecuteAll(SaveFile sav)
+    {
+        var sb = new StringBuilder();
+        for (int box = 0; box < sav.BoxCount; box++)
+            AppendBox(sb, sav, box);
+        return sb.ToString();
+    }
+
+    private static void AppendBox(StringBuilder sb, SaveFile sav, int box)
+    {
+        for (int slot = 0; slot < sav.BoxSlotCount; slot++)
+        {
+            var pk = sav.GetBoxSlotAtIndex(box, slot);
+            if (pk.Species == 0)
+                continue;
+            if (sb.Length > 0)
+                sb.Append('\n').Append('\n');
+            sb.Append(new ShowdownSet(pk).Text);
+        }
+    }
+}

--- a/PKHeX.Application/UseCases/ImportShowdownTeamUseCase.cs
+++ b/PKHeX.Application/UseCases/ImportShowdownTeamUseCase.cs
@@ -1,0 +1,68 @@
+using PKHeX.Core;
+
+namespace PKHeX.Application.UseCases;
+
+public readonly record struct ImportShowdownTeamResult(int Imported, IReadOnlyList<string> SetErrors, string? FatalError)
+{
+    public bool Success => FatalError is null;
+}
+
+/// <summary>
+/// Parses multi-set Showdown text (blank-line separated) and places each Pokémon into the first
+/// empty slots of the target box. All-or-nothing on space: if the valid sets outnumber the empty
+/// slots, nothing is written. Malformed sets are skipped and reported individually.
+/// </summary>
+public sealed class ImportShowdownTeamUseCase
+{
+    public ImportShowdownTeamResult Execute(SaveFile sav, string? text, int box)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return new ImportShowdownTeamResult(0, [], "Clipboard is empty.");
+
+        var lines = text.Split('\n').Select(l => l.TrimEnd('\r'));
+        var sets = ShowdownParsing.GetShowdownSets(lines).ToList();
+        if (sets.Count == 0)
+            return new ImportShowdownTeamResult(0, [], "No Showdown sets found in the text.");
+
+        var errors = new List<string>();
+        var pokemon = new List<PKM>();
+        for (int i = 0; i < sets.Count; i++)
+        {
+            var set = sets[i];
+            if (set.Species <= 0)
+            {
+                var reason = set.InvalidLines.Count > 0
+                    ? string.Join("; ", set.InvalidLines.Select(z => z.ToString()))
+                    : "Unrecognized species.";
+                errors.Add($"Set {i + 1}: {reason}");
+                continue;
+            }
+
+            var pk = sav.BlankPKM;
+            pk.ApplySetDetails(set);
+            if (pk.Format >= 8)
+                pk.Nature = pk.StatAlignment;
+            pk.SetPIDGender(pk.Gender);
+            pokemon.Add(pk);
+        }
+
+        if (pokemon.Count == 0)
+            return new ImportShowdownTeamResult(0, errors, "No valid Showdown sets found.");
+
+        var emptySlots = new List<int>();
+        for (int slot = 0; slot < sav.BoxSlotCount; slot++)
+        {
+            if (sav.GetBoxSlotAtIndex(box, slot).Species == 0)
+                emptySlots.Add(slot);
+        }
+
+        if (pokemon.Count > emptySlots.Count)
+            return new ImportShowdownTeamResult(0, errors,
+                $"Not enough empty slots in the current box: need {pokemon.Count}, have {emptySlots.Count}. Nothing was imported.");
+
+        for (int i = 0; i < pokemon.Count; i++)
+            sav.SetBoxSlotAtIndex(pokemon[i], box, emptySlots[i]);
+
+        return new ImportShowdownTeamResult(pokemon.Count, errors, null);
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -31,6 +31,10 @@
                 <MenuItem Header="Showdown">
                     <MenuItem Header="Import Set from Clipboard" Command="{Binding ImportShowdownCommand}" InputGesture="Ctrl+T" />
                     <MenuItem Header="Export Set to Clipboard" Command="{Binding ExportShowdownCommand}" InputGesture="Ctrl+Shift+T" />
+                    <Separator />
+                    <MenuItem Header="Import Team from Clipboard" Command="{Binding ImportShowdownTeamCommand}" />
+                    <MenuItem Header="Export Box to Clipboard" Command="{Binding ExportShowdownBoxCommand}" />
+                    <MenuItem Header="Export All Boxes to Clipboard" Command="{Binding ExportShowdownAllBoxesCommand}" />
                 </MenuItem>
                 <MenuItem Header="Data">
                     <MenuItem Header="Load Boxes" Command="{Binding LoadBoxesCommand}" />

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
@@ -71,6 +71,58 @@ public partial class MainWindowViewModel
     }
 
     [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task ImportShowdownTeamAsync()
+    {
+        if (CurrentSave is null || BoxViewer is null) return;
+
+        var text = await _clipboardService.GetTextAsync();
+        var result = new ImportShowdownTeamUseCase().Execute(CurrentSave, text, BoxViewer.CurrentBox);
+        if (!result.Success)
+        {
+            var detail = result.SetErrors.Count > 0
+                ? $"{result.FatalError}\n\n{string.Join("\n", result.SetErrors)}"
+                : result.FatalError!;
+            await _dialogService.ShowErrorAsync("Import Team Failed", detail);
+            return;
+        }
+
+        BoxViewer.RefreshCurrentBox();
+
+        var message = $"Imported {result.Imported} Pokémon into the current box.";
+        if (result.SetErrors.Count > 0)
+            message += $"\n\nSkipped sets:\n{string.Join("\n", result.SetErrors)}";
+        await _dialogService.ShowInformationAsync("Import Team", message);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task ExportShowdownBoxAsync()
+    {
+        if (CurrentSave is null || BoxViewer is null) return;
+
+        var text = new ExportShowdownBoxUseCase().Execute(CurrentSave, BoxViewer.CurrentBox);
+        if (text.Length == 0)
+        {
+            await _dialogService.ShowInformationAsync("Export Box", "The current box is empty.");
+            return;
+        }
+        await _clipboardService.SetTextAsync(text);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task ExportShowdownAllBoxesAsync()
+    {
+        if (CurrentSave is null) return;
+
+        var text = new ExportShowdownBoxUseCase().ExecuteAll(CurrentSave);
+        if (text.Length == 0)
+        {
+            await _dialogService.ShowInformationAsync("Export All Boxes", "All boxes are empty.");
+            return;
+        }
+        await _clipboardService.SetTextAsync(text);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenPKMDatabaseAsync()
     {
         if (CurrentSave is null) return;

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownTeamTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownTeamTests.cs
@@ -1,0 +1,116 @@
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class ShowdownTeamTests
+{
+    private const string TwoSets = """
+        Mudkip
+        Level: 5
+        - Tackle
+
+        Torchic
+        Level: 5
+        - Scratch
+        """;
+
+    [Fact]
+    public void ImportTeam_PlacesSetsInFirstEmptySlots()
+    {
+        var sav = new SAV3E();
+        var result = new ImportShowdownTeamUseCase().Execute(sav, TwoSets, box: 0);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Imported);
+        Assert.Empty(result.SetErrors);
+        Assert.Equal((ushort)Species.Mudkip, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.Equal((ushort)Species.Torchic, sav.GetBoxSlotAtIndex(0, 1).Species);
+    }
+
+    [Fact]
+    public void ImportTeam_SkipsOccupiedSlots()
+    {
+        var sav = new SAV3E();
+        sav.SetBoxSlotAtIndex(new PK3 { Species = (ushort)Species.Treecko }, 0, 0);
+
+        var result = new ImportShowdownTeamUseCase().Execute(sav, TwoSets, box: 0);
+
+        Assert.True(result.Success);
+        Assert.Equal((ushort)Species.Treecko, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.Equal((ushort)Species.Mudkip, sav.GetBoxSlotAtIndex(0, 1).Species);
+        Assert.Equal((ushort)Species.Torchic, sav.GetBoxSlotAtIndex(0, 2).Species);
+    }
+
+    [Fact]
+    public void ImportTeam_ReportsMalformedSet_ImportsRest()
+    {
+        var text = TwoSets + "\n\nNotARealSpeciesXyz\n- Fake Move";
+        var sav = new SAV3E();
+
+        var result = new ImportShowdownTeamUseCase().Execute(sav, text, box: 0);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Imported);
+        var error = Assert.Single(result.SetErrors);
+        Assert.StartsWith("Set 3:", error);
+    }
+
+    [Fact]
+    public void ImportTeam_AllOrNothing_WhenBoxLacksSpace()
+    {
+        var sav = new SAV3E();
+        for (int slot = 0; slot < sav.BoxSlotCount - 1; slot++)
+            sav.SetBoxSlotAtIndex(new PK3 { Species = (ushort)Species.Zigzagoon }, 0, slot);
+
+        var result = new ImportShowdownTeamUseCase().Execute(sav, TwoSets, box: 0);
+
+        Assert.False(result.Success);
+        Assert.Equal(0, result.Imported);
+        Assert.Contains("Not enough empty slots", result.FatalError);
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, sav.BoxSlotCount - 1).Species); // last slot untouched
+    }
+
+    [Fact]
+    public void ImportTeam_EmptyClipboard_Fails()
+    {
+        var result = new ImportShowdownTeamUseCase().Execute(new SAV3E(), "  ", box: 0);
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public void ExportBox_RoundTripsThroughImport()
+    {
+        var sav = new SAV3E();
+        Assert.True(new ImportShowdownTeamUseCase().Execute(sav, TwoSets, box: 0).Success);
+
+        var text = new ExportShowdownBoxUseCase().Execute(sav, box: 0);
+        Assert.Contains("Mudkip", text);
+        Assert.Contains("Torchic", text);
+
+        // Re-import the exported text into another box: same species, same count.
+        var result = new ImportShowdownTeamUseCase().Execute(sav, text, box: 1);
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Imported);
+        Assert.Equal((ushort)Species.Mudkip, sav.GetBoxSlotAtIndex(1, 0).Species);
+    }
+
+    [Fact]
+    public void ExportAllBoxes_IncludesEveryBox()
+    {
+        var sav = new SAV3E();
+        sav.SetBoxSlotAtIndex(new PK3 { Species = (ushort)Species.Mudkip, Move1 = (ushort)Move.Tackle }, 0, 0);
+        sav.SetBoxSlotAtIndex(new PK3 { Species = (ushort)Species.Torchic, Move1 = (ushort)Move.Scratch }, 2, 5);
+
+        var text = new ExportShowdownBoxUseCase().ExecuteAll(sav);
+
+        Assert.Contains("Mudkip", text);
+        Assert.Contains("Torchic", text);
+    }
+
+    [Fact]
+    public void ExportBox_Empty_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, new ExportShowdownBoxUseCase().Execute(new SAV3E(), 0));
+    }
+}


### PR DESCRIPTION
Closes #121 (Phase 0 of roadmap #125).

## What

**Tools > Showdown** gains three items below the existing single-set pair:
- **Import Team from Clipboard** — parses blank-line-separated sets (`ShowdownParsing.GetShowdownSets`), places each into the first empty slots of the current box, refreshes the box viewer, and reports the result.
- **Export Box to Clipboard** / **Export All Boxes to Clipboard** — every non-empty slot serialized in box/slot order.

Logic lives in two new Application-layer use cases (`ImportShowdownTeamUseCase`, `ExportShowdownBoxUseCase`) mirroring the existing single-set ones; Pokémon construction reuses the exact single-import path (`ApplySetDetails` + nature/PID-gender fixup).

## Documented choices (per issue acceptance criteria)

- **Insufficient space:** all-or-nothing — if valid sets outnumber empty slots, nothing is written and the error says need/have counts.
- **Malformed sets:** skipped and reported as `Set N: <reason>`; well-formed sets in the same paste still import.
- **Undo:** deviation from the issue — multi-set import is not registered as a single undo operation. The repo's `SlotChangelog` wrapper is strictly per-slot and existing bulk paths (Load Boxes) don't record undo either; grouping N slot writes into one undo step needs changelog-level work, out of scope here.

## Verification

- 8 new `ShowdownTeamTests`: placement, occupied-slot skipping, malformed-set reporting, all-or-nothing space handling, empty input, export round-trip through import, all-boxes export, empty-box export.
- Full suite: 2,369 tests passing; build clean. UIVersion 1.23.0 → 1.24.0.