### PR TITLE
feat: whole-save legality audit tool window (#134)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.27.0</UIVersion>
+    <UIVersion>1.28.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/UseCases/LegalityAuditUseCase.cs
+++ b/PKHeX.Application/UseCases/LegalityAuditUseCase.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using PKHeX.Core;
+
+namespace PKHeX.Application.UseCases;
+
+/// <summary>
+/// Progress notification for <see cref="LegalityAuditUseCase"/>: slots processed so far out of the total.
+/// </summary>
+public readonly record struct LegalityAuditProgress(int Completed, int Total);
+
+/// <summary>
+/// One audited slot: identity/location info plus the exact <see cref="LegalityAnalysis"/> outcome,
+/// so the result never diverges from what the single-Pokémon editor's legality panel would show.
+/// </summary>
+public sealed class LegalityAuditEntry
+{
+    /// <summary>The audited entity. Never a party/box slot placeholder (empty slots are skipped).</summary>
+    public PKM Entity { get; }
+
+    /// <summary>True if this slot came from the party, false if it came from a box.</summary>
+    public bool IsParty { get; }
+
+    /// <summary>Zero-based box index. Meaningless (0) when <see cref="IsParty"/> is true.</summary>
+    public int Box { get; }
+
+    /// <summary>Zero-based slot index within the box, or the party index when <see cref="IsParty"/> is true.</summary>
+    public int Slot { get; }
+
+    /// <summary>Whether the slot passed every legality check.</summary>
+    public bool Valid { get; }
+
+    /// <summary>
+    /// The standard PKHeX legality report text for this entity, i.e. <see cref="LegalityFormatting.Report(LegalityAnalysis, bool)"/>
+    /// on the exact same <see cref="LegalityAnalysis"/> used to compute <see cref="Valid"/>.
+    /// </summary>
+    public string ReportText { get; }
+
+    public LegalityAuditEntry(PKM pk, LegalityAnalysis la, bool isParty, int box, int slot)
+    {
+        Entity = pk;
+        IsParty = isParty;
+        Box = box;
+        Slot = slot;
+        Valid = la.Valid;
+        ReportText = la.Report();
+    }
+
+    /// <summary>Single-line, semicolon-joined rendering of <see cref="ReportText"/> for grid/CSV display.</summary>
+    public string FailureSummary => Valid ? string.Empty : ReportText.Replace(Environment.NewLine, "; ").Replace("\n", "; ");
+}
+
+/// <summary>
+/// Scans every occupied party and box slot of a save file, running each through the same
+/// <see cref="LegalityAnalysis"/> code path (same constructor arguments) as the single-Pokémon
+/// editor's legality panel, so audit verdicts can never diverge from the editor.
+/// Supports cooperative cancellation and progress reporting so callers can run it off the UI thread.
+/// </summary>
+public sealed class LegalityAuditUseCase
+{
+    public IReadOnlyList<LegalityAuditEntry> Execute(SaveFile sav, IProgress<LegalityAuditProgress>? progress = null, CancellationToken cancellationToken = default)
+    {
+        var boxData = sav.BoxData;
+        var slotsPerBox = sav.BoxSlotCount;
+        var partyCount = sav.PartyCount;
+        var total = boxData.Count + partyCount;
+        var completed = 0;
+
+        var results = new List<LegalityAuditEntry>();
+
+        for (int i = 0; i < boxData.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pk = boxData[i];
+            if (pk.Species != 0)
+            {
+                var la = new LegalityAnalysis(pk, sav.Personal);
+                results.Add(new LegalityAuditEntry(pk, la, isParty: false, box: i / slotsPerBox, slot: i % slotsPerBox));
+            }
+
+            progress?.Report(new LegalityAuditProgress(++completed, total));
+        }
+
+        for (int i = 0; i < partyCount; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            PKM pk;
+            try { pk = sav.GetPartySlotAtIndex(i); }
+            catch { pk = sav.BlankPKM; }
+
+            if (pk.Species != 0)
+            {
+                var la = new LegalityAnalysis(pk, sav.Personal);
+                results.Add(new LegalityAuditEntry(pk, la, isParty: true, box: 0, slot: i));
+            }
+
+            progress?.Report(new LegalityAuditProgress(++completed, total));
+        }
+
+        return results;
+    }
+}

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -47,6 +47,7 @@ public static class ViewLocator
         [typeof(HallOfFameEditorViewModel)] = () => new HallOfFameEditor(),
         [typeof(HoneyTreeEditorViewModel)] = () => new HoneyTreeEditor(),
         [typeof(JoinAvenueEditorViewModel)] = () => new JoinAvenueEditor(),
+        [typeof(LegalityAuditViewModel)] = () => new LegalityAuditView(),
         [typeof(LegalityViewModel)] = () => new LegalityView(),
         [typeof(Link6EditorViewModel)] = () => new Link6Editor(),
         [typeof(MailBoxEditorViewModel)] = () => new MailBoxEditor(),

--- a/PKHeX.Avalonia/Views/LegalityAuditView.axaml
+++ b/PKHeX.Avalonia/Views/LegalityAuditView.axaml
@@ -1,0 +1,53 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="650"
+             x:Class="PKHeX.Avalonia.Views.LegalityAuditView"
+             x:DataType="vm:LegalityAuditViewModel"
+             MinWidth="700" MinHeight="400" Width="1100" Height="650">
+
+    <DockPanel>
+        <Border DockPanel.Dock="Top" Padding="12,8">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8">
+                    <Button Content="Run Audit" Classes="accent" Command="{Binding RunCommand}" />
+                    <Button Content="Cancel" Command="{Binding CancelCommand}" />
+                    <Button Content="Export CSV" Command="{Binding ExportCsvCommand}" />
+                    <Button Content="Export Text" Command="{Binding ExportTextCommand}" />
+                    <Button Content="Copy Selected Report" Command="{Binding CopySelectedReportCommand}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBlock Text="Verdict:" VerticalAlignment="Center" />
+                    <ComboBox ItemsSource="{Binding VerdictFilterOptions}" SelectedItem="{Binding VerdictFilter}" Width="90" />
+                    <TextBlock Text="Filter:" VerticalAlignment="Center" />
+                    <TextBox Text="{Binding TextFilter}" Watermark="species, nickname, or failed check..." Width="240" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
+        <Border DockPanel.Dock="Top" Padding="12,0,12,8" IsVisible="{Binding IsRunning}">
+            <ProgressBar Minimum="0" Maximum="100" Value="{Binding Progress}" Height="6" />
+        </Border>
+
+        <Border DockPanel.Dock="Bottom" Padding="12,8">
+            <TextBlock Text="{Binding StatusText}" Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" />
+        </Border>
+
+        <DataGrid Name="AuditGrid" ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow}"
+                  CanUserSortColumns="True" IsReadOnly="True" CanUserResizeColumns="True"
+                  GridLinesVisibility="All" BorderThickness="1"
+                  BorderBrush="{DynamicResource ThemeBorderBrush}"
+                  DoubleTapped="OnRowDoubleTapped"
+                  ToolTip.Tip="Double-click a row to jump to that Pokémon in the editor">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Location" Binding="{Binding Position}" Width="90"/>
+                <DataGridTextColumn Header="Species" Binding="{Binding Species}" Width="120"/>
+                <DataGridTextColumn Header="Nickname" Binding="{Binding Nickname}" Width="110"/>
+                <DataGridTextColumn Header="Verdict" Binding="{Binding Verdict}" Width="70"/>
+                <DataGridTextColumn Header="Failed Checks" Binding="{Binding FailureSummary}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </DockPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/LegalityAuditView.axaml.cs
+++ b/PKHeX.Avalonia/Views/LegalityAuditView.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using PKHeX.Presentation.ViewModels;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class LegalityAuditView : UserControl
+{
+    public LegalityAuditView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnRowDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is LegalityAuditViewModel vm)
+            vm.ActivateSelectedRowCommand.Execute(null);
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -45,6 +45,7 @@
                     <MenuItem Header="Dump Boxes" Command="{Binding DumpBoxesCommand}" />
                     <MenuItem Header="PKM Database" Command="{Binding OpenPKMDatabaseCommand}" />
                     <MenuItem Header="Box Data Report" Command="{Binding OpenBoxReportCommand}" />
