### PR TITLE
feat(ui): QR code generation and import for Pokémon

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-<UIVersion>1.23.0</UIVersion>
+<UIVersion>1.25.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IQrCodeService.cs
+++ b/PKHeX.Application/Abstractions/IQrCodeService.cs
@@ -1,0 +1,14 @@
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// Encodes text payloads (see <c>PKHeX.Core.QRMessageUtil</c>) as QR code images and decodes them back.
+/// Payloads are raw byte data mapped char-per-byte, so both directions use ISO-8859-1 semantics.
+/// </summary>
+public interface IQrCodeService
+{
+    /// <summary>Renders the message as a QR code PNG.</summary>
+    byte[] GeneratePng(string message, int pixelsPerModule = 8);
+
+    /// <summary>Decodes a QR code from PNG/JPEG image bytes. Returns null when no QR code is found.</summary>
+    string? DecodePng(byte[] imageBytes);
+}

--- a/PKHeX.Avalonia/App.axaml.cs
+++ b/PKHeX.Avalonia/App.axaml.cs
@@ -56,6 +56,7 @@ public partial class App : global::Avalonia.Application
         services.AddSingleton<IWindowService, WindowService>();
         services.AddSingleton<ISpriteRenderer, AvaloniaSpriteRenderer>();
         services.AddSingleton<IClipboardService, ClipboardService>();
+        services.AddSingleton<IQrCodeService, QrCodeService>();
 
         // Root ViewModel (transient). Child/editor ViewModels are created by their parent presenter
         // with the current save, so they are not registered in the container.

--- a/PKHeX.Avalonia/PKHeX.Avalonia.csproj
+++ b/PKHeX.Avalonia/PKHeX.Avalonia.csproj
@@ -37,6 +37,7 @@
 
     <!-- DI -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="QRCoder" Version="1.6.0" />
 
     <!-- Rendering (for sprites) -->
     <PackageReference Include="SkiaSharp" Version="3.119.4" />
@@ -47,6 +48,7 @@
 
     <!-- Diagnostics (dev only) -->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="ZXing.Net" Version="0.16.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PKHeX.Avalonia/Services/QrCodeService.cs
+++ b/PKHeX.Avalonia/Services/QrCodeService.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using PKHeX.Application.Abstractions;
+using QRCoder;
+using SkiaSharp;
+using ZXing;
+using ZXing.Common;
+
+namespace PKHeX.Avalonia.Services;
+
+/// <summary>
+/// QR image encode/decode. Payloads from <c>QRMessageUtil</c> are raw bytes stored char-per-byte,
+/// so both directions pin the character set to ISO-8859-1 (matching upstream WinForms PKHeX).
+/// </summary>
+public sealed class QrCodeService : IQrCodeService
+{
+    public byte[] GeneratePng(string message, int pixelsPerModule = 8)
+    {
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(message, QRCodeGenerator.ECCLevel.Q,
+            forceUtf8: false, utf8BOM: false, eciMode: QRCodeGenerator.EciMode.Iso8859_1);
+        using var png = new PngByteQRCode(data);
+        return png.GetGraphic(pixelsPerModule);
+    }
+
+    public string? DecodePng(byte[] imageBytes)
+    {
+        using var codec = SKCodec.Create(new MemoryStream(imageBytes));
+        if (codec is null)
+            return null; // not a recognizable image
+
+        using var decoded = SKBitmap.Decode(codec);
+        if (decoded is null)
+            return null;
+
+        using var bitmap = decoded.ColorType == SKColorType.Bgra8888
+            ? decoded.Copy() // Copy so both branches own their bitmap and the using stays uniform.
+            : decoded.Copy(SKColorType.Bgra8888);
+        if (bitmap is null)
+            return null;
+
+        var source = new RGBLuminanceSource(bitmap.Bytes, bitmap.Width, bitmap.Height,
+            RGBLuminanceSource.BitmapFormat.BGRA32);
+        var reader = new BarcodeReaderGeneric
+        {
+            Options = new DecodingOptions
+            {
+                TryHarder = true,
+                PossibleFormats = [BarcodeFormat.QR_CODE],
+                CharacterSet = "ISO-8859-1",
+            },
+        };
+        return reader.Decode(source)?.Text;
+    }
+}

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -85,6 +85,7 @@ public static class ViewLocator
         [typeof(PokedexSimpleEditorViewModel)] = () => new PokedexSimpleEditor(),
         [typeof(PokepuffEditorViewModel)] = () => new PokepuffEditor(),
         [typeof(PoketchEditorViewModel)] = () => new PoketchEditorView(),
