### PR TITLE
feat: installers and package-manager distribution scaffolding (#130)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,84 @@ jobs:
           zip -r ../${{ matrix.artifact }}.zip PKHeX.Avalonia.app
           cd ..
 
+      # Gate real Developer ID signing/notarization on repo secrets. Without
+      # them we still ship a .dmg (clearly named "-unsigned") so the artifact
+      # shape stays stable either way; see docs/packaging.md for the secrets
+      # a repo owner needs to add to turn this on.
+      - name: Determine macOS signing capability
+        if: startsWith(matrix.rid, 'osx')
+        id: mac_sign
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.MACOS_CERT_P12 }}" ] && [ -n "${{ secrets.MACOS_SIGN_IDENTITY }}" ] && [ -n "${{ secrets.APPLE_NOTARY_KEY }}" ]; then
+            echo "Signing secrets present — will produce a Developer ID signed, notarized .dmg"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Signing secrets absent — will produce an UNSIGNED .dmg"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import Developer ID certificate
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "$MACOS_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Codesign with Developer ID (hardened runtime)
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+        run: |
+          codesign --force --deep --options runtime --timestamp \
+            --sign "$MACOS_SIGN_IDENTITY" publish/PKHeX.Avalonia.app
+          codesign --verify --deep --strict --verbose=2 publish/PKHeX.Avalonia.app
+
+      - name: Notarize and staple app bundle
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          echo "$APPLE_NOTARY_KEY" | base64 --decode > "$RUNNER_TEMP/notary_key.p8"
+          ditto -c -k --keepParent publish/PKHeX.Avalonia.app "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$RUNNER_TEMP/notary_key.p8" \
+            --key-id "$APPLE_NOTARY_KEY_ID" \
+            --issuer "$APPLE_NOTARY_ISSUER_ID" \
+            --wait
+          xcrun stapler staple publish/PKHeX.Avalonia.app
+          rm -f "$RUNNER_TEMP/notarize.zip" "$RUNNER_TEMP/notary_key.p8"
+
+      - name: Build DMG
+        if: startsWith(matrix.rid, 'osx')
+        shell: bash
+        run: |
+          DMG_STAGING=$(mktemp -d)
+          cp -R publish/PKHeX.Avalonia.app "$DMG_STAGING/"
+          ln -s /Applications "$DMG_STAGING/Applications"
+          if [ "${{ steps.mac_sign.outputs.enabled }}" = "true" ]; then
+            DMG_NAME="${{ matrix.artifact }}.dmg"
+          else
+            DMG_NAME="${{ matrix.artifact }}-unsigned.dmg"
+          fi
+          hdiutil create -volname "PKHeX-Avalonia" -srcfolder "$DMG_STAGING" -ov -format UDZO "$DMG_NAME"
+          rm -rf "$DMG_STAGING"
+
       # Linux: make executable and zip
       - name: Package (Linux)
         if: matrix.rid == 'linux-x64'