+                    <MenuItem Header="Legality Audit" Command="{Binding OpenLegalityAuditCommand}" />
                     <MenuItem Header="Mystery Gift Database" Command="{Binding OpenMysteryGiftDatabaseCommand}" />
                     <MenuItem Header="Block Editor" Command="{Binding OpenBlockEditorCommand}" />
                     <MenuItem Header="Encounter Database" Command="{Binding OpenEncounterDatabaseCommand}" />

--- a/PKHeX.Presentation/ViewModels/LegalityAuditRow.cs
+++ b/PKHeX.Presentation/ViewModels/LegalityAuditRow.cs
@@ -1,0 +1,42 @@
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// One row of the Legality Audit grid: an <see cref="EntitySummary"/> for display plus the
+/// verdict/location/failure text computed by <see cref="LegalityAuditUseCase"/> (the same
+/// <see cref="LegalityAnalysis"/> the editor's legality panel uses, so the verdict never diverges).
+/// </summary>
+public sealed class LegalityAuditRow : EntitySummary
+{
+    private readonly LegalityAuditEntry _entry;
+
+    /// <summary>True if this slot came from the party rather than a box.</summary>
+    public bool IsParty => _entry.IsParty;
+
+    /// <summary>Zero-based box index. Meaningless when <see cref="IsParty"/> is true.</summary>
+    public int Box => _entry.Box;
+
+    /// <summary>Zero-based slot index within the box, or the party index when <see cref="IsParty"/> is true.</summary>
+    public int Slot => _entry.Slot;
+
+    public override string Position => IsParty ? $"Party {Slot + 1}" : $"B{Box + 1:00}:{Slot + 1:00}";
+
+    /// <summary>Whether this entity passed every legality check.</summary>
+    public bool Valid => _entry.Valid;
+
+    /// <summary>"Legal" or "Illegal", for grid/CSV display.</summary>
+    public string Verdict => Valid ? "Legal" : "Illegal";
+
+    /// <summary>Semicolon-joined, single-line rendering of the failed checks (empty when <see cref="Valid"/>).</summary>
+    public string FailureSummary => _entry.FailureSummary;
+
+    /// <summary>The full standard PKHeX legality report text, identical to the editor's legality panel.</summary>
+    public string ReportText => _entry.ReportText;
+
+    public LegalityAuditRow(LegalityAuditEntry entry, GameStrings strings) : base(entry.Entity, strings)
+    {
+        _entry = entry;
+    }
+}

