### PR TITLE
feat: in-app update checker with changelog (#131)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.26.0</UIVersion>
+    <UIVersion>1.27.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IUpdateCheckService.cs
+++ b/PKHeX.Application/Abstractions/IUpdateCheckService.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// Fetches release metadata for the update checker. Implemented in the Infrastructure layer
+/// (an HTTP call to the GitHub Releases API); keeping this as a port lets the Application and
+/// Presentation layers stay free of networking concerns, and lets tests substitute a fake.
+/// </summary>
+public interface IUpdateCheckService
+{
+    /// <summary>
+    /// Returns all published (non-draft) releases for the app's repository, or <see langword="null"/>
+    /// if the check could not complete (offline, rate-limited, timed out, malformed response, etc.).
+    /// Callers must treat <see langword="null"/> as "stay silent" — no error dialog, just a log entry.
+    /// </summary>
+    Task<IReadOnlyList<ReleaseInfo>?> GetReleasesAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>A single GitHub release, trimmed to what the update notification/changelog need.</summary>
+public sealed record ReleaseInfo(
+    string TagName, string Name, string Body, string HtmlUrl, bool Prerelease, IReadOnlyList<ReleaseAsset> Assets);
+
+/// <summary>A downloadable file attached to a GitHub release (e.g. a per-platform zip).</summary>
+public sealed record ReleaseAsset(string Name, string BrowserDownloadUrl);

--- a/PKHeX.Application/Services/AppSettings.cs
+++ b/PKHeX.Application/Services/AppSettings.cs
@@ -52,6 +52,16 @@ public sealed class AppSettings : IProgramSettings
         public string Version { get; set; } = string.Empty;
         public bool ShowChangelogOnUpdate { get; set; } = true;
         public bool ForceHaXOnLaunch { get; set; } = false;
+
+        /// <summary>Whether to query the GitHub Releases API for a newer version at startup.</summary>
+        public bool CheckForUpdatesOnStartup { get; set; } = true;
+
+        /// <summary>
+        /// Release tag (e.g. "1.26.0") the user chose to skip via "Skip this version" on the update
+        /// notification. Suppresses the notification for that exact version only — a later release
+        /// will notify again.
+        /// </summary>
+        public string SkippedUpdateVersion { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/PKHeX.Application/Services/AssetSelector.cs
+++ b/PKHeX.Application/Services/AssetSelector.cs
@@ -1,0 +1,69 @@
+using PKHeX.Application.Abstractions;
+
+namespace PKHeX.Application.Services;
+
+/// <summary>
+/// Pure logic for picking the release asset that matches the running OS/architecture (e.g. an
+/// asset named "PKHeX-Avalonia-win-x64.zip" for a Windows x64 install). Takes plain os/arch
+/// strings rather than querying the platform itself, so it can be unit tested without a real
+/// OS/architecture and without any I/O.
+/// </summary>
+public static class AssetSelector
+{
+    private static readonly (string Canonical, string[] Aliases)[] OsTokens =
+    [
+        ("windows", ["windows", "win", "win64", "win32"]),
+        ("macos", ["macos", "osx", "mac", "darwin"]),
+        ("linux", ["linux"]),
+    ];
+
+    private static readonly (string Canonical, string[] Aliases)[] ArchTokens =
+    [
+        ("arm64", ["arm64", "aarch64"]),
+        ("x64", ["x64", "amd64", "x86_64", "x86-64"]),
+        ("x86", ["x86", "win32", "i386", "i686"]),
+    ];
+
+    /// <summary>
+    /// Returns the asset whose file name best matches <paramref name="os"/> and <paramref name="arch"/>,
+    /// or <see langword="null"/> if no asset matches. Prefers an asset that matches both OS and
+    /// architecture; falls back to an OS-only match (common for single-architecture builds, or
+    /// platforms where the asset name omits the architecture) when no exact combination exists.
+    /// </summary>
+    public static ReleaseAsset? SelectAsset(IEnumerable<ReleaseAsset> assets, string? os, string? arch)
+    {
+        var osAliases = ResolveAliases(OsTokens, os);
+        if (osAliases.Length == 0)
+            return null;
+
+        var list = assets as IReadOnlyList<ReleaseAsset> ?? assets.ToList();
+        var archAliases = ResolveAliases(ArchTokens, arch);
+
+        if (archAliases.Length > 0)
+        {
+            var exact = list.FirstOrDefault(a => ContainsAny(a.Name, osAliases) && ContainsAny(a.Name, archAliases));
+            if (exact is not null)
+                return exact;
+        }
+
+        return list.FirstOrDefault(a => ContainsAny(a.Name, osAliases));
+    }
+
+    private static string[] ResolveAliases((string Canonical, string[] Aliases)[] table, string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return [];
+
+        foreach (var (canonical, aliases) in table)
+        {
+            if (string.Equals(canonical, value, StringComparison.OrdinalIgnoreCase)
+                || aliases.Any(a => string.Equals(a, value, StringComparison.OrdinalIgnoreCase)))
+                return aliases;
+        }
+
+        return [];
+    }
+
+    private static bool ContainsAny(string name, IEnumerable<string> tokens) =>
+        tokens.Any(t => name.Contains(t, StringComparison.OrdinalIgnoreCase));
+}

--- a/PKHeX.Application/Services/SemanticVersion.cs
+++ b/PKHeX.Application/Services/SemanticVersion.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PKHeX.Application.Services;
+
+/// <summary>
+/// Minimal SemVer 2.0.0 parser/comparer (major.minor.patch[-prerelease][+build]). Pure and
+/// dependency-free so it can be unit tested in isolation — used to compare GitHub release tags
+/// (e.g. "v1.26.0", "1.26.0-beta.1") against the running <c>UIVersion</c>.
+/// </summary>
+public readonly struct SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+{
+    private static readonly Regex Pattern = new(
+        @"^[vV]?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<pre>[0-9A-Za-z\-.]+))?(?:\+[0-9A-Za-z\-.]+)?$",
+        RegexOptions.Compiled);
+
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    /// <summary>Dot-separated pre-release identifiers (e.g. ["beta", "1"]). Empty for a stable release.</summary>
+    public IReadOnlyList<string> PreRelease { get; }
+
+    public bool IsPreRelease => PreRelease.Count > 0;
+
+    private SemanticVersion(int major, int minor, int patch, IReadOnlyList<string> preRelease)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreRelease = preRelease;
+    }
+
+    public static bool TryParse(string? input, out SemanticVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+
+        var match = Pattern.Match(input.Trim());
+        if (!match.Success)
+            return false;
+
+        var major = int.Parse(match.Groups["major"].Value);
+        var minor = int.Parse(match.Groups["minor"].Value);
+        var patch = int.Parse(match.Groups["patch"].Value);
+        var preRelease = match.Groups["pre"].Success
+            ? match.Groups["pre"].Value.Split('.')
+            : [];
+
+        version = new SemanticVersion(major, minor, patch, preRelease);
+        return true;
+    }
+
+    public static SemanticVersion Parse(string input)
+    {
+        if (!TryParse(input, out var version))
+            throw new FormatException($"'{input}' is not a valid semantic version.");
+        return version;
+    }
+
+    public int CompareTo(SemanticVersion other)
+    {
+        var major = Major.CompareTo(other.Major);
+        if (major != 0) return major;
+
+        var minor = Minor.CompareTo(other.Minor);
+        if (minor != 0) return minor;
+
+        var patch = Patch.CompareTo(other.Patch);
+        if (patch != 0) return patch;
+
+        // SemVer 2.0.0 precedence rule #11: a stable release outranks a pre-release of the
+        // same major.minor.patch; among two pre-releases, compare identifiers left to right.
+        if (!IsPreRelease && !other.IsPreRelease) return 0;
+        if (!IsPreRelease) return 1;
+        if (!other.IsPreRelease) return -1;
+
+        var count = Math.Min(PreRelease.Count, other.PreRelease.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var cmp = ComparePreReleaseIdentifier(PreRelease[i], other.PreRelease[i]);
+            if (cmp != 0) return cmp;
+        }
+
+        // All shared identifiers equal: the longer set has higher precedence.
+        return PreRelease.Count.CompareTo(other.PreRelease.Count);
+    }
+
+    private static int ComparePreReleaseIdentifier(string a, string b)
+    {
+        var aNumeric = IsNumeric(a);
+        var bNumeric = IsNumeric(b);
+
+        if (aNumeric && bNumeric)
+            return long.Parse(a).CompareTo(long.Parse(b));
+        if (aNumeric) return -1; // numeric identifiers always have lower precedence than alphanumeric
+        if (bNumeric) return 1;
+        return string.CompareOrdinal(a, b);
+    }
+
+    private static bool IsNumeric(string s) => s.Length > 0 && s.All(char.IsAsciiDigit);
+
+    public bool Equals(SemanticVersion other) => CompareTo(other) == 0;
+    public override bool Equals(object? obj) => obj is SemanticVersion other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Major, Minor, Patch);
+
+    public override string ToString() =>
+        IsPreRelease ? $"{Major}.{Minor}.{Patch}-{string.Join('.', PreRelease)}" : $"{Major}.{Minor}.{Patch}";
+
+    public static bool operator ==(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) == 0;
+    public static bool operator !=(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) != 0;
+    public static bool operator <(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) < 0;
+    public static bool operator >(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) > 0;
+    public static bool operator <=(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) <= 0;
+    public static bool operator >=(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) >= 0;
+}

--- a/PKHeX.Application/Services/UpdateAvailabilityEvaluator.cs
+++ b/PKHeX.Application/Services/UpdateAvailabilityEvaluator.cs
@@ -1,0 +1,70 @@
+using PKHeX.Application.Abstractions;
+
+namespace PKHeX.Application.Services;
+
+/// <summary>
+/// Pure decision logic for the update checker: which release is "latest", whether the user should
+/// be notified, and which releases fall between the installed and latest version for changelog
+/// display. No I/O, so it can be unit tested without a mocked network call.
+/// </summary>
+public static class UpdateAvailabilityEvaluator
+{
+    /// <summary>Returns the highest-precedence stable (non-prerelease) release with a parseable tag, or null if none.</summary>
+    public static ReleaseInfo? GetLatestRelease(IEnumerable<ReleaseInfo> releases)
+    {
+        ReleaseInfo? latest = null;
+        var latestVersion = default(SemanticVersion);
+
+        foreach (var release in releases)
+        {
+            if (release.Prerelease)
+                continue;
+            if (!SemanticVersion.TryParse(release.TagName, out var version))
+                continue;
+            if (latest is null || version > latestVersion)
+            {
+                latest = release;
+                latestVersion = version;
+            }
+        }
+
+        return latest;
+    }
+
+    /// <summary>
+    /// True when <paramref name="latestTag"/> is newer than <paramref name="currentVersion"/> and the
+    /// user has not explicitly skipped that version.
+    /// </summary>
+    public static bool ShouldNotify(string currentVersion, string latestTag, string? skippedVersion)
+    {
+        if (!SemanticVersion.TryParse(currentVersion, out var current))
+            return false;
+        if (!SemanticVersion.TryParse(latestTag, out var latest))
+            return false;
+        if (latest <= current)
+            return false;
+        if (!string.IsNullOrEmpty(skippedVersion)
+            && SemanticVersion.TryParse(skippedVersion, out var skipped)
+            && skipped == latest)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>Releases newer than <paramref name="currentVersion"/>, newest first, for changelog display.</summary>
+    public static IReadOnlyList<ReleaseInfo> GetReleasesNewerThan(IEnumerable<ReleaseInfo> releases, string currentVersion)
+    {
+        if (!SemanticVersion.TryParse(currentVersion, out var current))
+            return [];
+
+        var newer = new List<(ReleaseInfo Release, SemanticVersion Version)>();
+        foreach (var release in releases)
+        {
+            if (SemanticVersion.TryParse(release.TagName, out var version) && version > current)
+                newer.Add((release, version));
+        }
+
+        newer.Sort((a, b) => b.Version.CompareTo(a.Version));
+        return newer.Select(x => x.Release).ToList();
+    }
+}

--- a/PKHeX.Avalonia/App.axaml.cs
+++ b/PKHeX.Avalonia/App.axaml.cs
@@ -32,10 +32,15 @@ public partial class App : global::Avalonia.Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            var mainViewModel = Services.GetRequiredService<MainWindowViewModel>();
             desktop.MainWindow = new MainWindow
             {
-                DataContext = Services.GetRequiredService<MainWindowViewModel>()
+                DataContext = mainViewModel
             };
+
+            // Fire-and-forget: never awaited here, so the main window is shown immediately and is
+            // never blocked by a slow, offline, or rate-limited GitHub API call.
+            _ = mainViewModel.CheckForUpdatesAsync();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -109,6 +109,7 @@ public static class ViewLocator
         [typeof(Underground8bEditorViewModel)] = () => new Underground8bEditor(),
         [typeof(UndergroundEditorViewModel)] = () => new UndergroundEditor(),
         [typeof(UnityTower5EditorViewModel)] = () => new UnityTower5Editor(),
+        [typeof(UpdateChangelogViewModel)] = () => new UpdateChangelogView(),
         [typeof(ZygardeCellEditorViewModel)] = () => new ZygardeCellEditor(),
     };
 

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -155,14 +155,31 @@
         </Menu>
 
         <!-- Status Bar - Themed -->
-        <Border DockPanel.Dock="Bottom" 
-                Background="{DynamicResource ThemeBackgroundCardBrush}" 
+        <Border DockPanel.Dock="Bottom"
+                Background="{DynamicResource ThemeBackgroundCardBrush}"
                 BorderBrush="{DynamicResource ThemeBorderDefaultBrush}"
                 BorderThickness="0,1,0,0"
                 Padding="12,6">
-            <TextBlock Text="{Binding CurrentSave.Version, StringFormat='Game: {0}', FallbackValue='No save loaded'}" 
-                       Foreground="{DynamicResource ThemeTextSecondaryBrush}"
-                       FontSize="12" />
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Grid.Column="0"
+                           Text="{Binding CurrentSave.Version, StringFormat='Game: {0}', FallbackValue='No save loaded'}"
+                           Foreground="{DynamicResource ThemeTextSecondaryBrush}"
+                           FontSize="12" />
+
+                <!-- Non-intrusive update notification: only visible when a newer, non-skipped release exists. -->
+                <Border Grid.Column="1" x:CompileBindings="False"
+                        IsVisible="{Binding UpdateNotification, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <StackPanel Orientation="Horizontal" Spacing="8" DataContext="{Binding UpdateNotification}">
+                        <TextBlock Text="{Binding Message}"
+                                   Foreground="{DynamicResource ThemeAccentBrush}"
+                                   FontSize="12" VerticalAlignment="Center" />
+                        <Button Content="What's New" Command="{Binding ShowChangelogCommand}" Padding="8,2" FontSize="11" />
+                        <Button Content="Download" Command="{Binding DownloadCommand}" Padding="8,2" FontSize="11" />
+                        <Button Content="Skip" Command="{Binding SkipCommand}" Padding="8,2" FontSize="11" />
+                        <Button Content="✕" Command="{Binding DismissCommand}" Padding="6,2" FontSize="11" />
+                    </StackPanel>
+                </Border>
+            </Grid>
         </Border>
 
         <!-- Main Content -->

--- a/PKHeX.Avalonia/Views/SettingsView.axaml
+++ b/PKHeX.Avalonia/Views/SettingsView.axaml
@@ -96,8 +96,36 @@
                 </StackPanel>
             </Border>
 
+            <!-- Updates Settings Card -->
+            <Border Classes="section-card" Padding="20" CornerRadius="8">
+                <StackPanel Spacing="16">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <TextBlock Text="🔔" FontSize="20" VerticalAlignment="Center"/>
+                        <TextBlock Text="Updates" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Check for Updates on Startup" FontWeight="Medium"/>
+                            <TextBlock Text="Query GitHub for a newer release when the app launches. Disabling this makes zero network calls at startup."
+                                       FontSize="12" Opacity="0.6" TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <ToggleSwitch Grid.Column="1" IsChecked="{Binding CheckForUpdatesOnStartup}" OnContent="On" OffContent="Off"/>
+                    </Grid>
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Show Changelog after Update" FontWeight="Medium"/>
+                            <TextBlock Text="Automatically show the 'What's New' dialog the first time you launch a newer version."
+                                       FontSize="12" Opacity="0.6" TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <ToggleSwitch Grid.Column="1" IsChecked="{Binding ShowChangelog}" OnContent="On" OffContent="Off"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
             <Button Content="Save Changes"
-                    Command="{Binding SaveCommand}" 
+                    Command="{Binding SaveCommand}"
                     Classes="accent"
                     HorizontalAlignment="Right" 
                     Padding="24,12"/>

--- a/PKHeX.Avalonia/Views/UpdateChangelogView.axaml
+++ b/PKHeX.Avalonia/Views/UpdateChangelogView.axaml
@@ -1,0 +1,38 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             x:Class="PKHeX.Avalonia.Views.UpdateChangelogView"
+             x:DataType="vm:UpdateChangelogViewModel"
+             Width="520" Height="480">
+    <Border Padding="24" Classes="view-container">
+        <DockPanel>
+            <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,12">
+                <TextBlock Text="What's New" FontSize="22" FontWeight="Bold" />
+                <TextBlock Text="{Binding LatestVersion, StringFormat='Latest version: {0}'}"
+                           Opacity="0.7" FontSize="12" />
+            </StackPanel>
+
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8"
+                        HorizontalAlignment="Right" Margin="0,12,0,0">
+                <Button Content="View Release Page" Command="{Binding OpenReleasePageCommand}" />
+                <Button Content="Download" Command="{Binding DownloadCommand}" Classes="accent" />
+                <Button Content="Close" Command="{Binding CloseCommand}" />
+            </StackPanel>
+
+            <ScrollViewer>
+                <ItemsControl ItemsSource="{Binding Releases}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:ReleaseNoteViewModel">
+                            <Border Classes="section-card" Padding="16" CornerRadius="8" Margin="0,0,0,12">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="15" />
+                                    <TextBlock Text="{Binding Body}" TextWrapping="Wrap" FontSize="12" Opacity="0.85" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/PKHeX.Avalonia/Views/UpdateChangelogView.axaml.cs
+++ b/PKHeX.Avalonia/Views/UpdateChangelogView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class UpdateChangelogView : UserControl
+{
+    public UpdateChangelogView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Infrastructure/DependencyInjection.cs
+++ b/PKHeX.Infrastructure/DependencyInjection.cs
@@ -12,6 +12,7 @@ public static class DependencyInjection
         services.AddSingleton<ISaveFileGateway, SaveFileService>();
         services.AddSingleton<IAppPaths, AppPaths>();
         services.AddSingleton<ISettingsStore, SettingsStore>();
+        services.AddSingleton<IUpdateCheckService, GitHubUpdateCheckService>();
         return services;
     }
 }

