### PR TITLE
feat: platform-standard config directories with legacy migration (#138)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.25.3</UIVersion>
+    <UIVersion>1.26.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IAppPaths.cs
+++ b/PKHeX.Application/Abstractions/IAppPaths.cs
@@ -1,0 +1,25 @@
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// Port describing where the application stores per-user data. Implemented in the Infrastructure
+/// layer, which resolves platform-standard locations (macOS <c>~/Library/Application Support</c>,
+/// Windows <c>%APPDATA%</c>/<c>%LOCALAPPDATA%</c>, Linux <c>$XDG_CONFIG_HOME</c>/<c>$XDG_DATA_HOME</c>
+/// with fallbacks). Keeps OS/file-system knowledge out of the inner layers.
+/// </summary>
+public interface IAppPaths
+{
+    /// <summary>Directory for user configuration (settings). Created on demand by writers.</summary>
+    string ConfigDirectory { get; }
+
+    /// <summary>Directory for larger user data (backups, caches). Created on demand by writers.</summary>
+    string DataDirectory { get; }
+
+    /// <summary>Full path to the settings file inside <see cref="ConfigDirectory"/>.</summary>
+    string ConfigFilePath { get; }
+
+    /// <summary>
+    /// Full path to the legacy settings file that older builds wrote next to the executable.
+    /// Used once for migration, then ignored.
+    /// </summary>
+    string LegacyConfigFilePath { get; }
+}

--- a/PKHeX.Application/Abstractions/ISettingsStore.cs
+++ b/PKHeX.Application/Abstractions/ISettingsStore.cs
@@ -1,0 +1,21 @@
+using PKHeX.Application.Services;
+
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// Port for loading and persisting <see cref="AppSettings"/>. The Infrastructure implementation is
+/// responsible for platform path resolution, one-time migration from the legacy location,
+/// corrupt-file recovery, and forward-compatible JSON handling. Keeps file IO out of the inner
+/// layers (see issue #138).
+/// </summary>
+public interface ISettingsStore
+{
+    /// <summary>
+    /// Loads settings from the platform config directory. Migrates a legacy file on first run,
+    /// recovers to defaults (preserving a <c>.bak</c>) if the file is corrupt, and never throws.
+    /// </summary>
+    AppSettings Load();
+
+    /// <summary>Persists settings to the platform config directory. Never throws.</summary>
+    void Save(AppSettings settings);
+}

--- a/PKHeX.Application/Services/AppSettings.cs
+++ b/PKHeX.Application/Services/AppSettings.cs
@@ -1,18 +1,17 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using PKHeX.Core;
 
 namespace PKHeX.Application.Services;
 
 /// <summary>
-/// Application-layer settings model. Implements Core's <see cref="IProgramSettings"/> and persists
-/// itself as JSON. Plain POCO (no MVVM-framework coupling) — the settings screen binds to
-/// <c>SettingsViewModel</c>, which wraps this model.
+/// Application-layer settings model. Implements Core's <see cref="IProgramSettings"/>. Plain POCO
+/// (no MVVM-framework coupling, no file IO) — persistence is handled by an
+/// <see cref="Abstractions.ISettingsStore"/> implementation in the Infrastructure layer, and the
+/// settings screen binds to <c>SettingsViewModel</c>, which wraps this model.
 /// </summary>
 public sealed class AppSettings : IProgramSettings
 {
-    private const string ConfigFileName = "config.json";
-    private static readonly string ConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFileName);
-
     IStartupSettings IProgramSettings.Startup => Startup;
 
     // Settings groups (Core-defined types; locally-defined where Core only ships an interface).
@@ -28,37 +27,13 @@ public sealed class AppSettings : IProgramSettings
 
     public string DisplayLanguage { get; set; } = "en";
 
-    public static AppSettings Load()
-    {
-        if (!File.Exists(ConfigPath))
-            return new AppSettings();
-
-        try
-        {
-            var json = File.ReadAllText(ConfigPath);
-            var settings = JsonSerializer.Deserialize<AppSettings>(json);
-            return settings ?? new AppSettings();
-        }
-        catch (Exception)
-        {
-            // Fallback to defaults on error
-            return new AppSettings();
-        }
-    }
-
-    public void Save()
-    {
-        try
-        {
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            var json = JsonSerializer.Serialize(this, options);
-            File.WriteAllText(ConfigPath, json);
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Trace.TraceWarning($"Failed to save settings: {ex.Message}");
-        }
-    }
+    /// <summary>
+    /// Forward-compatibility bucket: any JSON keys written by a newer version that this build does
+    /// not recognize are captured here and re-emitted on save, so upgrading/downgrading does not
+    /// silently drop settings. See issue #138 acceptance criteria.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtensionData { get; set; }
 
     public void InitializeCore()
     {

--- a/PKHeX.Avalonia/App.axaml.cs
+++ b/PKHeX.Avalonia/App.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using PKHeX.Application;
 using PKHeX.Infrastructure;
+using PKHeX.Infrastructure.Configuration;
 using PKHeX.Avalonia.Services;
 using PKHeX.Presentation.ViewModels;
 using PKHeX.Avalonia.Views;
@@ -46,9 +47,14 @@ public partial class App : global::Avalonia.Application
         services.AddApplication();
         services.AddInfrastructure();
 
-        // Config: load + seed Core localization, then register as the IProgramSettings model.
-        var config = AppSettings.Load();
+        // Config: resolve platform paths, load (migrating/recovering as needed) + seed Core
+        // localization, then register the store and the loaded model for injection.
+        IAppPaths paths = new AppPaths();
+        ISettingsStore settingsStore = new SettingsStore(paths);
+        var config = settingsStore.Load();
         config.InitializeCore();
+        services.AddSingleton(paths);
+        services.AddSingleton(settingsStore);
         services.AddSingleton(config);
 
         // Host (Frameworks & Drivers): Avalonia/Skia implementations of the Application ports.

--- a/PKHeX.Infrastructure/Configuration/AppPathResolver.cs
+++ b/PKHeX.Infrastructure/Configuration/AppPathResolver.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace PKHeX.Infrastructure.Configuration;
+
+/// <summary>The three platform families we resolve paths for.</summary>
+public enum OSKind
+{
+    Windows,
+    MacOS,
+    Linux,
+}
+
+/// <summary>
+/// Pure, side-effect-free resolution of platform-standard config/data directories. All OS and
+/// environment inputs are passed in explicitly so the logic can be unit-tested for every platform
+/// regardless of the host the tests run on.
+/// </summary>
+public static class AppPathResolver
+{
+    /// <summary>Detects the current host platform.</summary>
+    public static OSKind DetectOS()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return OSKind.Windows;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return OSKind.MacOS;
+        return OSKind.Linux;
+    }
+
+    /// <summary>
+    /// Resolves the per-user configuration directory for <paramref name="appName"/>.
+    /// Windows: <c>%APPDATA%\appName</c>. macOS: <c>~/Library/Application Support/appName</c>.
+    /// Linux: <c>$XDG_CONFIG_HOME/appName</c>, falling back to <c>~/.config/appName</c>.
+    /// </summary>
+    public static string ResolveConfigDirectory(OSKind os, string home, Func<string, string?> getEnv, string appName)
+    {
+        return os switch
+        {
+            OSKind.Windows => Path.Combine(WindowsRoaming(getEnv, home), appName),
+            OSKind.MacOS => Path.Combine(home, "Library", "Application Support", appName),
+            _ => Path.Combine(NonEmptyEnv(getEnv, "XDG_CONFIG_HOME") ?? Path.Combine(home, ".config"), appName),
+        };
+    }
+
+    /// <summary>
+    /// Resolves the per-user data directory (backups, caches) for <paramref name="appName"/>.
+    /// Windows: <c>%LOCALAPPDATA%\appName</c>. macOS: shares Application Support with config.
+    /// Linux: <c>$XDG_DATA_HOME/appName</c>, falling back to <c>~/.local/share/appName</c>.
+    /// </summary>
+    public static string ResolveDataDirectory(OSKind os, string home, Func<string, string?> getEnv, string appName)
+    {
+        return os switch
+        {
+            OSKind.Windows => Path.Combine(WindowsLocal(getEnv, home), appName),
+            OSKind.MacOS => Path.Combine(home, "Library", "Application Support", appName),
+            _ => Path.Combine(NonEmptyEnv(getEnv, "XDG_DATA_HOME") ?? Path.Combine(home, ".local", "share"), appName),
+        };
+    }
+
+    private static string WindowsRoaming(Func<string, string?> getEnv, string home)
+        => NonEmptyEnv(getEnv, "APPDATA") ?? Path.Combine(home, "AppData", "Roaming");
+
+    private static string WindowsLocal(Func<string, string?> getEnv, string home)
+        => NonEmptyEnv(getEnv, "LOCALAPPDATA") ?? Path.Combine(home, "AppData", "Local");
+
+    private static string? NonEmptyEnv(Func<string, string?> getEnv, string key)
+    {
+        var value = getEnv(key);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/PKHeX.Infrastructure/Configuration/AppPaths.cs
+++ b/PKHeX.Infrastructure/Configuration/AppPaths.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO;
+using PKHeX.Application.Abstractions;
+
+namespace PKHeX.Infrastructure.Configuration;
+
+/// <summary>
+/// Default <see cref="IAppPaths"/> implementation backed by <see cref="AppPathResolver"/> and the
+/// live OS/environment. Directories are computed lazily and are not created here — writers create
+/// them on demand.
+/// </summary>
+public sealed class AppPaths : IAppPaths
+{
+    private const string AppName = "PKHeX-Avalonia";
+    private const string ConfigFileName = "config.json";
+
+    public string ConfigDirectory { get; }
+    public string DataDirectory { get; }
+    public string ConfigFilePath { get; }
+    public string LegacyConfigFilePath { get; }
+
+    public AppPaths()
+    {
+        var os = AppPathResolver.DetectOS();
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Func<string, string?> getEnv = Environment.GetEnvironmentVariable;
+
+        ConfigDirectory = AppPathResolver.ResolveConfigDirectory(os, home, getEnv, AppName);
+        DataDirectory = AppPathResolver.ResolveDataDirectory(os, home, getEnv, AppName);
+        ConfigFilePath = Path.Combine(ConfigDirectory, ConfigFileName);
+        LegacyConfigFilePath = Path.Combine(AppContext.BaseDirectory, ConfigFileName);
+    }
+}

--- a/PKHeX.Infrastructure/Configuration/SettingsStore.cs
+++ b/PKHeX.Infrastructure/Configuration/SettingsStore.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Services;
+
+namespace PKHeX.Infrastructure.Configuration;
+
+/// <summary>
+/// JSON-backed <see cref="ISettingsStore"/>. Responsibilities (issue #138):
+/// <list type="bullet">
+/// <item>Reads/writes the settings file under the platform config directory (<see cref="IAppPaths"/>).</item>
+/// <item>One-time migration: copies a legacy file found next to the executable into the new
+/// location on first run, then leaves it untouched and never reads it again.</item>
+/// <item>Corrupt-file recovery: renames the bad file to <c>.bak</c>, logs a warning, and returns
+/// defaults instead of crashing.</item>
+/// <item>Forward compatibility: unknown JSON keys are preserved via
+/// <see cref="AppSettings.ExtensionData"/> (or at minimum tolerated) so newer/older versions
+/// round-trip without data loss.</item>
+/// </list>
+/// Never throws to callers.
+/// </summary>
+public sealed class SettingsStore : ISettingsStore
+{
+    private readonly IAppPaths _paths;
+
+    private static readonly JsonSerializerOptions ReadOptions = new()
+    {
+        // Tolerate anything a newer version might legitimately emit rather than treating it as corrupt.
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    private static readonly JsonSerializerOptions WriteOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    public SettingsStore(IAppPaths paths) => _paths = paths;
+
+    public AppSettings Load()
+    {
+        var configPath = _paths.ConfigFilePath;
+
+        MigrateLegacyIfNeeded(configPath);
+
+        if (!File.Exists(configPath))
+            return new AppSettings();
+
+        try
+        {
+            var json = File.ReadAllText(configPath);
+            var settings = JsonSerializer.Deserialize<AppSettings>(json, ReadOptions);
+            return settings ?? new AppSettings();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            RecoverCorruptFile(configPath, ex);
+            return new AppSettings();
+        }
+    }
+
+    public void Save(AppSettings settings)
+    {
+        try
+        {
+            var dir = _paths.ConfigDirectory;
+            Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(settings, WriteOptions);
+
+            // Write to a temp file in the same directory, then swap into place so a crash mid-write
+            // cannot leave a half-written (corrupt) settings file behind.
+            var tempPath = _paths.ConfigFilePath + ".tmp";
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, _paths.ConfigFilePath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning($"Failed to save settings: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// On first run (no file in the new location), imports a legacy <c>config.json</c> that older
+    /// builds wrote next to the executable. The legacy file is copied (left in place) so a rollback
+    /// still finds it; once the new file exists this is a no-op forever.
+    /// </summary>
+    private void MigrateLegacyIfNeeded(string configPath)
+    {
+        try
+        {
+            if (File.Exists(configPath))
+                return;
+
+            var legacy = _paths.LegacyConfigFilePath;
+            if (!File.Exists(legacy))
+                return;
+
+            // Guard against the (degenerate) case where the legacy path resolves to the new path.
+            if (string.Equals(Path.GetFullPath(legacy), Path.GetFullPath(configPath), StringComparison.Ordinal))
+                return;
+
+            Directory.CreateDirectory(_paths.ConfigDirectory);
+            File.Copy(legacy, configPath, overwrite: false);
+            Trace.TraceInformation($"Migrated legacy settings from '{legacy}' to '{configPath}'.");
+        }
+        catch (Exception ex)
+        {
+            // Migration is best-effort: a failure here just means we start from defaults, which the
+            // caller handles. Do not surface it.
+            Trace.TraceWarning($"Failed to migrate legacy settings: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Preserves a corrupt settings file as <c>config.json.bak</c> (overwriting any previous backup)
+    /// and logs a warning, so the reset is traceable and the bad data is recoverable.
+    /// </summary>
+    private static void RecoverCorruptFile(string configPath, Exception cause)
+    {
+        var backupPath = configPath + ".bak";
+        try
+        {
+            File.Move(configPath, backupPath, overwrite: true);
+            Trace.TraceWarning(
+                $"Settings file '{configPath}' was unreadable ({cause.Message}); preserved as '{backupPath}' and reset to defaults.");
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning(
+                $"Settings file '{configPath}' was unreadable ({cause.Message}) and could not be backed up: {ex.Message}. Using defaults.");
+        }
+    }
+}

--- a/PKHeX.Infrastructure/DependencyInjection.cs
+++ b/PKHeX.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using PKHeX.Application.Abstractions;
+using PKHeX.Infrastructure.Configuration;
 
 namespace PKHeX.Infrastructure;
 
@@ -9,6 +10,8 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
         services.AddSingleton<ISaveFileGateway, SaveFileService>();
+        services.AddSingleton<IAppPaths, AppPaths>();
+        services.AddSingleton<ISettingsStore, SettingsStore>();
         return services;
     }
 }

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -23,7 +23,7 @@ public partial class MainWindowViewModel
     [RelayCommand]
     private async Task OpenSettingsAsync()
     {
-        var vm = new SettingsViewModel(_settings);
+        var vm = new SettingsViewModel(_settings, _settingsStore);
         await _windowService.ShowDialogAsync(vm, "Settings");
 
         // The sprite preference may have changed; re-apply the style and refresh open views.

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IClipboardService _clipboardService;
     private readonly IQrCodeService _qrCodeService;
     private readonly AppSettings _settings;
+    private readonly ISettingsStore _settingsStore;
     private readonly UndoRedoService _undoRedo;
     private readonly LanguageService _languageService;
 
@@ -60,6 +61,7 @@ public partial class MainWindowViewModel : ViewModelBase
         IClipboardService clipboardService,
         IQrCodeService qrCodeService,
         AppSettings settings,
+        ISettingsStore settingsStore,
         UndoRedoService undoRedo,
         LanguageService languageService)
     {
@@ -71,6 +73,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _clipboardService = clipboardService;
         _qrCodeService = qrCodeService;
         _settings = settings;
+        _settingsStore = settingsStore;
         _undoRedo = undoRedo;
         _languageService = languageService;
 

--- a/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
@@ -9,12 +9,14 @@ namespace PKHeX.Presentation.ViewModels;
 public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
 {
     private readonly AppSettings _settings;
+    private readonly ISettingsStore _settingsStore;
 
     public Action? CloseRequested { get; set; }
 
-    public SettingsViewModel(AppSettings settings)
+    public SettingsViewModel(AppSettings settings, ISettingsStore settingsStore)
     {
         _settings = settings;
+        _settingsStore = settingsStore;
         Load();
     }
 
@@ -78,7 +80,7 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
 
         _settings.Sprite.SpritePreference = SpritePreference;
 
-        _settings.Save();
+        _settingsStore.Save(_settings);
         _settings.InitializeCore();
 
         CloseRequested?.Invoke();

--- a/Tests/PKHeX.Avalonia.Tests/AppPathResolverTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/AppPathResolverTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.IO;
+using PKHeX.Infrastructure.Configuration;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Locks in platform-standard config/data directory resolution (issue #138). Inputs are passed
+/// explicitly so every platform is covered regardless of the host OS the tests run on.
+/// </summary>
+public class AppPathResolverTests
+{
+    private const string App = "PKHeX-Avalonia";
+
+    private static System.Func<string, string?> Env(Dictionary<string, string?> vars)
+        => key => vars.TryGetValue(key, out var v) ? v : null;
+
+    [Fact]
+    public void Windows_Config_UsesAppData()
+    {
+        var env = Env(new() { ["APPDATA"] = @"C:\Users\ash\AppData\Roaming" });
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.Windows, @"C:\Users\ash", env, App);
+        Assert.Equal(Path.Combine(@"C:\Users\ash\AppData\Roaming", App), dir);
+    }
+
+    [Fact]
+    public void Windows_Config_FallsBackToProfile_WhenAppDataUnset()
+    {
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.Windows, @"C:\Users\ash", Env(new()), App);
+        Assert.Equal(Path.Combine(@"C:\Users\ash", "AppData", "Roaming", App), dir);
+    }
+
+    [Fact]
+    public void Windows_Data_UsesLocalAppData()
+    {
+        var env = Env(new() { ["LOCALAPPDATA"] = @"C:\Users\ash\AppData\Local" });
+        var dir = AppPathResolver.ResolveDataDirectory(OSKind.Windows, @"C:\Users\ash", env, App);
+        Assert.Equal(Path.Combine(@"C:\Users\ash\AppData\Local", App), dir);
+    }
+
+    [Fact]
+    public void MacOS_Config_UsesApplicationSupport()
+    {
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.MacOS, "/Users/ash", Env(new()), App);
+        Assert.Equal(Path.Combine("/Users/ash", "Library", "Application Support", App), dir);
+    }
+
+    [Fact]
+    public void MacOS_Data_SharesApplicationSupport()
+    {
+        var dir = AppPathResolver.ResolveDataDirectory(OSKind.MacOS, "/Users/ash", Env(new()), App);
+        Assert.Equal(Path.Combine("/Users/ash", "Library", "Application Support", App), dir);
+    }
+
+    [Fact]
+    public void Linux_Config_UsesXdgConfigHome_WhenSet()
+    {
+        var env = Env(new() { ["XDG_CONFIG_HOME"] = "/home/ash/.custom-config" });
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.Linux, "/home/ash", env, App);
+        Assert.Equal(Path.Combine("/home/ash/.custom-config", App), dir);
+    }
+
+    [Fact]
+    public void Linux_Config_FallsBackToDotConfig_WhenXdgUnset()
+    {
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.Linux, "/home/ash", Env(new()), App);
+        Assert.Equal(Path.Combine("/home/ash", ".config", App), dir);
+    }
+
+    [Fact]
+    public void Linux_Config_FallsBackToDotConfig_WhenXdgBlank()
+    {
+        var env = Env(new() { ["XDG_CONFIG_HOME"] = "   " });
+        var dir = AppPathResolver.ResolveConfigDirectory(OSKind.Linux, "/home/ash", env, App);
+        Assert.Equal(Path.Combine("/home/ash", ".config", App), dir);
+    }
+
+    [Fact]
+    public void Linux_Data_UsesXdgDataHome_WhenSet()
+    {
+        var env = Env(new() { ["XDG_DATA_HOME"] = "/home/ash/.custom-data" });
+        var dir = AppPathResolver.ResolveDataDirectory(OSKind.Linux, "/home/ash", env, App);
+        Assert.Equal(Path.Combine("/home/ash/.custom-data", App), dir);
+    }
+
+    [Fact]
+    public void Linux_Data_FallsBackToLocalShare_WhenXdgUnset()
+    {
+        var dir = AppPathResolver.ResolveDataDirectory(OSKind.Linux, "/home/ash", Env(new()), App);
+        Assert.Equal(Path.Combine("/home/ash", ".local", "share", App), dir);
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/FakeSettingsStore.cs
+++ b/Tests/PKHeX.Avalonia.Tests/FakeSettingsStore.cs
@@ -1,0 +1,11 @@
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>In-memory <see cref="ISettingsStore"/> for tests that don't exercise persistence.</summary>
+internal sealed class FakeSettingsStore : ISettingsStore
+{
+    public AppSettings? Saved { get; private set; }
+    public AppSettings ToLoad { get; set; } = new();
+
+    public AppSettings Load() => ToLoad;
+    public void Save(AppSettings settings) => Saved = settings;
+}

--- a/Tests/PKHeX.Avalonia.Tests/SettingsStoreTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SettingsStoreTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using PKHeX.Infrastructure.Configuration;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Covers the persistence behaviour required by issue #138: round-trip, one-time legacy migration,
+/// corrupt-file recovery, and forward-compatible unknown-field handling. Uses a throwaway temp
+/// directory so nothing touches the real user config location.
+/// </summary>
+public sealed class SettingsStoreTests : IDisposable
+{
+    private readonly string _root;
+    private readonly TempAppPaths _paths;
+
+    public SettingsStoreTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "pkhex-settings-tests-" + Guid.NewGuid().ToString("N"));
+        var configDir = Path.Combine(_root, "config");
+        var dataDir = Path.Combine(_root, "data");
+        var exeDir = Path.Combine(_root, "exe");
+        Directory.CreateDirectory(exeDir);
+        _paths = new TempAppPaths
+        {
+            ConfigDirectory = configDir,
+            DataDirectory = dataDir,
+            ConfigFilePath = Path.Combine(configDir, "config.json"),
+            LegacyConfigFilePath = Path.Combine(exeDir, "config.json"),
+        };
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private SettingsStore NewStore() => new(_paths);
+
+    [Fact]
+    public void Load_WhenNoFile_ReturnsDefaults()
+    {
+        var settings = NewStore().Load();
+
+        Assert.NotNull(settings);
+        Assert.Equal("en", settings.DisplayLanguage);
+        Assert.False(File.Exists(_paths.ConfigFilePath)); // load must not create a file
+    }
+
+    [Fact]
+    public void Save_CreatesDirectoryAndFile()
+    {
+        var store = NewStore();
+        store.Save(new AppSettings { DisplayLanguage = "fr" });
+
+        Assert.True(File.Exists(_paths.ConfigFilePath));
+    }
+
+    [Fact]
+    public void SaveThenLoad_RoundTripsChangedValues()
+    {
+        var store = NewStore();
+        var toSave = new AppSettings { DisplayLanguage = "de" };
+        toSave.Startup.ForceHaXOnLaunch = true;
+        toSave.Startup.RecentlyLoaded.Add("/tmp/recent.sav");
+        store.Save(toSave);
+
+        var loaded = NewStore().Load();
+
+        Assert.Equal("de", loaded.DisplayLanguage);
+        Assert.True(loaded.Startup.ForceHaXOnLaunch);
+        Assert.Contains("/tmp/recent.sav", loaded.Startup.RecentlyLoaded);
+    }
+
+    [Fact]
+    public void Migration_ImportsLegacyConfig_WhenTargetMissing()
+    {
+        File.WriteAllText(_paths.LegacyConfigFilePath, "{ \"DisplayLanguage\": \"it\" }");
+
+        var loaded = NewStore().Load();
+
+        Assert.Equal("it", loaded.DisplayLanguage);
+        Assert.True(File.Exists(_paths.ConfigFilePath), "legacy config should have been copied to the new location");
+        Assert.True(File.Exists(_paths.LegacyConfigFilePath), "legacy config must be left in place, not moved");
+    }
+
+    [Fact]
+    public void Migration_HappensOnce_LegacyIgnoredAfterImport()
+    {
+        // First run migrates the legacy file.
+        File.WriteAllText(_paths.LegacyConfigFilePath, "{ \"DisplayLanguage\": \"it\" }");
+        Assert.Equal("it", NewStore().Load().DisplayLanguage);
+
+        // Simulate the user changing settings (new file) and a stale legacy file changing too.
+        File.WriteAllText(_paths.ConfigFilePath, "{ \"DisplayLanguage\": \"ja\" }");
+        File.WriteAllText(_paths.LegacyConfigFilePath, "{ \"DisplayLanguage\": \"ko\" }");
+
+        // Second run must read the new file and ignore the legacy one entirely.
+        Assert.Equal("ja", NewStore().Load().DisplayLanguage);
+    }
+
+    [Fact]
+    public void Load_CorruptFile_ReturnsDefaults_AndPreservesBak()
+    {
+        Directory.CreateDirectory(_paths.ConfigDirectory);
+        const string garbage = "{ this is not valid json ]";
+        File.WriteAllText(_paths.ConfigFilePath, garbage);
+
+        var loaded = NewStore().Load(); // must not throw
+
+        Assert.Equal("en", loaded.DisplayLanguage); // defaults
+        var bak = _paths.ConfigFilePath + ".bak";
+        Assert.True(File.Exists(bak), "corrupt file should be preserved as .bak");
+        Assert.Equal(garbage, File.ReadAllText(bak));
+        Assert.False(File.Exists(_paths.ConfigFilePath), "corrupt file should have been moved aside");
+    }
+
+    [Fact]
+    public void Load_UnknownJsonFields_AreTolerated()
+    {
+        Directory.CreateDirectory(_paths.ConfigDirectory);
+        File.WriteAllText(_paths.ConfigFilePath,
+            "{ \"DisplayLanguage\": \"es\", \"FutureFeature\": { \"enabled\": true }, \"AnotherNewKey\": 42 }");
+
+        var loaded = NewStore().Load(); // must not throw on unknown keys
+
+        Assert.Equal("es", loaded.DisplayLanguage);
+    }
+
+    [Fact]
+    public void Save_PreservesUnknownTopLevelFields_ForForwardCompat()
+    {
+        Directory.CreateDirectory(_paths.ConfigDirectory);
+        File.WriteAllText(_paths.ConfigFilePath,
+            "{ \"DisplayLanguage\": \"es\", \"FutureFeature\": { \"enabled\": true } }");
+
+        var store = NewStore();
+        var loaded = store.Load();
+        store.Save(loaded); // an older version re-saving must not drop the newer version's key
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(_paths.ConfigFilePath));
+        Assert.True(doc.RootElement.TryGetProperty("FutureFeature", out var future));
+        Assert.True(future.GetProperty("enabled").GetBoolean());
+    }
+
+    private sealed class TempAppPaths : IAppPaths
+    {
+        public required string ConfigDirectory { get; init; }
+        public required string DataDirectory { get; init; }
+        public required string ConfigFilePath { get; init; }
+        public required string LegacyConfigFilePath { get; init; }
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -40,6 +40,7 @@ public class ShowdownIntegrationTests : IDisposable
             _clipboardServiceMock.Object,
             new Mock<IQrCodeService>().Object,
             new AppSettings(),
+            new FakeSettingsStore(),
             new UndoRedoService(),
             new LanguageService()
         );

--- a/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
@@ -125,7 +125,7 @@ public class SpriteStyleTests
     {
         // Proves the new Sprites card wires up at runtime: the XAML resource (converter),
         // the ComboBox ItemsSource, and the SelectedItem binding.
-        var vm = new SettingsViewModel(new AppSettings());
+        var vm = new SettingsViewModel(new AppSettings(), new FakeSettingsStore());
         var view = new SettingsView { DataContext = vm };
         var window = new Window { Content = view, Width = 480, Height = 720 };
         window.Show();


### PR DESCRIPTION
## Summary

Moves `config.json` out of the executable directory into platform-standard per-user config locations, fixing settings loss on macOS translocated apps, read-only AppImage mounts, Program Files installs, and directory-replacing updates. Unblocks #130 (installers) and #135 (backups), which need a stable per-user data home.

### Design

**PKHeX.Application (ports + model)**
- `IAppPaths` — port exposing `ConfigDirectory`, `DataDirectory`, `ConfigFilePath`, `LegacyConfigFilePath`. Keeps OS/filesystem knowledge out of the inner layers.
- `ISettingsStore` — port for `Load()` / `Save(AppSettings)`; owns migration, recovery, and forward-compat.
- `AppSettings` is now a pure POCO (file IO removed) with a top-level `[JsonExtensionData]` bucket so unknown keys from newer versions survive round-trips.

**PKHeX.Infrastructure (implementations)**
- `AppPathResolver` — pure, side-effect-free per-platform resolution. OS/home/env are explicit inputs, so every platform is unit-testable on any host.
- `AppPaths` — binds the resolver to the live OS/environment; legacy path is `AppContext.BaseDirectory/config.json`.
- `SettingsStore` — JSON persistence with **atomic writes** (temp file + swap), **copy-based one-time migration** (legacy file left in place, ignored thereafter), and **corrupt→`.bak` recovery** (unreadable file renamed to `.bak` with a logged warning, defaults returned, never throws).

Wired through DI (`AddInfrastructure`), the `App` composition root, `MainWindowViewModel`, and `SettingsViewModel`.

### Platform paths

| Platform | Config | Data |
|----------|--------|------|
| macOS | `~/Library/Application Support/PKHeX-Avalonia` | `~/Library/Application Support/PKHeX-Avalonia` |
| Windows | `%APPDATA%\PKHeX-Avalonia` | `%LOCALAPPDATA%\PKHeX-Avalonia` |
| Linux | `$XDG_CONFIG_HOME/PKHeX-Avalonia` (fallback `~/.config/PKHeX-Avalonia`) | `$XDG_DATA_HOME/PKHeX-Avalonia` (fallback `~/.local/share/PKHeX-Avalonia`) |

### Verification

- **Build:** `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors.
- **Tests:** `dotnet test PKHeX.sln -c Release` — all green. Architecture 5, Core 449 (+1 pre-existing skip), Avalonia 1937 including the 18 new tests added here (10 `AppPathResolverTests` covering per-platform resolution + fallbacks, 8 `SettingsStoreTests` covering round-trip, migration incl. happens-once, corrupt→`.bak` recovery, and unknown-field tolerance/preservation).

### Caveats

- **AppImage & macOS translocation:** verified by design and unit tests only. The acceptance criteria ask for verification inside a real AppImage and a translocated macOS run; that needs a packaged build and manual runtime testing, which is not done here. By construction nothing is ever written next to the executable, so it should hold.
- **Nested unknown JSON fields are tolerated but dropped on re-save.** Forward-compat is lossless only at the **top level** (`[JsonExtensionData]` on `AppSettings`). Unknown keys inside nested settings groups are dropped on re-save, because those nested types live in the PKHeX.Core 1:1 upstream mirror and cannot be annotated. New top-level setting groups — the most likely forward-compat scenario — round-trip losslessly.

UIVersion 1.25.3 → 1.26.0.

Closes #138