--- a/PKHeX.Presentation/ViewModels/LegalityAuditViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/LegalityAuditViewModel.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Legality Audit: scans every occupied party/box slot of the current save with the same
+/// <see cref="LegalityAnalysis"/> code path the editor's legality panel uses, and shows the
+/// results in a filterable, exportable, sortable spreadsheet in a modeless tool window.
+/// </summary>
+public partial class LegalityAuditViewModel : ViewModelBase
+{
+    private readonly SaveFile _sav;
+    private readonly IDialogService _dialogService;
+    private readonly LegalityAuditUseCase _useCase = new();
+
+    private List<LegalityAuditRow> _allRows = [];
+    private CancellationTokenSource? _cts;
+
+    [ObservableProperty]
+    private ObservableCollection<LegalityAuditRow> _rows = [];
+
+    [ObservableProperty]
+    private LegalityAuditRow? _selectedRow;
+
+    [ObservableProperty]
+    private string _statusText = "Run an audit to scan the current save.";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RunCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
+    private bool _isRunning;
+
+    [ObservableProperty]
+    private double _progress;
+
+    /// <summary>Verdict filter applied to <see cref="Rows"/>: "All", "Legal", or "Illegal".</summary>
+    [ObservableProperty]
+    private string _verdictFilter = "All";
+
+    /// <summary>Free-text filter matched against species, nickname, and failure summary.</summary>
+    [ObservableProperty]
+    private string _textFilter = string.Empty;
+
+    public static IReadOnlyList<string> VerdictFilterOptions { get; } = ["All", "Legal", "Illegal"];
+
+    /// <summary>Raised when the user activates (double-clicks) a row to navigate to it in the editor.</summary>
+    public event Action<LegalityAuditRow>? RowActivated;
+
+    public LegalityAuditViewModel(SaveFile sav, IDialogService dialogService)
+    {
+        _sav = sav;
+        _dialogService = dialogService;
+    }
+
+    partial void OnVerdictFilterChanged(string value) => ApplyFilter();
+    partial void OnTextFilterChanged(string value) => ApplyFilter();
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task RunAsync()
+    {
+        IsRunning = true;
+        Progress = 0;
+        StatusText = "Auditing...";
+        _cts = new CancellationTokenSource();
+
+        try
+        {
+            var strings = GameInfo.Strings;
+            var progress = new Progress<LegalityAuditProgress>(p =>
+                Progress = p.Total == 0 ? 0 : 100.0 * p.Completed / p.Total);
+            var token = _cts.Token;
+
+            var entries = await Task.Run(() => _useCase.Execute(_sav, progress, token), token);
+
+            _allRows = entries.Select(e => new LegalityAuditRow(e, strings)).ToList();
+            ApplyFilter();
+
+            var illegalCount = _allRows.Count(r => !r.Valid);
+            StatusText = illegalCount == 0
+                ? $"Audit complete: {_allRows.Count} Pokémon checked, 0 findings."
+                : $"Audit complete: {_allRows.Count} Pokémon checked, {illegalCount} illegal.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusText = "Audit cancelled.";
+        }
+        finally
+        {
+            IsRunning = false;
+            Progress = 0;
+            _cts = null;
+        }
+    }
+
+    private bool CanRun() => !IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanCancel))]
+    private void Cancel() => _cts?.Cancel();
+
+    private bool CanCancel() => IsRunning;
+
+    private void ApplyFilter()
+    {
+        IEnumerable<LegalityAuditRow> filtered = _allRows;
+
+        if (VerdictFilter is "Legal")
+            filtered = filtered.Where(r => r.Valid);
+        else if (VerdictFilter is "Illegal")
+            filtered = filtered.Where(r => !r.Valid);
+
+        if (!string.IsNullOrWhiteSpace(TextFilter))
+        {
+            var text = TextFilter.Trim();
+            filtered = filtered.Where(r =>
+                r.Species.Contains(text, StringComparison.OrdinalIgnoreCase) ||
+                r.Nickname.Contains(text, StringComparison.OrdinalIgnoreCase) ||
+                r.FailureSummary.Contains(text, StringComparison.OrdinalIgnoreCase));
+        }
+
+        Rows = new ObservableCollection<LegalityAuditRow>(filtered);
+    }
+
+    [RelayCommand]
+    private void ActivateSelectedRow()
+    {
+        if (SelectedRow is not null)
+            RowActivated?.Invoke(SelectedRow);
+    }
+
+    [RelayCommand]
+    private async Task ExportCsvAsync()
+    {
+        var path = await _dialogService.SaveFileAsync("Export Legality Audit", "LegalityAudit.csv");
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        try
+        {
+            File.WriteAllText(path, BuildCsv(Rows), Encoding.UTF8);
+            await _dialogService.ShowInformationAsync("Export Complete", $"Exported {Rows.Count} rows to {path}");
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Export Error", ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private async Task ExportTextAsync()
+    {
+        var path = await _dialogService.SaveFileAsync("Export Legality Reports", "LegalityAudit.txt");
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        try
+        {
+            File.WriteAllText(path, BuildTextReport(Rows), Encoding.UTF8);
+            await _dialogService.ShowInformationAsync("Export Complete", $"Exported {Rows.Count} reports to {path}");
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync("Export Error", ex.Message);
+        }
+    }
+
+    [RelayCommand]
+    private async Task CopySelectedReportAsync()
+    {
+        if (SelectedRow is null)
+            return;
+
+        await _dialogService.SetClipboardTextAsync(SelectedRow.ReportText);
+    }
+
+    private static readonly (string Header, Func<LegalityAuditRow, object?> Get)[] CsvColumns =
+    [
+        ("Location", r => r.Position),
+        ("Species", r => r.Species),
+        ("Nickname", r => r.Nickname),
+        ("Verdict", r => r.Verdict),
+        ("FailedChecks", r => r.FailureSummary),
+    ];
+
+    private static string BuildCsv(IEnumerable<LegalityAuditRow> rows)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(string.Join(',', Array.ConvertAll(CsvColumns, c => c.Header)));
+        foreach (var row in rows)
+        {
+            for (int i = 0; i < CsvColumns.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(',');
+                sb.Append(EscapeCsv(CsvColumns[i].Get(row)?.ToString() ?? string.Empty));
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    private static string EscapeCsv(string value)
+        => value.Contains(',') || value.Contains('"') || value.Contains('\n')
+            ? $"\"{value.Replace("\"", "\"\"")}\""
+            : value;
+
+    /// <summary>
+    /// Builds the standard PKHeX legality report text for each row, one after another,
+    /// each report identical to what the editor's legality panel would show for that entity.
+    /// </summary>
+    private static string BuildTextReport(IEnumerable<LegalityAuditRow> rows)
+    {
+        var sb = new StringBuilder();
+        foreach (var row in rows)
+        {
+            if (sb.Length > 0)
+                sb.AppendLine().AppendLine();
+            sb.AppendLine($"{row.Position} - {row.Species} ({row.Nickname})");
+            sb.Append(row.ReportText);
+        }
+        return sb.ToString();
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.FileCommands.cs
@@ -219,6 +219,31 @@ public partial class MainWindowViewModel
         _windowService.ShowTool(_boxReport, "Box Data Report");
     }
 
+    // Cached so re-invoking the menu item focuses the existing tool window instead of
+    // opening a duplicate (ShowTool keys off the ViewModel instance). Reset on save change.
+    private LegalityAuditViewModel? _legalityAudit;
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private void OpenLegalityAudit()
+    {
+        if (CurrentSave is null) return;
+
+        if (_legalityAudit is null)
+        {
+            _legalityAudit = new LegalityAuditViewModel(CurrentSave, _dialogService);
+            _legalityAudit.RowActivated += row =>
+            {
+                if (row.IsParty)
+                    PartyViewer?.RefreshParty();
+                else
+                    ((IBoxNavigator?)BoxViewer)?.NavigateTo(row.Box, row.Slot);
+                CurrentPokemonEditor?.LoadPKM(row.Entity);
+            };
+        }
+
+        _windowService.ShowTool(_legalityAudit, "Legality Audit");
+    }
+
     [RelayCommand(CanExecute = nameof(HasSave))]
     private async Task OpenMysteryGiftDatabaseAsync()
     {

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -123,6 +123,7 @@ public partial class MainWindowViewModel : ViewModelBase
         // Dismiss any modeless tool windows (e.g. the box seek tool) bound to the previous save.
         _windowService.CloseAllTools();
         _boxReport = null;
+        _legalityAudit = null;
 
         CurrentSave = sav;
         if (sav is not null)

--- a/Tests/PKHeX.Avalonia.Tests/LegalityAuditTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LegalityAuditTests.cs
@@ -1,0 +1,258 @@
+using Avalonia.Headless.XUnit;
+using Moq;
+using PKHeX.Application.UseCases;
+using PKHeX.Avalonia.Tests.Fixtures;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit.Abstractions;
+
+namespace PKHeX.Avalonia.Tests;
+
+public class LegalityAuditTests(ITestOutputHelper output)
+{
+    private readonly Mock<IDialogService> _dialogServiceMock = new();
+
+    private SaveFile? GetEmerald(out string? skipReason)
+    {
+        var savPath = SaveFileFixture.FindSaveFilesPath();
+        if (savPath == null) { skipReason = "savefiles directory not found"; return null; }
+
+        var sav = SaveFileFixture.LoadSave(Path.Combine(savPath, "gen3_emerald.sav"));
+        if (sav == null) { skipReason = "gen3_emerald.sav missing"; return null; }
+
+        skipReason = null;
+        return sav;
+    }
+
+    /// <summary>A synchronous <see cref="IProgress{T}"/> for deterministic cancellation tests
+    /// (the real <see cref="Progress{T}"/> marshals callbacks asynchronously).</summary>
+    private sealed class SyncProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _callback;
+        public SyncProgress(Action<T> callback) => _callback = callback;
+        public void Report(T value) => _callback(value);
+    }
+
+    [AvaloniaFact]
+    public async Task Run_MatchesDirectLegalityAnalysisForEverySlot()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.NotEmpty(vm.Rows);
+
+        foreach (var row in vm.Rows)
+        {
+            var expected = new LegalityAnalysis(row.Entity, sav.Personal);
+            Assert.Equal(expected.Valid, row.Valid);
+            Assert.Equal(expected.Report(), row.ReportText);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Execute_SkipsEmptySlotsAndEggsDoNotFalsePositive()
+    {
+        var sav = new SAV3E();
+        var egg = new PK3
+        {
+            Species = (ushort)Species.Togepi,
+            IsEgg = true,
+            CurrentLevel = 5,
+            OriginalTrainerName = sav.OT,
+            TID16 = sav.TID16,
+            SID16 = sav.SID16,
+        };
+        egg.RefreshChecksum();
+        sav.SetBoxSlotAtIndex(egg, 2, 0); // box 2, slot 0; all other slots remain empty
+
+        var useCase = new LegalityAuditUseCase();
+        var entries = useCase.Execute(sav);
+
+        // Only the one occupied slot should produce an entry; every empty slot is skipped
+        // (no false-positive findings just because a slot is empty).
+        var entry = Assert.Single(entries);
+        Assert.Equal(2, entry.Box);
+        Assert.Equal(0, entry.Slot);
+    }
+
+    [AvaloniaFact]
+    public void Execute_EmptySaveReportsZeroFindings()
+    {
+        var sav = new SAV3E();
+        var useCase = new LegalityAuditUseCase();
+
+        var entries = useCase.Execute(sav);
+
+        Assert.Empty(entries);
+    }
+
+    [AvaloniaFact]
+    public void Execute_CancellationStopsFurtherProcessing()
+    {
+        var sav = new SAV3E();
+        var pk = new PK3 { Species = (ushort)Species.Mudkip, CurrentLevel = 5 };
+        pk.RefreshChecksum();
+        sav.SetBoxSlotAtIndex(pk, 0, 0);
+
+        var useCase = new LegalityAuditUseCase();
+        using var cts = new CancellationTokenSource();
+
+        // Cancel as soon as the very first slot has been processed; a correctly-implemented
+        // service must observe this before finishing the (much larger) remaining slot scan.
+        var progress = new SyncProgress<LegalityAuditProgress>(p =>
+        {
+            if (p.Completed >= 1)
+                cts.Cancel();
+        });
+
+        Assert.Throws<OperationCanceledException>(() => useCase.Execute(sav, progress, cts.Token));
+    }
+
+    [AvaloniaFact]
+    public async Task ExportCsv_HasExpectedColumnsAndRowCount()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.Rows);
+
+        var path = Path.Combine(Path.GetTempPath(), $"legalityaudit-test-{Guid.NewGuid():N}.csv");
+        _dialogServiceMock
+            .Setup(d => d.SaveFileAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string[]?>()))
+            .ReturnsAsync(path);
+
+        try
+        {
+            await vm.ExportCsvCommand.ExecuteAsync(null);
+
+            var lines = File.ReadAllLines(path);
+            Assert.Equal("Location,Species,Nickname,Verdict,FailedChecks", lines[0]);
+            Assert.Equal(vm.Rows.Count + 1, lines.Length);
+
+            // Any exported field containing a raw comma must be quoted so the CSV parses correctly
+            // (failed-check summaries frequently contain commas from the underlying report text).
+            foreach (var row in vm.Rows)
+            {
+                if (!row.FailureSummary.Contains(','))
+                    continue;
+                Assert.Contains(lines, l => l.Contains($"\"{row.FailureSummary.Replace("\"", "\"\"")}\""));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task ExportText_SingleFlaggedEntryMatchesLegalityAnalysisReport()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+
+        vm.VerdictFilter = "Illegal";
+        if (vm.Rows.Count == 0) { output.WriteLine("Skip: gen3_emerald.sav has no illegal entries to export"); return; }
+
+        var illegalPk = vm.Rows[0].Entity;
+        var expectedReport = new LegalityAnalysis(illegalPk, sav.Personal).Report();
+
+        var path = Path.Combine(Path.GetTempPath(), $"legalityaudit-text-{Guid.NewGuid():N}.txt");
+        _dialogServiceMock
+            .Setup(d => d.SaveFileAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string[]?>()))
+            .ReturnsAsync(path);
+
+        try
+        {
+            vm.SelectedRow = vm.Rows[0];
+            await vm.ExportTextCommand.ExecuteAsync(null);
+
+            var text = File.ReadAllText(path);
+            Assert.Contains(expectedReport, text);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task VerdictFilter_ShowsOnlyMatchingRows()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+        var total = vm.Rows.Count;
+        Assert.NotEmpty(vm.Rows);
+
+        vm.VerdictFilter = "Illegal";
+        Assert.All(vm.Rows, r => Assert.False(r.Valid));
+        var illegalCount = vm.Rows.Count;
+
+        vm.VerdictFilter = "Legal";
+        Assert.All(vm.Rows, r => Assert.True(r.Valid));
+        var legalCount = vm.Rows.Count;
+
+        Assert.Equal(total, legalCount + illegalCount);
+
+        vm.VerdictFilter = "All";
+        Assert.Equal(total, vm.Rows.Count);
+    }
+
+    [AvaloniaFact]
+    public async Task TextFilter_MatchesSpeciesOrNicknameCaseInsensitively()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.Rows);
+
+        var target = vm.Rows[0];
+        vm.TextFilter = target.Species.ToUpperInvariant();
+
+        Assert.Contains(vm.Rows, r => r.Species == target.Species);
+        Assert.All(vm.Rows, r => Assert.Equal(target.Species, r.Species));
+    }
+
+    [AvaloniaFact]
+    public async Task ActivateSelectedRow_RaisesRowActivatedWithBoxAndSlot()
+    {
+        var sav = GetEmerald(out var skip);
+        if (sav is null) { output.WriteLine($"Skip: {skip}"); return; }
+
+        var vm = new LegalityAuditViewModel(sav, _dialogServiceMock.Object);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.Rows);
+
+        var partyRow = vm.Rows.FirstOrDefault(r => r.IsParty);
+        var boxRow = vm.Rows.FirstOrDefault(r => !r.IsParty);
+        Assert.True(partyRow is not null || boxRow is not null);
+
+        LegalityAuditRow? activated = null;
+        vm.RowActivated += r => activated = r;
+
+        vm.ActivateSelectedRowCommand.Execute(null); // no selection: no event
+        Assert.Null(activated);
+
+        var target = boxRow ?? partyRow!;
+        vm.SelectedRow = target;
+        vm.ActivateSelectedRowCommand.Execute(null);
+
+        Assert.NotNull(activated);
+        Assert.Same(target.Entity, activated!.Entity);
+        Assert.Equal(target.IsParty, activated.IsParty);
+        Assert.Equal(target.Box, activated.Box);
+        Assert.Equal(target.Slot, activated.Slot);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a whole-save Legality Audit tool window (issue #134):

- `LegalityAuditUseCase` reuses the editor's exact `LegalityAnalysis` code path so audit verdicts can never diverge from the single-Pokémon editor.
- Avalonia-free `LegalityAuditViewModel` provides run/cancel, verdict/text filtering, CSV export, and plain-text export matching `LegalityAnalysis.Report()` format, plus row-activation navigation.
- The view is a modeless tool window opened via `IWindowService.ShowTool`, wired into the Tools menu.

## Verification

- `dotnet build PKHeX.sln -c Release`: Build succeeded, 0 Warning(s), 0 Error(s).
- `dotnet test PKHeX.sln -c Release`:
  - PKHeX.Architecture.Tests: Passed 5, Failed 0, Skipped 0 (Total 5)
  - PKHeX.Core.Tests: Passed 449, Failed 0, Skipped 1 (Total 450)
  - PKHeX.Avalonia.Tests: Passed 1996, Failed 0, Skipped 0 (Total 1996)
- New tests added in `Tests/PKHeX.Avalonia.Tests/LegalityAuditTests.cs` (9):
  - `Run_MatchesDirectLegalityAnalysisForEverySlot` — audit verdicts match direct `LegalityAnalysis` for every slot.
  - `Execute_SkipsEmptySlotsAndEggsDoNotFalsePositive` — empty slots skipped, eggs don't false-positive.
  - `Execute_EmptySaveReportsZeroFindings` — an empty save reports zero findings.
  - `Execute_CancellationStopsFurtherProcessing` — cancellation halts further processing.
  - `ExportCsv_HasExpectedColumnsAndRowCount` — CSV export has expected columns and row count.
  - `ExportText_SingleFlaggedEntryMatchesLegalityAnalysisReport` — text export matches `LegalityAnalysis.Report()`.
  - `VerdictFilter_ShowsOnlyMatchingRows` — verdict filter shows only matching rows.
  - `TextFilter_MatchesSpeciesOrNicknameCaseInsensitively` — text filter matches species/nickname case-insensitively.
  - `ActivateSelectedRow_RaisesRowActivatedWithBoxAndSlot` — activating a row raises `RowActivated` with box and slot.

## Deviations / caveats

- No sprite thumbnail column in the results grid, matching existing `BoxReportView` precedent — a natural follow-up.
- Double-click navigation loads the Pokémon into the editor correctly but uses `PartyViewer.RefreshParty()` rather than a dedicated select-party-slot command, since none existed.
- Responsiveness/cancel behavior on a real ~960-slot save and double-click navigation in the running app still need manual UI verification (not covered by unit tests).

UIVersion 1.27.0 → 1.28.0.

Closes #134