--- a/PKHeX.Infrastructure/GitHubUpdateCheckService.cs
+++ b/PKHeX.Infrastructure/GitHubUpdateCheckService.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using PKHeX.Application.Abstractions;
+
+namespace PKHeX.Infrastructure;
+
+/// <summary>
+/// Queries the GitHub Releases API for realgarit/PKHeX-Avalonia. Any failure (offline, DNS,
+/// timeout, rate limit, malformed JSON) is caught and logged — never surfaced to the caller as an
+/// exception — so a failed startup check never blocks or interrupts the user.
+/// </summary>
+public sealed class GitHubUpdateCheckService : IUpdateCheckService
+{
+    private const string ReleasesUrl = "https://api.github.com/repos/realgarit/PKHeX-Avalonia/releases";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _client;
+
+    public GitHubUpdateCheckService() : this(CreateDefaultClient())
+    {
+    }
+
+    // Internal for testability: lets tests inject a client with a fake handler instead of hitting the network.
+    internal GitHubUpdateCheckService(HttpClient client)
+    {
+        _client = client;
+    }
+
+    private static HttpClient CreateDefaultClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PKHeX-Avalonia-UpdateChecker", "1.0"));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        return client;
+    }
+
+    public async Task<IReadOnlyList<ReleaseInfo>?> GetReleasesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _client.GetAsync(ReleasesUrl, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                Trace.TraceWarning($"Update check failed: GitHub API returned {(int)response.StatusCode} {response.StatusCode}.");
+                return null;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            var releases = await JsonSerializer.DeserializeAsync<List<GitHubRelease>>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+            if (releases is null)
+                return null;
+
+            return releases
+                .Where(r => !r.Draft)
+                .Select(r => new ReleaseInfo(
+                    r.TagName ?? string.Empty,
+                    string.IsNullOrEmpty(r.Name) ? r.TagName ?? string.Empty : r.Name,
+                    r.Body ?? string.Empty,
+                    r.HtmlUrl ?? string.Empty,
+                    r.Prerelease,
+                    (r.Assets ?? [])
+                        .Where(a => !string.IsNullOrEmpty(a.Name) && !string.IsNullOrEmpty(a.BrowserDownloadUrl))
+                        .Select(a => new ReleaseAsset(a.Name!, a.BrowserDownloadUrl!))
+                        .ToList()))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            // Offline, DNS failure, timeout, rate-limit, malformed response, etc. — stay silent, just log.
+            Trace.TraceWarning($"Update check failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    private sealed class GitHubRelease
+    {
+        [JsonPropertyName("tag_name")]
+        public string? TagName { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("body")]
+        public string? Body { get; set; }
+
+        [JsonPropertyName("html_url")]
+        public string? HtmlUrl { get; set; }
+
+        [JsonPropertyName("draft")]
+        public bool Draft { get; set; }
+
+        [JsonPropertyName("prerelease")]
+        public bool Prerelease { get; set; }
+
+        [JsonPropertyName("assets")]
+        public List<GitHubAsset>? Assets { get; set; }
+    }
+
+    private sealed class GitHubAsset
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("browser_download_url")]
+        public string? BrowserDownloadUrl { get; set; }
+    }
+}