@@ -153,6 +231,75 @@ jobs:
         shell: pwsh
         run: Compress-Archive -Path publish/* -DestinationPath ${{ matrix.artifact }}.zip
 
+      - name: Install Inno Setup
+        if: matrix.rid == 'win-x64'
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      # Gate real code signing on repo secrets. Without them we still ship an
+      # installer (clearly named "-unsigned") so the artifact shape stays
+      # stable either way; see docs/packaging.md for the secrets a repo
+      # owner needs to add to turn this on.
+      - name: Determine Windows signing capability
+        if: matrix.rid == 'win-x64'
+        id: win_sign
+        shell: pwsh
+        run: |
+          if ("${{ secrets.WINDOWS_CERT_P12 }}" -ne "" -and "${{ secrets.WINDOWS_CERT_PASSWORD }}" -ne "") {
+            Write-Host "Signing secrets present -- will produce a code-signed installer"
+            "enabled=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Signing secrets absent -- will produce an UNSIGNED installer"
+            "enabled=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Import Windows code-signing certificate
+        if: matrix.rid == 'win-x64' && steps.win_sign.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          WINDOWS_CERT_P12: ${{ secrets.WINDOWS_CERT_P12 }}
+        run: |
+          $certPath = Join-Path $env:RUNNER_TEMP "windows-cert.pfx"
+          [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_CERT_P12))
+          "CERT_PATH=$certPath" >> $env:GITHUB_ENV
+
+      - name: Code-sign application executable
+        if: matrix.rid == 'win-x64' && steps.win_sign.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $signtool = (Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          & $signtool sign /f "$env:CERT_PATH" /p "$env:WINDOWS_CERT_PASSWORD" /fd SHA256 `
+            /tr http://timestamp.digicert.com /td SHA256 publish\PKHeX.Avalonia.exe
+
+      - name: Build Inno Setup installer
+        if: matrix.rid == 'win-x64'
+        shell: pwsh
+        run: |
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            "/DMyAppVersion=${{ needs.check-version.outputs.version }}" `
+            "/DSourceDir=$(Resolve-Path publish)" `
+            "/DOutputDir=$(Get-Location)" `
+            "packaging/windows/installer.iss"
+
+      - name: Code-sign installer
+        if: matrix.rid == 'win-x64' && steps.win_sign.outputs.enabled == 'true'
+        shell: pwsh
+        env:
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          $signtool = (Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName -Descending | Select-Object -First 1).FullName
+          & $signtool sign /f "$env:CERT_PATH" /p "$env:WINDOWS_CERT_PASSWORD" /fd SHA256 `
+            /tr http://timestamp.digicert.com /td SHA256 PKHeX-Avalonia-Setup.exe
+
+      - name: Rename unsigned installer
+        if: matrix.rid == 'win-x64' && steps.win_sign.outputs.enabled != 'true'
+        shell: pwsh
+        run: Rename-Item PKHeX-Avalonia-Setup.exe PKHeX-Avalonia-Setup-unsigned.exe
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -160,6 +307,9 @@ jobs:
           path: |
             ${{ matrix.artifact }}.zip
             *.AppImage
+            *.dmg
+            PKHeX-Avalonia-Setup*.exe
+          if-no-files-found: ignore
           retention-days: 5
 
   release:
@@ -195,5 +345,7 @@ jobs:
           files: |
             artifacts/**/*.zip
             artifacts/**/*.AppImage
+            artifacts/**/*.dmg
+            artifacts/**/PKHeX-Avalonia-Setup*.exe
           draft: false
           prerelease: false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.29.0</UIVersion>