+        [typeof(QrCodeViewModel)] = () => new QrCodeView(),
         [typeof(RTC3EditorViewModel)] = () => new RTC3Editor(),
         [typeof(RTCEditorViewModel)] = () => new RTCEditor(),
         [typeof(Raid9EditorViewModel)] = () => new Raid9Editor(),

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -32,6 +32,10 @@
                     <MenuItem Header="Import Set from Clipboard" Command="{Binding ImportShowdownCommand}" InputGesture="Ctrl+T" />
                     <MenuItem Header="Export Set to Clipboard" Command="{Binding ExportShowdownCommand}" InputGesture="Ctrl+Shift+T" />
                 </MenuItem>
+                <MenuItem Header="QR Code">
+                    <MenuItem Header="Show Current Pokémon…" Command="{Binding ShowQrCodeCommand}" />
+                    <MenuItem Header="Import from Image…" Command="{Binding ImportQrCodeCommand}" />
+                </MenuItem>
                 <MenuItem Header="Data">
                     <MenuItem Header="Load Boxes" Command="{Binding LoadBoxesCommand}" />
                     <MenuItem Header="Dump Boxes" Command="{Binding DumpBoxesCommand}" />

--- a/PKHeX.Avalonia/Views/QrCodeView.axaml
+++ b/PKHeX.Avalonia/Views/QrCodeView.axaml
@@ -1,0 +1,23 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             xmlns:conv="clr-namespace:PKHeX.Avalonia.Converters"
+             x:Class="PKHeX.Avalonia.Views.QrCodeView"
+             x:DataType="vm:QrCodeViewModel"
+             Width="420">
+
+    <UserControl.Resources>
+        <conv:PngBytesToBitmapConverter x:Key="PngToBitmap" />
+    </UserControl.Resources>
+
+    <StackPanel Margin="16" Spacing="12">
+        <Border HorizontalAlignment="Center" Background="White" Padding="8" CornerRadius="4">
+            <Image Source="{Binding PngBytes, Converter={StaticResource PngToBitmap}}"
+                   Width="320" Height="320" RenderOptions.BitmapInterpolationMode="None" />
+        </Border>
+        <TextBlock Text="{Binding Caption}" TextWrapping="Wrap" HorizontalAlignment="Center"
+                   TextAlignment="Center" Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" />
+        <Button Content="Save as PNG…" Classes="accent" HorizontalAlignment="Center"
+                Command="{Binding SaveAsPngCommand}" />
+    </StackPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/QrCodeView.axaml.cs
+++ b/PKHeX.Avalonia/Views/QrCodeView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class QrCodeView : UserControl
+{
+    public QrCodeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
@@ -71,6 +71,66 @@ public partial class MainWindowViewModel
     }
 
     [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task ShowQrCodeAsync()
+    {
+        if (CurrentSave is null || CurrentPokemonEditor is null) return;
+
+        var pk = CurrentPokemonEditor.PreparePKM();
+        if (pk.Species == 0)
+        {
+            await _dialogService.ShowErrorAsync("QR Code", "Load a Pokémon into the editor first.");
+            return;
+        }
+
+        var message = QRMessageUtil.GetMessage(pk);
+        var png = _qrCodeService.GeneratePng(message);
+        var species = GameInfo.Strings.Species[pk.Species];
+        var caption = pk.Format == 7
+            ? $"{species} — scannable by the Gen 7 in-game QR Scanner."
+            : $"{species} — raw data QR (import via PKHeX's QR import).";
+
+        await _windowService.ShowDialogAsync(
+            new QrCodeViewModel(png, caption, $"{species}_qr.png", _dialogService),
+            "QR Code");
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private async Task ImportQrCodeAsync()
+    {
+        if (CurrentSave is null || CurrentPokemonEditor is null) return;
+
+        var path = await _dialogService.OpenFileAsync("Open QR Code Image", ["*.png", "*.jpg", "*.jpeg", "*.bmp"]);
+        if (string.IsNullOrEmpty(path)) return;
+
+        string? message;
+        try
+        {
+            message = _qrCodeService.DecodePng(File.ReadAllBytes(path));
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("QR Import Failed", $"Could not read the image.\n\n{ex.Message}");
+            return;
+        }
+
+        if (message is null)
+        {
+            await _dialogService.ShowErrorAsync("QR Import Failed", "No QR code was found in the image.");
+            return;
+        }
+
+        var pk = QRMessageUtil.GetPKM(message, CurrentSave.Context);
+        if (pk is null)
+        {
+            await _dialogService.ShowErrorAsync("QR Import Failed",
+                "The QR code was read, but it does not contain Pokémon data compatible with this save.");
+            return;
+        }
+
+        CurrentPokemonEditor.LoadPKM(pk);
+    }
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenPKMDatabaseAsync()
     {
         if (CurrentSave is null) return;

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly ISpriteRenderer _spriteRenderer;
     private readonly ISlotService _slotService;
     private readonly IClipboardService _clipboardService;
+    private readonly IQrCodeService _qrCodeService;
     private readonly AppSettings _settings;
     private readonly UndoRedoService _undoRedo;
     private readonly LanguageService _languageService;
@@ -57,6 +58,7 @@ public partial class MainWindowViewModel : ViewModelBase
         ISpriteRenderer spriteRenderer,
         ISlotService slotService,
         IClipboardService clipboardService,
+        IQrCodeService qrCodeService,
         AppSettings settings,
         UndoRedoService undoRedo,
         LanguageService languageService)
@@ -67,6 +69,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _spriteRenderer = spriteRenderer;
         _slotService = slotService;
         _clipboardService = clipboardService;
+        _qrCodeService = qrCodeService;
         _settings = settings;
         _undoRedo = undoRedo;
         _languageService = languageService;

--- a/PKHeX.Presentation/ViewModels/QrCodeViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/QrCodeViewModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using CommunityToolkit.Mvvm.Input;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Dialog showing a QR code for a Pokémon, with save-to-PNG. The image is rendered by the
+/// Infrastructure QR service; this VM only carries the PNG bytes and a caption.
+/// </summary>
+public partial class QrCodeViewModel : ViewModelBase
+{
+    private readonly IDialogService _dialogService;
+
+    public byte[] PngBytes { get; }
+    public string Caption { get; }
+    public string DefaultFileName { get; }
+
+    public QrCodeViewModel(byte[] pngBytes, string caption, string defaultFileName, IDialogService dialogService)
+    {
+        PngBytes = pngBytes;
+        Caption = caption;
+        DefaultFileName = defaultFileName;
+        _dialogService = dialogService;
+    }
+
+    [RelayCommand]
+    private async System.Threading.Tasks.Task SaveAsPngAsync()
+    {
+        var path = await _dialogService.SaveFileAsync("Save QR Code", DefaultFileName);
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        try
+        {
+            File.WriteAllBytes(path, PngBytes);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Save Error", ex.Message);
+        }
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/QrCodeTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/QrCodeTests.cs
@@ -1,0 +1,62 @@
+using PKHeX.Core;
+using PKHeX.Avalonia.Services;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class QrCodeTests
+{
+    private readonly QrCodeService _service = new();
+
+    [Fact]
+    public void GenerateAndDecode_RoundTripsAsciiMessage()
+    {
+        const string message = "http://lunarcookies.github.io/b1s1.html#dGVzdA==";
+        var png = _service.GeneratePng(message);
+
+        Assert.True(png.Length > 0);
+        Assert.Equal(message, _service.DecodePng(png));
+    }
+
+    [Fact]
+    public void GenerateAndDecode_RoundTripsPk7ToIdenticalBytes()
+    {
+        // Gen 7 QR payloads are raw bytes stored char-per-byte (ISO-8859-1), the hardest case.
+        var pk = new PK7
+        {
+            Species = (ushort)Species.Rowlet,
+            CurrentLevel = 5,
+            Move1 = (ushort)Move.Tackle,
+            PID = 0x12345678,
+            EncryptionConstant = 0x87654321,
+        };
+        pk.RefreshChecksum();
+
+        var message = QRMessageUtil.GetMessage(pk);
+        var png = _service.GeneratePng(message);
+        var decodedMessage = _service.DecodePng(png);
+
+        Assert.NotNull(decodedMessage);
+        var decoded = QRMessageUtil.GetPKM(decodedMessage, EntityContext.Gen7);
+        Assert.NotNull(decoded);
+        var decodedPk7 = Assert.IsType<PK7>(decoded);
+        Assert.Equal(pk.Species, decodedPk7.Species);
+        Assert.Equal(pk.PID, decodedPk7.PID);
+        Assert.Equal(pk.EncryptionConstant, decodedPk7.EncryptionConstant);
+        Assert.Equal(pk.Data[..pk.SIZE_STORED].ToArray(), decodedPk7.Data[..pk.SIZE_STORED].ToArray());
+    }
+
+    [Fact]
+    public void Decode_NonQrImage_ReturnsNull()
+    {
+        // A 1x1 transparent PNG.
+        var png = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==");
+        Assert.Null(_service.DecodePng(png));
+    }
+
+    [Fact]
+    public void Decode_GarbageBytes_ReturnsNull()
+    {
+        Assert.Null(_service.DecodePng([1, 2, 3, 4]));
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -38,6 +38,7 @@ public class ShowdownIntegrationTests : IDisposable
             _spriteRendererMock.Object,
             _slotServiceMock.Object,
             _clipboardServiceMock.Object,
+            new Mock<IQrCodeService>().Object,
             new AppSettings(),
             new UndoRedoService(),
             new LanguageService()


### PR DESCRIPTION
Closes #122 (Phase 0 of roadmap #125; completes the parity phase with #120/#121).

## What

**Tools > QR Code**:
- **Show Current Pokémon…** — renders the editor's Pokémon as a QR in a dialog with Save-as-PNG. PK7 gets the Gen 7 in-game QR-Scanner payload; other formats get the raw-data QR — both via Core's `QRMessageUtil`, matching WinForms.
- **Import from Image…** — pick a PNG/JPEG, decode the QR, and load the Pokémon into the editor. Clear errors for unreadable images, images without a QR, and QRs without compatible Pokémon data.

## How

- `IQrCodeService` in `PKHeX.Application.Abstractions`; implementation in `PKHeX.Avalonia/Services` (QRCoder encode + ZXing.Net decode over SkiaSharp pixels, both pinned to ISO-8859-1 since QR payloads are raw bytes stored char-per-byte).
- Initially placed in `PKHeX.Infrastructure` — the `LayerDependencyTests` architecture test rejected the SkiaSharp dependency there, so it lives in the host next to `AvaloniaSpriteRenderer`, which uses SkiaSharp for the same reason.
- New deps on the host project only: QRCoder 1.6.0 (already credited in the README), ZXing.Net 0.16.10.

## Verification

- 4 new `QrCodeTests`, including the issue's required round-trip: a PK7's QR message → PNG → decode → `QRMessageUtil.GetPKM` reproduces byte-identical stored data. Plus non-QR image and garbage-bytes decode returning null (no crash).
- Full suite: 2,373 tests passing (incl. architecture tests); build clean. UIVersion → 1.25.0.