--- a/PKHeX.Presentation/ViewModels/CurrentPlatform.cs
+++ b/PKHeX.Presentation/ViewModels/CurrentPlatform.cs
@@ -1,0 +1,24 @@
+using System.Runtime.InteropServices;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Thin, impure wrapper around the running OS/architecture, kept separate from
+/// <see cref="Services.AssetSelector"/> so that asset-matching logic itself stays a pure function
+/// of plain os/arch strings and is testable without depending on the real platform.
+/// </summary>
+internal static class CurrentPlatform
+{
+    public static string Os => OperatingSystem.IsWindows() ? "windows"
+        : OperatingSystem.IsMacOS() ? "macos"
+        : OperatingSystem.IsLinux() ? "linux"
+        : "unknown";
+
+    public static string Arch => RuntimeInformation.ProcessArchitecture switch
+    {
+        Architecture.Arm64 => "arm64",
+        Architecture.X64 => "x64",
+        Architecture.X86 => "x86",
+        var other => other.ToString(),
+    };
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -14,10 +16,14 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly ISlotService _slotService;
     private readonly IClipboardService _clipboardService;
     private readonly IQrCodeService _qrCodeService;
+    private readonly IUpdateCheckService _updateCheckService;
     private readonly AppSettings _settings;
     private readonly ISettingsStore _settingsStore;
     private readonly UndoRedoService _undoRedo;
     private readonly LanguageService _languageService;
+    private readonly string _currentVersion;
+
+    [ObservableProperty] private UpdateNotificationViewModel? _updateNotification;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSave))]
@@ -60,6 +66,7 @@ public partial class MainWindowViewModel : ViewModelBase
         ISlotService slotService,
         IClipboardService clipboardService,
         IQrCodeService qrCodeService,