+    <UIVersion>1.29.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -13,16 +13,28 @@ Get the latest build for your platform from the [Releases](https://github.com/re
 
 | Platform | File |
 |----------|------|
-| Windows (x64) | `PKHeX-Avalonia-win-x64.zip` |
-| Linux (x64) | `PKHeX-Avalonia-linux-x64.zip` |
-| macOS Apple Silicon | `PKHeX-Avalonia-osx-arm64.zip` |
-| macOS Intel | `PKHeX-Avalonia-osx-x64.zip` |
+| Windows (x64) | `PKHeX-Avalonia-win-x64.zip`, or the `PKHeX-Avalonia-Setup.exe` installer |
+| Linux (x64) | `PKHeX-Avalonia-linux-x64.zip`, or `PKHeX-Avalonia-linux-x64.AppImage` |
+| macOS Apple Silicon | `PKHeX-Avalonia-osx-arm64.zip`, or `PKHeX-Avalonia-osx-arm64.dmg` |
+| macOS Intel | `PKHeX-Avalonia-osx-x64.zip`, or `PKHeX-Avalonia-osx-x64.dmg` |
 
 Every build is self-contained, so you don't need to install .NET.
 
-**macOS note:** the app is ad-hoc signed but not notarized. So on first launch macOS warns about an "unidentified developer". To open it:
-1. Right-click the app, pick **Open**, then click **Open** in the dialog.
-2. Or run `xattr -d com.apple.quarantine ~/Downloads/PKHeX.Avalonia.app` in Terminal.
+**Signing note:** the installer/dmg builds are code-signed and (on macOS)
+notarized only once the repo owner has configured signing secrets — see
+[`docs/packaging.md`](docs/packaging.md). Until then, filenames ending in
+`-unsigned` (e.g. `PKHeX-Avalonia-Setup-unsigned.exe`,
+`PKHeX-Avalonia-osx-arm64-unsigned.dmg`) mean the OS will still warn on
+first launch:
+- **Windows:** SmartScreen "unknown publisher" — click **More info** then
+  **Run anyway**.
+- **macOS:** right-click the app, pick **Open**, then click **Open** in the
+  dialog (or run `xattr -d com.apple.quarantine
+  ~/Downloads/PKHeX.Avalonia.app`).
+
+Package-manager installs (Homebrew cask, winget) are templated under
+`packaging/` and documented in `docs/packaging.md`, pending signed release
+builds to submit.
 
 
 ## Project Structure

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,146 @@
+# Packaging & distribution
+
+This document covers how `release.yml` builds installers for each platform,
+which secrets unlock real code signing / notarization, and how to submit the
+package-manager templates under `packaging/` once signed builds exist.
+
+Everything described here runs automatically on every release (a push to
+`main` that changes `Directory.Build.props`'s `<UIVersion>`, or a manual
+`workflow_dispatch`). There are no manual signing steps — the workflow signs
+when it can and clearly labels artifacts as unsigned when it can't.
+
+## Artifact matrix
+
+| Platform | Artifact(s) | Notes |
+|---|---|---|
+| Windows x64 | `PKHeX-Avalonia-win-x64.zip` (unchanged) + `PKHeX-Avalonia-Setup.exe` (or `PKHeX-Avalonia-Setup-unsigned.exe`) | Installer built with Inno Setup via chocolatey |
+| Linux x64 | `PKHeX-Avalonia-linux-x64.zip` (unchanged) + `PKHeX-Avalonia-linux-x64.AppImage` (unchanged) | See "Why AppImage, not Flatpak" below |
+| macOS arm64 / x64 | `PKHeX-Avalonia-osx-{arm64,x64}.zip` (unchanged, ad-hoc signed as before) + `PKHeX-Avalonia-osx-{arm64,x64}.dmg` or `-unsigned.dmg` | `.dmg` contains the `.app` bundle plus an `Applications` symlink |
+
+The existing `.zip` and `.AppImage` artifacts are unchanged — this is
+additive, per the acceptance criteria.
+
+## macOS: signing & notarization
+
+`release.yml`'s `build` job (macOS legs of the matrix) gates real Developer
+ID signing on three secrets:
+
+| Secret | Contents |
+|---|---|
+| `MACOS_CERT_P12` | Base64-encoded `.p12` export of a **Developer ID Application** certificate (`base64 -i cert.p12 \| pbcopy`) |
+| `MACOS_CERT_PASSWORD` | Password used when exporting the `.p12` |
+| `MACOS_SIGN_IDENTITY` | The identity string codesign should use, e.g. `Developer ID Application: Your Name (TEAMID)` |
+| `APPLE_NOTARY_KEY_ID` | Key ID of an App Store Connect API key with the Developer role |
+| `APPLE_NOTARY_KEY` | Base64-encoded `.p8` private key for that API key |
+| `APPLE_NOTARY_ISSUER_ID` | Issuer ID (UUID) for the API key, from App Store Connect > Users and Access > Keys |
+
+If `MACOS_CERT_P12`, `MACOS_SIGN_IDENTITY`, and `APPLE_NOTARY_KEY` are all
+present, the workflow:
+
+1. Imports the certificate into a temporary keychain.
+2. Re-signs the `.app` with `codesign --options runtime` (hardened runtime,
+   required for notarization) using the Developer ID identity.
+3. Submits it to `notarytool`, waits for the result, and staples the ticket
+   with `stapler staple`.
+4. Packs the notarized `.app` into `PKHeX-Avalonia-osx-<arch>.dmg`.
+
+If any of those secrets are absent, the workflow skips straight to step 4
+and names the output `PKHeX-Avalonia-osx-<arch>-unsigned.dmg` so it's obvious
+from the filename (and should be called out in release notes) that
+Gatekeeper will still complain.
+
+The existing ad-hoc-signed `.zip` artifacts are untouched by this change.
+
+## Windows: installer & code signing
+
+`release.yml`'s Windows leg installs Inno Setup via `choco install
+innosetup`, then builds `packaging/windows/installer.iss` into
+`PKHeX-Avalonia-Setup.exe` (registers Start Menu / desktop shortcuts and an
+Add/Remove Programs entry that uninstalls cleanly).
+
+Code signing (via `signtool.exe`, part of the Windows SDK already present on
+`windows-latest`) is gated on:
+
+| Secret | Contents |
+|---|---|
+| `WINDOWS_CERT_P12` | Base64-encoded `.pfx`/`.p12` of an OV (or EV) code-signing certificate |
+| `WINDOWS_CERT_PASSWORD` | Password for that `.pfx` |
+
+If both secrets are present, the workflow signs both the published
+`PKHeX.Avalonia.exe` (before packaging) and the final
+`PKHeX-Avalonia-Setup.exe` with a SHA-256 signature and a DigiCert RFC 3161
+timestamp. If they're absent, the installer is renamed to
+`PKHeX-Avalonia-Setup-unsigned.exe` so SmartScreen's "unknown publisher"
+warning is expected and self-explanatory from the filename.
+
+**Note:** an OV certificate alone does not eliminate SmartScreen warnings
+immediately — Microsoft's reputation system needs download volume to build
+trust for a given cert. An EV certificate (or Azure Trusted Signing) avoids
+the warning from day one. Either kind of certificate works with the signing
+steps above; only the secret contents change.
+
+## Linux: why AppImage, not Flatpak/Flathub
+
+The existing `.AppImage` build (via `appimagetool`) is kept as-is, per the
+issue's scope ("AppImage stays as-is"). Flathub distribution is **not**
+implemented here:
+
+- Flathub requires a manifest-driven build from source inside a Flatpak
+  sandbox (no bundling a self-contained `dotnet publish` output directly),
+  plus a review/approval process on their side — this is a separate,
+  larger effort than an additive CI step, and the issue explicitly scopes
+  Flathub as a stretch goal alongside Homebrew/winget rather than a hard
+  CI requirement.
+- AppImage requires no external approval and works today, so it remains the
+  primary Linux distribution channel until a Flatpak manifest is built as
+  follow-up work.
+
+## Package managers (Homebrew cask, winget)
+
+Publishing to Homebrew/winget means opening a PR against **their**
+repositories (`homebrew/homebrew-cask`, `microsoft/winget-pkgs`) — this repo
+cannot and does not auto-publish there. `packaging/` contains ready-to-fill
+templates plus the exact submission steps:
+
+### Homebrew cask — `packaging/homebrew/pkhex-avalonia.rb`
+
+Prerequisite: a release with signed & notarized `.dmg` files (see above) —
+Homebrew cask maintainers reject casks whose binaries fail Gatekeeper.
+
+1. `shasum -a 256 PKHeX-Avalonia-osx-arm64.dmg PKHeX-Avalonia-osx-x64.dmg`
+   and fill in `version` + both `sha256` values in the template.
+2. `brew bump-cask-pr --cask pkhex-avalonia --version <version>` (once the
+   cask already exists upstream), or for the first submission, fork
+   `homebrew/homebrew-cask`, copy the file to
+   `Casks/p/pkhex-avalonia.rb`, and open a PR.
+3. `brew audit --cask --online pkhex-avalonia` locally before submitting.
+
+### winget — `packaging/winget/realgarit.PKHeXAvalonia.*.yaml`
+
+Prerequisite: a release with a signed `PKHeX-Avalonia-Setup.exe` — winget
+also flags unsigned installers during validation and Microsoft's manual
+review is far more likely to reject them.
+
+1. Replace `{{VERSION}}` in all three files and `{{INSTALLER_SHA256}}` in
+   the installer manifest (`Get-FileHash PKHeX-Avalonia-Setup.exe -Algorithm
+   SHA256` on Windows, or `sha256sum` elsewhere).
+2. Easiest path: `wingetcreate update realgarit.PKHeXAvalonia -u
+   https://github.com/realgarit/PKHeX-Avalonia/releases/download/v<version>/PKHeX-Avalonia-Setup.exe
+   -v <version> -s` (the `-s` submits a PR directly if you're
+   authenticated with `gh`).
+3. Manual path: `winget validate --manifest packaging/winget/` then copy the
+   three files into a fork of `microsoft/winget-pkgs` under
+   `manifests/r/realgarit/PKHeXAvalonia/<version>/` and open a PR.
+
+## Summary: what's automatic vs. gated vs. manual
+
+- **Fully automatic, every release:** zip artifacts (all platforms),
+  AppImage, `.dmg` (signed or unsigned), Windows installer (signed or
+  unsigned), GitHub Release creation and asset upload.
+- **Gated on secrets (automatic once configured):** Developer ID codesigning
+  + notarization/stapling for macOS, code signing for the Windows installer
+  and exe.
+- **Manual, one-time-per-version, by design (cannot be automated without
+  publishing into third-party repos on the maintainer's behalf):**
+  submitting the Homebrew cask and winget manifest PRs. Flathub packaging is
+  left as future work.

--- a/packaging/homebrew/pkhex-avalonia.rb
+++ b/packaging/homebrew/pkhex-avalonia.rb
@@ -1,0 +1,30 @@
+# Homebrew Cask template for PKHeX-Avalonia.
+#
+# This is NOT auto-published. Once a signed & notarized macOS release exists,
+# submit it to homebrew/homebrew-cask following docs/packaging.md:
+#   1. Fill in `version` and both `sha256` values from the release's .dmg files
+#      (`shasum -a 256 PKHeX-Avalonia-osx-arm64.dmg PKHeX-Avalonia-osx-x64.dmg`).
+#   2. `brew bump-cask-pr` or open a PR against homebrew/homebrew-cask with
+#      this file renamed to Casks/p/pkhex-avalonia.rb.
+cask "pkhex-avalonia" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.29.0"
+  sha256 arm:   "REPLACE_WITH_OSX_ARM64_DMG_SHA256",
+         intel: "REPLACE_WITH_OSX_X64_DMG_SHA256"
+
+  url "https://github.com/realgarit/PKHeX-Avalonia/releases/download/v#{version}/PKHeX-Avalonia-osx-#{arch}.dmg"
+  name "PKHeX-Avalonia"
+  desc "Avalonia-based save editor for Pokémon games"
+  homepage "https://github.com/realgarit/PKHeX-Avalonia"
+
+  auto_updates false
+  depends_on macos: ">= :big_sur"
+
+  app "PKHeX.Avalonia.app"
+
+  zap trash: [
+    "~/Library/Application Support/PKHeX.Avalonia",
+    "~/Library/Preferences/io.pkhex.avalonia.plist",
+  ]
+end

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,0 +1,64 @@
+; Inno Setup script for PKHeX-Avalonia.
+;
+; Built automatically by .github/workflows/release.yml on the windows-latest
+; runner via chocolatey's `innosetup` package. Invoked as:
+;
+;   ISCC.exe /DMyAppVersion=<version> /DSourceDir=<publish dir> /DOutputDir=<out dir> installer.iss
+;
+; The three defines above are supplied by CI; fallback values below let the
+; script also run locally (e.g. `iscc packaging\windows\installer.iss`)
+; against a `publish` folder produced by `dotnet publish`.
+
+#ifndef MyAppVersion
+#define MyAppVersion "0.0.0"
+#endif
+#ifndef SourceDir
+#define SourceDir "..\..\publish"
+#endif
+#ifndef OutputDir
+#define OutputDir "."
+#endif
+
+#define MyAppName "PKHeX-Avalonia"
+#define MyAppPublisher "realgarit"
+#define MyAppURL "https://github.com/realgarit/PKHeX-Avalonia"
+#define MyAppExeName "PKHeX.Avalonia.exe"
+
+[Setup]
+; Fixed GUID so upgrades/uninstalls track the same product across versions.
+AppId={{B6C9F1B4-7B7B-4B7A-9C2E-8B6C9C7B7B7B}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+OutputDir={#OutputDir}
+OutputBaseFilename=PKHeX-Avalonia-Setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+SetupIconFile=..\..\PKHeX.Avalonia\Assets\Icons\icon.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent

--- a/packaging/winget/realgarit.PKHeXAvalonia.installer.yaml
+++ b/packaging/winget/realgarit.PKHeXAvalonia.installer.yaml
@@ -1,0 +1,16 @@
+# winget manifest template — installer manifest.
+# See realgarit.PKHeXAvalonia.yaml for submission instructions.
+PackageIdentifier: realgarit.PKHeXAvalonia
+PackageVersion: "{{VERSION}}"
+InstallerType: inno
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/realgarit/PKHeX-Avalonia/releases/download/v{{VERSION}}/PKHeX-Avalonia-Setup.exe
+    InstallerSha256: "{{INSTALLER_SHA256}}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/realgarit.PKHeXAvalonia.locale.en-US.yaml
+++ b/packaging/winget/realgarit.PKHeXAvalonia.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# winget manifest template — default locale manifest.
+# See realgarit.PKHeXAvalonia.yaml for submission instructions.
+PackageIdentifier: realgarit.PKHeXAvalonia
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+Publisher: realgarit
+PublisherUrl: https://github.com/realgarit
+PublisherSupportUrl: https://github.com/realgarit/PKHeX-Avalonia/issues
+PackageName: PKHeX-Avalonia
+PackageUrl: https://github.com/realgarit/PKHeX-Avalonia
+License: GPL-3.0-only
+LicenseUrl: https://github.com/realgarit/PKHeX-Avalonia/blob/main/LICENSE
+ShortDescription: Avalonia-based save editor for Pokemon games.
+Moniker: pkhex-avalonia
+Tags:
+  - pokemon
+  - save-editor
+  - avalonia
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/realgarit.PKHeXAvalonia.yaml
+++ b/packaging/winget/realgarit.PKHeXAvalonia.yaml
@@ -1,0 +1,12 @@
+# winget manifest template — version manifest.
+#
+# NOT auto-published. Once a signed Windows installer exists (see
+# docs/packaging.md), fill in {{VERSION}}, run `winget validate` locally,
+# and submit via a PR to microsoft/winget-pkgs under
+# manifests/r/realgarit/PKHeXAvalonia/{{VERSION}}/, or use
+# `wingetcreate update realgarit.PKHeXAvalonia -u <installer-url> -v {{VERSION}}`.
+PackageIdentifier: realgarit.PKHeXAvalonia
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds signed-installer scaffolding and package-manager distribution templates on top of the existing zip/AppImage release flow, per #130. Nothing here changes the release trigger — it's still a push to `main` touching `Directory.Build.props`, or manual `workflow_dispatch`.

### Fully automated, every release (no secrets required)
- Existing `.zip` artifacts (Windows/Linux/macOS) and the Linux `.AppImage` are **unchanged**.
- **macOS:** a `.dmg` containing the `.app` bundle + an `Applications` symlink, built with `hdiutil` (no extra brew install needed).
- **Windows:** an Inno Setup installer (`PKHeX-Avalonia-Setup.exe`) built via `choco install innosetup` + `ISCC.exe` on `windows-latest` — Start Menu/desktop shortcuts, Add/Remove Programs entry, clean uninstall.
- When signing secrets are absent, both the `.dmg` and the installer are explicitly suffixed `-unsigned` (e.g. `PKHeX-Avalonia-osx-arm64-unsigned.dmg`, `PKHeX-Avalonia-Setup-unsigned.exe`) so it's obvious from the filename that Gatekeeper/SmartScreen will still warn.

### Gated on repo secrets (auto-signs once configured — no manual steps)

| Secret | Purpose |
|---|---|
| `MACOS_CERT_P12` | Base64 `.p12` export of a Developer ID Application certificate |
| `MACOS_CERT_PASSWORD` | Password for that `.p12` |
| `MACOS_SIGN_IDENTITY` | Signing identity string, e.g. `Developer ID Application: Name (TEAMID)` |
| `APPLE_NOTARY_KEY_ID` | App Store Connect API key ID |
| `APPLE_NOTARY_KEY` | Base64 `.p8` private key for that API key |
| `APPLE_NOTARY_ISSUER_ID` | Issuer UUID for the API key |
| `WINDOWS_CERT_P12` | Base64 `.pfx`/`.p12` code-signing certificate |
| `WINDOWS_CERT_PASSWORD` | Password for that `.pfx` |

Once all three macOS secrets are present: `codesign --options runtime` (hardened runtime) → `notarytool submit --wait` → `stapler staple` → `.dmg` built from the notarized app, named without `-unsigned`.

Once both Windows secrets are present: `signtool` signs the published exe *and* the built installer exe (SHA-256, DigiCert RFC 3161 timestamp), named without `-unsigned`.

Full secret setup instructions: `docs/packaging.md`.

### Manual by design (cannot be automated without publishing into third-party repos on the maintainer's behalf)
- **Homebrew cask** (`packaging/homebrew/pkhex-avalonia.rb`) and **winget manifest** (`packaging/winget/realgarit.PKHeXAvalonia*.yaml`) templates are included, with exact submission commands in `docs/packaging.md` (`brew bump-cask-pr`, `wingetcreate update` / `winget validate`). These require signed release artifacts to exist first — Homebrew/winget both reject unsigned binaries.
- **Flathub** is deferred (not scaffolded): it requires a from-source Flatpak manifest rather than bundling a self-contained `dotnet publish` output, which is a materially larger effort than an additive CI step. Rationale documented in `docs/packaging.md`.

### Verification performed
- `release.yml` parses cleanly via `python3 -c "yaml.safe_load(...)"` (no `actionlint`/`yamllint` available in this environment).
- `dotnet build PKHeX.sln -c Release` → 0 warnings, 0 errors (no application source touched).
- The exact "Build DMG" shell logic (`hdiutil create -format UDZO ...`) was run locally on macOS against a fake `.app` bundle and produced a valid `.dmg`.
- `packaging/windows/installer.iss` was reviewed by hand for Inno Setup section/syntax correctness — `ISCC.exe` can't run outside Windows so it hasn't been compiled.

### Honest caveats
- The Windows (`choco`/`ISCC`/`signtool`) and macOS (`codesign`/`notarytool`/`stapler`) signing and installer steps can only be fully proven by an actual tagged release run in CI — this PR does not (and cannot, without a real macOS/Windows CI run) trigger that.
- **No signed artifacts can exist until the repo owner adds the certificates/keys listed above as repo secrets** (see `docs/packaging.md`). Until then every macOS/Windows installer build will be the `-unsigned` variant, which is expected and safe (same trust level as today's ad-hoc-signed zips).

### Hard rules respected
- `PKHeX.Core/` untouched.
- `Directory.Build.props` only touched for the mandatory UIVersion bump (`1.29.0` → `1.29.1`, patch — chore/infra change).
- Additive only: existing zip/AppImage artifacts and the release trigger are unchanged.

## Test plan
- [ ] CI `ci.yml` passes on this PR (no source/test changes expected to break).
- [ ] After merge, a real tagged release run confirms: `.dmg`/installer build succeeds unsigned; once secrets are added by the repo owner, a follow-up release run confirms signed/notarized artifacts and stapling.
- [ ] Homebrew cask / winget manifest PRs submitted manually once a signed release exists (tracked outside this repo).

Closes #130