+        IUpdateCheckService updateCheckService,
         AppSettings settings,
         ISettingsStore settingsStore,
         UndoRedoService undoRedo,
@@ -72,10 +79,12 @@ public partial class MainWindowViewModel : ViewModelBase
         _slotService = slotService;
         _clipboardService = clipboardService;
         _qrCodeService = qrCodeService;
+        _updateCheckService = updateCheckService;
         _settings = settings;
         _settingsStore = settingsStore;
         _undoRedo = undoRedo;
         _languageService = languageService;
+        _currentVersion = GetCurrentVersion();
 
         _saveFileService.SaveFileChanged += OnSaveFileChanged;
         _slotService.ViewRequested += OnViewRequested;
@@ -185,5 +194,65 @@ public partial class MainWindowViewModel : ViewModelBase
                 BatchEditor = null;
             }
         }
+    }
+
+    /// <summary>
+    /// Fire-and-forget from the host at startup (never awaited there, so the main window is never
+    /// blocked). Offline/rate-limited failures resolve to a null release list from
+    /// <see cref="IUpdateCheckService"/> and are handled silently — no error dialog, no retry.
+    /// </summary>
+    public async Task CheckForUpdatesAsync()
+    {
+        var startup = _settings.Startup;
+        var previousVersion = startup.Version;
+        var showChangelogOnUpgrade = startup.ShowChangelogOnUpdate
+            && SemanticVersion.TryParse(previousVersion, out var previous)
+            && SemanticVersion.TryParse(_currentVersion, out var current)
+            && current > previous;
+
+        // Record that this version has now been run, so the "just upgraded" changelog fires only once.
+        if (!string.Equals(previousVersion, _currentVersion, StringComparison.Ordinal))
+        {
+            startup.Version = _currentVersion;
+            _settingsStore.Save(_settings);
+        }
+
+        if (!startup.CheckForUpdatesOnStartup)
+            return; // Settings toggle disabled: zero network calls.
+
+        var releases = await _updateCheckService.GetReleasesAsync();
+        if (releases is null || releases.Count == 0)
+            return; // Offline/rate-limited/malformed — already logged by the service; stay silent.
+
+        if (showChangelogOnUpgrade)
+        {
+            var upgradeNotes = UpdateAvailabilityEvaluator.GetReleasesNewerThan(releases, previousVersion);
+            if (upgradeNotes.Count > 0)
+                await _windowService.ShowDialogAsync(new UpdateChangelogViewModel(upgradeNotes), "What's New");
+        }
+
+        var latest = UpdateAvailabilityEvaluator.GetLatestRelease(releases);
+        if (latest is null)
+            return;
+        if (!UpdateAvailabilityEvaluator.ShouldNotify(_currentVersion, latest.TagName, startup.SkippedUpdateVersion))
+            return;
+
+        var newerReleases = UpdateAvailabilityEvaluator.GetReleasesNewerThan(releases, _currentVersion);
+        var notification = new UpdateNotificationViewModel(
+            newerReleases.Count > 0 ? newerReleases : [latest], _windowService, _settings, _settingsStore);
+        notification.Dismissed += () => UpdateNotification = null;
+        UpdateNotification = notification;
+    }
+
+    private static string GetCurrentVersion()
+    {
+        // Looked up by assembly name so this Presentation-layer type never references the host
+        // assembly directly (same trick used by AboutViewModel).
+        var asm = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, "PKHeX.Avalonia", StringComparison.Ordinal));
+        var version = asm?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                      ?? asm?.GetName().Version?.ToString(3)
+                      ?? "0.0.0";
+        return version.Contains('+') ? version[..version.IndexOf('+')] : version;
     }
 }

--- a/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
@@ -29,6 +29,7 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
 
     [ObservableProperty] private bool _forceHaX;
     [ObservableProperty] private bool _showChangelog;
+    [ObservableProperty] private bool _checkForUpdatesOnStartup;
 
     // Backup
     [ObservableProperty] private bool _bakEnabled;
@@ -50,6 +51,7 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
         AutoLoadMode = _settings.Startup.AutoLoadSaveOnStartup;
         ForceHaX = _settings.Startup.ForceHaXOnLaunch;
         ShowChangelog = _settings.Startup.ShowChangelogOnUpdate;
+        CheckForUpdatesOnStartup = _settings.Startup.CheckForUpdatesOnStartup;
 
         BakEnabled = _settings.Backup.BAKEnabled;
         BakPrompt = _settings.Backup.BAKPrompt;
@@ -69,6 +71,7 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
         _settings.Startup.AutoLoadSaveOnStartup = AutoLoadMode;
         _settings.Startup.ForceHaXOnLaunch = ForceHaX;
         _settings.Startup.ShowChangelogOnUpdate = ShowChangelog;
+        _settings.Startup.CheckForUpdatesOnStartup = CheckForUpdatesOnStartup;
 
         _settings.Backup.BAKEnabled = BakEnabled;
         _settings.Backup.BAKPrompt = BakPrompt;

--- a/PKHeX.Presentation/ViewModels/UpdateChangelogViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/UpdateChangelogViewModel.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Services;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// "What's new" dialog: renders the release notes for every version between the installed build
+/// and the latest one, with a link to the release page for full details/assets.
+/// </summary>
+public partial class UpdateChangelogViewModel : ViewModelBase, ICloseableDialog
+{
+    private readonly IReadOnlyList<ReleaseInfo> _releasesNewestFirst;
+
+    public Action? CloseRequested { get; set; }
+
+    public IReadOnlyList<ReleaseNoteViewModel> Releases { get; }
+
+    public string LatestVersion { get; }
+    public string LatestReleaseUrl { get; }
+
+    public UpdateChangelogViewModel(IReadOnlyList<ReleaseInfo> releasesNewestFirst)
+    {
+        _releasesNewestFirst = releasesNewestFirst;
+
+        Releases = releasesNewestFirst
+            .Select(r => new ReleaseNoteViewModel(r.TagName, r.Name, r.Body, r.HtmlUrl))
+            .ToList();
+
+        var latest = releasesNewestFirst.Count > 0 ? releasesNewestFirst[0] : null;
+        LatestVersion = latest?.TagName ?? string.Empty;
+        LatestReleaseUrl = latest?.HtmlUrl ?? string.Empty;
+    }
+
+    [RelayCommand]
+    private void OpenReleasePage()
+    {
+        OpenUrl(LatestReleaseUrl);
+    }
+
+    [RelayCommand]
+    private void Download()
+    {
+        DownloadLatestRelease(_releasesNewestFirst);
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        CloseRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// Opens the release asset matching the current OS/architecture (see <see cref="AssetSelector"/>),
+    /// falling back to the release page itself when no asset matches (e.g. a release with no
+    /// binaries attached, or an unrecognized platform). Shared by the changelog dialog and the
+    /// status-bar notification so both "Download" actions behave identically.
+    /// </summary>
+    internal static void DownloadLatestRelease(IReadOnlyList<ReleaseInfo> releasesNewestFirst)
+    {
+        if (releasesNewestFirst.Count == 0)
+            return;
+
+        var latest = releasesNewestFirst[0];
+        var asset = AssetSelector.SelectAsset(latest.Assets, CurrentPlatform.Os, CurrentPlatform.Arch);
+        OpenUrl(asset?.BrowserDownloadUrl ?? latest.HtmlUrl);
+    }
+
+    internal static void OpenUrl(string url)
+    {
+        if (string.IsNullOrEmpty(url))
+            return;
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            else if (OperatingSystem.IsMacOS())
+                Process.Start("open", url);
+            else if (OperatingSystem.IsLinux())
+                Process.Start("xdg-open", url);
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceWarning($"Failed to open release/asset URL '{url}': {ex.Message}");
+        }
+    }
+}
+
+/// <summary>A single release's notes, formatted for display in the changelog dialog.</summary>
+public sealed class ReleaseNoteViewModel(string tagName, string name, string body, string htmlUrl)
+{
+    public string TagName { get; } = tagName;
+    public string Name { get; } = name;
+    public string Body { get; } = body;
+    public string HtmlUrl { get; } = htmlUrl;
+}

--- a/PKHeX.Presentation/ViewModels/UpdateNotificationViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/UpdateNotificationViewModel.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Services;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Backs the non-intrusive "update available" status-bar item. Created only when
+/// <see cref="UpdateAvailabilityEvaluator.ShouldNotify"/> says a newer, non-skipped release exists;
+/// null/absent otherwise, so the status bar shows nothing on a normal launch.
+/// </summary>
+public partial class UpdateNotificationViewModel : ViewModelBase
+{
+    private readonly IReadOnlyList<ReleaseInfo> _releasesNewestFirst;
+    private readonly IWindowService _windowService;
+    private readonly AppSettings _settings;
+    private readonly ISettingsStore _settingsStore;
+
+    public string LatestVersion { get; }
+    public string Message => $"Update available: v{LatestVersion}";
+
+    /// <summary>Raised when the notification should be removed from the status bar (dismissed or skipped).</summary>
+    public event Action? Dismissed;
+
+    public UpdateNotificationViewModel(
+        IReadOnlyList<ReleaseInfo> releasesNewestFirst, IWindowService windowService, AppSettings settings, ISettingsStore settingsStore)
+    {
+        _releasesNewestFirst = releasesNewestFirst;
+        _windowService = windowService;
+        _settings = settings;
+        _settingsStore = settingsStore;
+        LatestVersion = releasesNewestFirst.Count > 0 ? releasesNewestFirst[0].TagName.TrimStart('v', 'V') : string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task ShowChangelog()
+    {
+        var changelog = new UpdateChangelogViewModel(_releasesNewestFirst);
+        await _windowService.ShowDialogAsync(changelog, "What's New");
+    }
+
+    [RelayCommand]
+    private void Download()
+    {
+        UpdateChangelogViewModel.DownloadLatestRelease(_releasesNewestFirst);
+    }
+
+    [RelayCommand]
+    private void Skip()
+    {
+        _settings.Startup.SkippedUpdateVersion = LatestVersion;
+        _settingsStore.Save(_settings);
+        Dismissed?.Invoke();
+    }
+
+    [RelayCommand]
+    private void Dismiss()
+    {
+        Dismissed?.Invoke();
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -39,6 +39,7 @@ public class ShowdownIntegrationTests : IDisposable
             _slotServiceMock.Object,
             _clipboardServiceMock.Object,
             new Mock<IQrCodeService>().Object,
+            new Mock<IUpdateCheckService>().Object,
             new AppSettings(),
             new FakeSettingsStore(),
             new UndoRedoService(),

--- a/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,345 @@
+using System.Threading;
+using Moq;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("v1.2.3")]
+    [InlineData("V1.2.3")]
+    [InlineData("1.2.3-beta.1")]
+    [InlineData("1.2.3+build.5")]
+    [InlineData("1.2.3-beta.1+build.5")]
+    public void TryParse_accepts_valid_versions(string input)
+    {
+        Assert.True(SemanticVersion.TryParse(input, out _));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-a-version")]
+    [InlineData("1.2")]
+    [InlineData("1")]
+    public void TryParse_rejects_invalid_versions(string? input)
+    {
+        Assert.False(SemanticVersion.TryParse(input, out _));
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "2.0.0")]     // major
+    [InlineData("1.1.0", "1.2.0")]     // minor
+    [InlineData("1.1.1", "1.1.2")]     // patch
+    [InlineData("1.0.0-alpha", "1.0.0")] // pre-release < stable
+    [InlineData("1.0.0-alpha", "1.0.0-alpha.1")] // fewer identifiers < more, when equal prefix
+    [InlineData("1.0.0-alpha.1", "1.0.0-alpha.beta")] // numeric identifier < alphanumeric
+    [InlineData("1.0.0-alpha.beta", "1.0.0-beta")]
+    [InlineData("1.0.0-beta", "1.0.0-beta.2")]
+    [InlineData("1.0.0-beta.2", "1.0.0-beta.11")] // numeric comparison, not lexical ("11" > "2")
+    [InlineData("1.0.0-beta.11", "1.0.0-rc.1")]
+    [InlineData("1.0.0-rc.1", "1.0.0")]
+    public void CompareTo_orders_versions_including_prerelease_precedence(string lesser, string greater)
+    {
+        var left = SemanticVersion.Parse(lesser);
+        var right = SemanticVersion.Parse(greater);
+
+        Assert.True(left < right, $"'{lesser}' should sort before '{greater}'");
+        Assert.True(right > left);
+        Assert.False(left == right);
+    }
+
+    [Fact]
+    public void CompareTo_treats_equal_versions_as_equal_regardless_of_v_prefix()
+    {
+        var left = SemanticVersion.Parse("v1.25.3");
+        var right = SemanticVersion.Parse("1.25.3");
+
+        Assert.True(left == right);
+        Assert.Equal(0, left.CompareTo(right));
+    }
+
+    [Fact]
+    public void ToString_round_trips_stable_and_prerelease_versions()
+    {
+        Assert.Equal("1.2.3", SemanticVersion.Parse("1.2.3").ToString());
+        Assert.Equal("1.2.3-beta.1", SemanticVersion.Parse("1.2.3-beta.1").ToString());
+    }
+}
+
+public class UpdateAvailabilityEvaluatorTests
+{
+    private static ReleaseInfo Release(string tag, bool prerelease = false) =>
+        new(tag, $"Release {tag}", $"Notes for {tag}", $"https://example.com/{tag}", prerelease, []);
+
+    [Fact]
+    public void GetLatestRelease_picks_highest_stable_version_and_skips_prereleases()
+    {
+        var releases = new[]
+        {
+            Release("1.0.0"),
+            Release("1.2.0"),
+            Release("2.0.0-beta.1", prerelease: true),
+            Release("1.1.0"),
+        };
+
+        var latest = UpdateAvailabilityEvaluator.GetLatestRelease(releases);
+
+        Assert.NotNull(latest);
+        Assert.Equal("1.2.0", latest!.TagName);
+    }
+
+    [Fact]
+    public void GetLatestRelease_ignores_unparseable_tags()
+    {
+        var releases = new[] { Release("not-a-version"), Release("1.0.0") };
+
+        var latest = UpdateAvailabilityEvaluator.GetLatestRelease(releases);
+
+        Assert.Equal("1.0.0", latest!.TagName);
+    }
+
+    [Fact]
+    public void GetLatestRelease_returns_null_when_no_stable_release_parses()
+    {
+        var releases = new[] { Release("2.0.0-beta.1", prerelease: true), Release("garbage") };
+
+        Assert.Null(UpdateAvailabilityEvaluator.GetLatestRelease(releases));
+    }
+
+    [Theory]
+    [InlineData("1.25.2", "1.25.3", null, true)]   // newer, not skipped -> notify
+    [InlineData("1.25.3", "1.25.3", null, false)]  // same version -> no notify
+    [InlineData("1.25.3", "1.25.2", null, false)]  // current is newer -> no notify
+    [InlineData("1.25.2", "1.25.3", "1.25.3", false)] // newer, but exactly the skipped version -> no notify
+    [InlineData("1.25.2", "1.25.3", "1.25.2", true)]  // an older skip entry does not suppress a newer release
+    public void ShouldNotify_respects_version_ordering_and_skip_list(
+        string current, string latestTag, string? skipped, bool expected)
+    {
+        Assert.Equal(expected, UpdateAvailabilityEvaluator.ShouldNotify(current, latestTag, skipped));
+    }
+
+    [Fact]
+    public void ShouldNotify_treats_a_later_release_as_not_skipped_by_an_older_skip_entry()
+    {
+        // User skipped 1.26.0; a subsequent 1.27.0 release must still notify.
+        Assert.True(UpdateAvailabilityEvaluator.ShouldNotify("1.25.0", "1.27.0", "1.26.0"));
+    }
+
+    [Fact]
+    public void GetReleasesNewerThan_returns_only_newer_releases_ordered_newest_first()
+    {
+        var releases = new[] { Release("1.0.0"), Release("1.2.0"), Release("1.1.0"), Release("0.9.0") };
+
+        var newer = UpdateAvailabilityEvaluator.GetReleasesNewerThan(releases, "1.0.0");
+
+        Assert.Equal(["1.2.0", "1.1.0"], newer.Select(r => r.TagName));
+    }
+
+    [Fact]
+    public void GetReleasesNewerThan_returns_empty_when_current_version_is_unparseable()
+    {
+        var releases = new[] { Release("1.0.0") };
+
+        Assert.Empty(UpdateAvailabilityEvaluator.GetReleasesNewerThan(releases, "not-a-version"));
+    }
+}
+
+public class MainWindowUpdateCheckTests
+{
+    private static ReleaseInfo Release(string tag, bool prerelease = false) =>
+        new(tag, $"Release {tag}", $"Notes for {tag}", $"https://example.com/{tag}", prerelease, []);
+
+    private static MainWindowViewModel CreateViewModel(
+        Mock<IUpdateCheckService> updateCheckServiceMock,
+        Mock<IWindowService> windowServiceMock,
+        AppSettings settings)
+    {
+        return new MainWindowViewModel(
+            new Mock<ISaveFileGateway>().Object,
+            new Mock<IDialogService>().Object,
+            windowServiceMock.Object,
+            new Mock<ISpriteRenderer>().Object,
+            new Mock<ISlotService>().Object,
+            new Mock<IClipboardService>().Object,
+            new Mock<IQrCodeService>().Object,
+            updateCheckServiceMock.Object,
+            settings,
+            new FakeSettingsStore(),
+            new UndoRedoService(),
+            new LanguageService());
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesAsync_does_not_call_the_service_when_disabled_in_settings()
+    {
+        var updateCheckServiceMock = new Mock<IUpdateCheckService>();
+        var windowServiceMock = new Mock<IWindowService>();
+        var settings = new AppSettings();
+        settings.Startup.CheckForUpdatesOnStartup = false;
+
+        var vm = CreateViewModel(updateCheckServiceMock, windowServiceMock, settings);
+        await vm.CheckForUpdatesAsync();
+
+        updateCheckServiceMock.Verify(
+            s => s.GetReleasesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Null(vm.UpdateNotification);
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesAsync_stays_silent_when_the_service_fails()
+    {
+        var updateCheckServiceMock = new Mock<IUpdateCheckService>();
+        updateCheckServiceMock
+            .Setup(s => s.GetReleasesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ReleaseInfo>?)null);
+        var windowServiceMock = new Mock<IWindowService>();
+        var settings = new AppSettings();
+
+        var vm = CreateViewModel(updateCheckServiceMock, windowServiceMock, settings);
+        await vm.CheckForUpdatesAsync();
+
+        Assert.Null(vm.UpdateNotification);
+        windowServiceMock.Verify(
+            w => w.ShowDialogAsync(It.IsAny<object>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesAsync_surfaces_a_notification_when_a_newer_release_exists()
+    {
+        var updateCheckServiceMock = new Mock<IUpdateCheckService>();
+        updateCheckServiceMock
+            .Setup(s => s.GetReleasesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ReleaseInfo>?)[Release("99.0.0")]);
+        var windowServiceMock = new Mock<IWindowService>();
+        var settings = new AppSettings();
+
+        var vm = CreateViewModel(updateCheckServiceMock, windowServiceMock, settings);
+        await vm.CheckForUpdatesAsync();
+
+        Assert.NotNull(vm.UpdateNotification);
+        Assert.Equal("99.0.0", vm.UpdateNotification!.LatestVersion);
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesAsync_does_not_notify_for_a_skipped_version()
+    {
+        var updateCheckServiceMock = new Mock<IUpdateCheckService>();
+        updateCheckServiceMock
+            .Setup(s => s.GetReleasesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ReleaseInfo>?)[Release("99.0.0")]);
+        var windowServiceMock = new Mock<IWindowService>();
+        var settings = new AppSettings();
+        settings.Startup.SkippedUpdateVersion = "99.0.0";
+
+        var vm = CreateViewModel(updateCheckServiceMock, windowServiceMock, settings);
+        await vm.CheckForUpdatesAsync();
+
+        Assert.Null(vm.UpdateNotification);
+    }
+
+    [Fact]
+    public async Task Skip_command_persists_the_skipped_version_and_dismisses_the_notification()
+    {
+        var updateCheckServiceMock = new Mock<IUpdateCheckService>();
+        updateCheckServiceMock
+            .Setup(s => s.GetReleasesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ReleaseInfo>?)[Release("99.0.0")]);
+        var windowServiceMock = new Mock<IWindowService>();
+        var settings = new AppSettings();
+
+        var vm = CreateViewModel(updateCheckServiceMock, windowServiceMock, settings);
+        await vm.CheckForUpdatesAsync();
+        Assert.NotNull(vm.UpdateNotification);
+
+        vm.UpdateNotification!.SkipCommand.Execute(null);
+
+        Assert.Equal("99.0.0", settings.Startup.SkippedUpdateVersion);
+        Assert.Null(vm.UpdateNotification);
+    }
+}
+
+public class AssetSelectorTests
+{
+    private static ReleaseAsset Asset(string name) => new(name, $"https://example.com/{name}");
+
+    [Theory]
+    [InlineData("windows", "x64", "PKHeX-Avalonia-win-x64.zip")]
+    [InlineData("macos", "arm64", "PKHeX-Avalonia-osx-arm64.zip")]
+    [InlineData("macos", "x64", "PKHeX-Avalonia-osx-x64.zip")]
+    [InlineData("linux", "x64", "PKHeX-Avalonia-linux-x64.zip")]
+    public void SelectAsset_matches_os_and_architecture(string os, string arch, string expected)
+    {
+        var assets = new[]
+        {
+            Asset("PKHeX-Avalonia-win-x64.zip"),
+            Asset("PKHeX-Avalonia-osx-arm64.zip"),
+            Asset("PKHeX-Avalonia-osx-x64.zip"),
+            Asset("PKHeX-Avalonia-linux-x64.zip"),
+        };
+
+        var selected = AssetSelector.SelectAsset(assets, os, arch);
+
+        Assert.NotNull(selected);
+        Assert.Equal(expected, selected!.Name);
+    }
+
+    [Fact]
+    public void SelectAsset_accepts_common_aliases_for_os_and_arch()
+    {
+        var assets = new[] { Asset("PKHeX-Avalonia-macos-aarch64.zip") };
+
+        // "macos"/"aarch64" are aliases for the canonical "osx"/"arm64" tokens used elsewhere.
+        var selected = AssetSelector.SelectAsset(assets, "macos", "aarch64");
+
+        Assert.NotNull(selected);
+        Assert.Equal("PKHeX-Avalonia-macos-aarch64.zip", selected!.Name);
+    }
+
+    [Fact]
+    public void SelectAsset_falls_back_to_os_only_match_when_no_os_plus_arch_asset_exists()
+    {
+        // Single-architecture release: the asset name has no arch token at all.
+        var assets = new[] { Asset("PKHeX-Avalonia-win.zip") };
+
+        var selected = AssetSelector.SelectAsset(assets, "windows", "x64");
+
+        Assert.NotNull(selected);
+        Assert.Equal("PKHeX-Avalonia-win.zip", selected!.Name);
+    }
+
+    [Fact]
+    public void SelectAsset_prefers_exact_os_and_arch_match_over_an_os_only_match()
+    {
+        var assets = new[] { Asset("PKHeX-Avalonia-win-x86.zip"), Asset("PKHeX-Avalonia-win-x64.zip") };
+
+        var selected = AssetSelector.SelectAsset(assets, "windows", "x64");
+
+        Assert.Equal("PKHeX-Avalonia-win-x64.zip", selected!.Name);
+    }
+
+    [Fact]
+    public void SelectAsset_returns_null_when_no_asset_matches_the_os()
+    {
+        var assets = new[] { Asset("PKHeX-Avalonia-win-x64.zip") };
+
+        Assert.Null(AssetSelector.SelectAsset(assets, "linux", "x64"));
+    }
+
+    [Fact]
+    public void SelectAsset_returns_null_for_an_unrecognized_os()
+    {
+        var assets = new[] { Asset("PKHeX-Avalonia-win-x64.zip") };
+
+        Assert.Null(AssetSelector.SelectAsset(assets, "amigaos", "m68k"));
+    }
+
+    [Fact]
+    public void SelectAsset_returns_null_when_there_are_no_assets()
+    {
+        Assert.Null(AssetSelector.SelectAsset([], "windows", "x64"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an async, non-blocking startup check against the GitHub Releases API for `realgarit/PKHeX-Avalonia`, comparing the latest release tag against the running `UIVersion`.

**Design**
- `IUpdateCheckService` (PKHeX.Application port) — `GetReleasesAsync()` returns all published releases or `null` on any failure.
- `GitHubUpdateCheckService` (PKHeX.Infrastructure) — HTTP call to the GitHub Releases API; catches every failure mode (offline, DNS, timeout, rate limit, malformed JSON) and returns `null` with a `Trace.TraceWarning` log entry — never throws, never surfaces an error dialog.
- `SemanticVersion` (PKHeX.Application, pure) — SemVer 2.0.0 parser/comparer, including correct pre-release precedence ordering (numeric vs. alphanumeric identifiers, identifier-count tiebreak, stable > pre-release).
- `UpdateAvailabilityEvaluator` (PKHeX.Application, pure) — decides the latest stable release, whether to notify (newer version + not the skipped version), and which releases are newer than the installed version (for changelog display).
- `AssetSelector` (PKHeX.Application, pure) — matches a release's assets against the current OS/architecture (win/macos/linux × x64/arm64/x86, with common aliases), falling back to an OS-only match, then to the release page when nothing matches. Takes plain os/arch strings so it's testable without touching the real platform.
- Presentation: `UpdateNotificationViewModel` (status-bar item: What's New / Download / Skip / dismiss) and `UpdateChangelogViewModel` (dialog rendering release notes between installed and latest, with "View Release Page" and "Download" actions). `MainWindowViewModel.CheckForUpdatesAsync()` is the fire-and-forget entry point called once from `App.axaml.cs` after the main window is shown.
- Settings: `AppSettings.StartupSettings.CheckForUpdatesOnStartup` (default on) and `SkippedUpdateVersion`, both wired into `SettingsViewModel`/`SettingsView` under a new "Updates" card, persisted through the existing `ISettingsStore` (from #138).
- Honors the pre-existing `ShowChangelogOnUpdate` flag: on the first launch after a version change, if the GitHub fetch succeeds, the changelog for the newly-installed version is shown once (persists the seen version regardless, so it won't retroactively fire once network is back).

## Verification

```
dotnet build PKHeX.sln -c Release   -> Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test  PKHeX.sln -c Release --no-build
  PKHeX.Architecture.Tests.dll : 5 passed   (layering rules hold — no Avalonia/Infra leak into Application/Presentation)
  PKHeX.Core.Tests.dll         : 449 passed, 1 skipped
  PKHeX.Avalonia.Tests.dll     : 1987 passed, 0 failed
```

New tests: `SemanticVersionTests` (parsing, pre-release ordering incl. numeric-vs-alphanumeric precedence), `UpdateAvailabilityEvaluatorTests` (latest-release selection, notify/skip decision, newer-than filtering), `AssetSelectorTests` (per-OS/arch asset matching, alias handling, os-only fallback, exact-match preference, no-match cases), `MainWindowUpdateCheckTests` (end-to-end `CheckForUpdatesAsync` flow with mocked `IUpdateCheckService`/`IWindowService`/`ISettingsStore`).

## Caveats

- Live acceptance criteria that need a real newer GitHub release or a packaged app launch (notification appears within seconds of launch, main window never blocked, offline/rate-limited startup produces no dialog) are not exercisable against `api.github.com` or a real app bundle in this sandbox — they're covered by the mocked-path unit tests exercising the same logic (success / `null` / newer-version paths).
- Offline startup with `ShowChangelogOnUpdate` enabled still marks the new version as "seen" (by design, so it doesn't retroactively fire once the network is back) — meaning if the very first post-upgrade launch happens offline, the changelog for that version won't be shown later either.
- `UIVersion`: 1.26.0 → 1.27.0 (feat → minor), in a separate `chore:` commit.

Closes #131