### PR TITLE
feat: LiveHeX — live console box editing over Wi-Fi (#124)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.29.1</UIVersion>
+    <UIVersion>1.30.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IDialogService.cs
+++ b/PKHeX.Application/Abstractions/IDialogService.cs
@@ -11,6 +11,12 @@ public interface IDialogService
     Task<string?> SaveFileAsync(string title, string? defaultFileName = null, string[]? filters = null);
     Task ShowErrorAsync(string title, string message);
     Task ShowInformationAsync(string title, string message);
+
+    /// <summary>
+    /// Shows a modal confirm/cancel prompt. Returns <see langword="true"/> only when the user
+    /// explicitly confirms. Used to gate destructive actions such as writing to a live console.
+    /// </summary>
+    Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "Yes", string cancelText = "Cancel");
     Task<string?> GetClipboardTextAsync();
     Task SetClipboardTextAsync(string text);
 }

--- a/PKHeX.Application/Abstractions/LiveHex/IConsoleConnection.cs
+++ b/PKHeX.Application/Abstractions/LiveHex/IConsoleConnection.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace PKHeX.Application.Abstractions.LiveHex;
+
+/// <summary>
+/// Low-level, framework-free abstraction over a single console memory-injection connection
+/// (sys-botbase over TCP). This is the Application-layer port for all network IO; the concrete
+/// socket implementation lives in the Infrastructure layer and this interface is fully mockable
+/// so protocol/box logic can be unit-tested against a fake console.
+/// </summary>
+/// <remarks>
+/// All members are synchronous because the sys-botbase wire protocol is a strict
+/// request/response exchange over a single socket. Higher layers marshal these onto a background
+/// thread to keep the UI responsive.
+/// </remarks>
+public interface IConsoleConnection : IDisposable
+{
+    /// <summary>True while the underlying socket is connected.</summary>
+    bool Connected { get; }
+
+    /// <summary>Opens the socket to <paramref name="ip"/>:<paramref name="port"/>.</summary>
+    /// <param name="ip">Console IP address.</param>
+    /// <param name="port">sys-botbase port (default 6000).</param>
+    /// <param name="timeoutMs">Connect/read/write timeout in milliseconds.</param>
+    /// <exception cref="LiveHexConnectionException">Thrown when the connection cannot be established.</exception>
+    void Connect(string ip, int port, int timeoutMs);
+
+    /// <summary>Closes the socket. Safe to call when already disconnected.</summary>
+    void Disconnect();
+
+    /// <summary>Reads <paramref name="length"/> bytes from the heap-relative <paramref name="offset"/>.</summary>
+    byte[] ReadHeap(ulong offset, int length);
+
+    /// <summary>Writes <paramref name="data"/> to the heap-relative <paramref name="offset"/>.</summary>
+    void WriteHeap(ReadOnlySpan<byte> data, ulong offset);
+
+    /// <summary>Reads <paramref name="length"/> bytes from the main-NSO-relative <paramref name="offset"/>.</summary>
+    byte[] ReadMain(ulong offset, int length);
+
+    /// <summary>Reads <paramref name="length"/> bytes from the absolute <paramref name="offset"/>.</summary>
+    byte[] ReadAbsolute(ulong offset, int length);
+
+    /// <summary>Writes <paramref name="data"/> to the absolute <paramref name="offset"/>.</summary>
+    void WriteAbsolute(ReadOnlySpan<byte> data, ulong offset);
+
+    /// <summary>Requests the heap base address of the attached process.</summary>
+    ulong GetHeapBase();
+
+    /// <summary>Requests the title id (16 hex chars) of the attached process.</summary>
+    string GetTitleId();
+
+    /// <summary>Requests the sys-botbase version string.</summary>
+    string GetBotbaseVersion();
+
+    /// <summary>Requests a piece of running-game information (e.g. <c>"version"</c>).</summary>
+    string GetGameInfo(string info);
+}

--- a/PKHeX.Application/Abstractions/LiveHex/IConsoleConnectionFactory.cs
+++ b/PKHeX.Application/Abstractions/LiveHex/IConsoleConnectionFactory.cs
@@ -1,0 +1,12 @@
+namespace PKHeX.Application.Abstractions.LiveHex;
+
+/// <summary>
+/// Creates fresh <see cref="IConsoleConnection"/> instances. Lets the LiveHeX service open a new
+/// socket per session while remaining decoupled from the concrete Infrastructure socket type
+/// (and trivially fakeable in tests).
+/// </summary>
+public interface IConsoleConnectionFactory
+{
+    /// <summary>Creates a new, unconnected console connection.</summary>
+    IConsoleConnection Create();
+}

--- a/PKHeX.Application/Abstractions/LiveHex/ILiveHexService.cs
+++ b/PKHeX.Application/Abstractions/LiveHex/ILiveHexService.cs
@@ -1,0 +1,68 @@
+using System.Threading;
+using System.Threading.Tasks;
+using PKHeX.Core;
+
+namespace PKHeX.Application.Abstractions.LiveHex;
+
+/// <summary>
+/// Game-support classification for a loaded <see cref="SaveFile"/>.
+/// </summary>
+/// <param name="Supported">Whether LiveHeX box read/write is available for this save type.</param>
+/// <param name="GameName">Human-readable game name (e.g. "Sword/Shield").</param>
+/// <param name="Detail">Supplementary note (supported firmware versions, or why it is unsupported).</param>
+public readonly record struct LiveHexGameSupport(bool Supported, string GameName, string Detail);
+
+/// <summary>
+/// Details about the currently attached console, populated on a successful connect.
+/// </summary>
+/// <param name="TitleId">Attached process title id.</param>
+/// <param name="BotbaseVersion">Reported sys-botbase version.</param>
+/// <param name="GameVersion">Reported running-game version (e.g. "1.3.2").</param>
+/// <param name="ProfileLabel">The matched offset-profile label used for box addressing.</param>
+public readonly record struct LiveHexSessionInfo(string TitleId, string BotbaseVersion, string GameVersion, string ProfileLabel);
+
+/// <summary>
+/// High-level, ViewModel-facing LiveHeX port: connect to a console over Wi-Fi (sys-botbase TCP),
+/// detect game support, and read/write the current box between the console and a
+/// <see cref="SaveFile"/>. All network IO happens behind this port; the implementation lives in
+/// the Infrastructure layer and is injectable/mockable.
+/// </summary>
+public interface ILiveHexService
+{
+    /// <summary>True while a console session is open.</summary>
+    bool IsConnected { get; }
+
+    /// <summary>Session details once connected; <see langword="null"/> otherwise.</summary>
+    LiveHexSessionInfo? Session { get; }
+
+    /// <summary>Classifies whether the given save type is supported by LiveHeX.</summary>
+    LiveHexGameSupport GetSupport(SaveFile sav);
+
+    /// <summary>
+    /// Opens a sys-botbase connection and validates that the attached game matches
+    /// <paramref name="sav"/> and runs a supported firmware version.
+    /// </summary>
+    /// <exception cref="LiveHexConnectionException">On any connect/validation failure.</exception>
+    Task ConnectAsync(string ip, int port, SaveFile sav, CancellationToken cancellationToken = default);
+
+    /// <summary>Closes the console connection. Safe to call when not connected.</summary>
+    Task DisconnectAsync();
+
+    /// <summary>
+    /// Reads box <paramref name="box"/> from the console and applies it to <paramref name="sav"/>
+    /// (via <see cref="SaveFile.SetBoxBinary"/>).
+    /// </summary>
+    /// <exception cref="LiveHexConnectionException">On any IO/protocol failure.</exception>
+    Task ReadBoxAsync(SaveFile sav, int box, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes box <paramref name="box"/> from <paramref name="sav"/> (via
+    /// <see cref="SaveFile.GetBoxBinary"/>) back to the console.
+    /// </summary>
+    /// <remarks>
+    /// This performs no confirmation of its own; callers MUST obtain explicit user confirmation
+    /// before invoking it (see the LiveHeX ViewModel).
+    /// </remarks>
+    /// <exception cref="LiveHexConnectionException">On any IO/protocol failure.</exception>
+    Task WriteBoxAsync(SaveFile sav, int box, CancellationToken cancellationToken = default);
+}

--- a/PKHeX.Application/Abstractions/LiveHex/LiveHexConnectionException.cs
+++ b/PKHeX.Application/Abstractions/LiveHex/LiveHexConnectionException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace PKHeX.Application.Abstractions.LiveHex;
+
+/// <summary>
+/// Raised when a LiveHeX operation fails in a way that should be surfaced to the user with a clear,
+/// actionable message (unreachable console, wrong game, unsupported firmware, timeout, protocol
+/// error). Carrying a dedicated type lets the ViewModel render the message without leaking raw
+/// socket/format exceptions.
+/// </summary>
+public sealed class LiveHexConnectionException : Exception
+{
+    public LiveHexConnectionException(string message) : base(message) { }
+    public LiveHexConnectionException(string message, Exception inner) : base(message, inner) { }
+}

--- a/PKHeX.Avalonia/Services/DialogService.cs
+++ b/PKHeX.Avalonia/Services/DialogService.cs
@@ -85,6 +85,50 @@ public sealed class DialogService : IDialogService
     public async Task ShowErrorAsync(string title, string message) => await ShowMessageBoxAsync(title, message);
     public async Task ShowInformationAsync(string title, string message) => await ShowMessageBoxAsync(title, message);
 
+    public async Task<bool> ShowConfirmationAsync(string title, string message, string confirmText = "Yes", string cancelText = "Cancel")
+    {
+        var window = GetMainWindow();
+        if (window is null) return false;
+
+        var confirmButton = new Button { Content = confirmText, MinWidth = 90 };
+        var cancelButton = new Button { Content = cancelText, MinWidth = 90 };
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 440,
+            MinHeight = 130,
+            MaxWidth = 620,
+            MaxHeight = 520,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Content = new StackPanel
+            {
+                Margin = new Thickness(20),
+                Spacing = 16,
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        Spacing = 12,
+                        Children = { cancelButton, confirmButton },
+                    },
+                },
+            },
+        };
+
+        var result = false;
+        confirmButton.Click += (_, _) => { result = true; dialog.Close(); };
+        cancelButton.Click += (_, _) => { result = false; dialog.Close(); };
+
+        await dialog.ShowDialog(window);
+        return result;
+    }
+
     private async Task ShowMessageBoxAsync(string title, string message)
     {
         var window = GetMainWindow();

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -50,6 +50,7 @@ public static class ViewLocator
         [typeof(JoinAvenueEditorViewModel)] = () => new JoinAvenueEditor(),
         [typeof(LegalityAuditViewModel)] = () => new LegalityAuditView(),
         [typeof(LegalityViewModel)] = () => new LegalityView(),
+        [typeof(LiveHeXViewModel)] = () => new LiveHeXView(),
         [typeof(Link6EditorViewModel)] = () => new Link6Editor(),
         [typeof(MailBoxEditorViewModel)] = () => new MailBoxEditor(),
         [typeof(MedalEditorViewModel)] = () => new MedalEditorView(),

--- a/PKHeX.Avalonia/Views/LiveHeXView.axaml
+++ b/PKHeX.Avalonia/Views/LiveHeXView.axaml
@@ -1,0 +1,80 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="520"
+             x:Class="PKHeX.Avalonia.Views.LiveHeXView"
+             x:DataType="vm:LiveHeXViewModel"
+             MinWidth="440" MinHeight="460" Width="480" Height="520">
+
+    <DockPanel Margin="12">
+        <TextBlock DockPanel.Dock="Top" Text="LiveHeX" FontSize="16" FontWeight="SemiBold" />
+        <TextBlock DockPanel.Dock="Top" Margin="0,2,0,10"
+                   Text="Read and write the current box on a hacked console over Wi-Fi (sys-botbase)."
+                   TextWrapping="Wrap"
+                   Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" />
+
+        <!-- Status bar -->
+        <Border DockPanel.Dock="Bottom" Margin="0,10,0,0" Padding="8"
+                BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}">
+            <StackPanel Spacing="6">
+                <TextBlock Text="{Binding Status}" TextWrapping="Wrap" FontSize="12" />
+                <TextBlock Text="{Binding SessionInfo}" TextWrapping="Wrap" FontSize="11"
+                           Foreground="{DynamicResource ThemeTextMutedBrush}"
+                           IsVisible="{Binding SessionInfo, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+        </Border>
+
+        <StackPanel Spacing="12">
+            <!-- Game support -->
+            <Border Padding="8" BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{Binding GameName}" FontWeight="SemiBold" FontSize="13" />
+                    <TextBlock Text="{Binding SupportDetail}" TextWrapping="Wrap" FontSize="12"
+                               Foreground="{DynamicResource ThemeTextMutedBrush}" />
+                </StackPanel>
+            </Border>
+
+            <!-- Connection panel -->
+            <Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="Auto,Auto"
+                  ColumnSpacing="8" RowSpacing="8">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Console IP" VerticalAlignment="Center" />
+                <TextBox Grid.Row="0" Grid.Column="1"
+                         Text="{Binding IpAddress}" Watermark="192.168.0.1"
+                         IsEnabled="{Binding !IsConnected}" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Text="Port" VerticalAlignment="Center" />
+                <TextBox Grid.Row="0" Grid.Column="3" Width="70"
+                         Text="{Binding Port}"
+                         IsEnabled="{Binding !IsConnected}" />
+
+                <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="4"
+                            Orientation="Horizontal" Spacing="8">
+                    <Button Content="Connect" Classes="accent" Command="{Binding ConnectCommand}" />
+                    <Button Content="Disconnect" Command="{Binding DisconnectCommand}" />
+                    <ProgressBar IsIndeterminate="True" Width="110" VerticalAlignment="Center"
+                                 IsVisible="{Binding IsBusy}" />
+                </StackPanel>
+            </Grid>
+
+            <!-- Box transfer -->
+            <StackPanel Spacing="6">
+                <TextBlock Text="Current box" FontWeight="SemiBold" FontSize="13" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="Read box from console" Command="{Binding ReadBoxCommand}" />
+                    <Button Content="Write box to console" Command="{Binding WriteBoxCommand}"
+                            ToolTip.Tip="Overwrites the current box on the console (asks for confirmation first)" />
+                </StackPanel>
+                <TextBlock Text="Writes overwrite the current box on the console and always ask for confirmation first."
+                           TextWrapping="Wrap" FontSize="11"
+                           Foreground="{DynamicResource ThemeTextMutedBrush}" />
+            </StackPanel>
+
+            <!-- Support matrix -->
+            <Expander Header="Supported games">
+                <SelectableTextBlock Text="{Binding SupportMatrix}" TextWrapping="Wrap"
+                                     FontSize="12" Padding="4" />
+            </Expander>
+        </StackPanel>
+    </DockPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/LiveHeXView.axaml.cs
+++ b/PKHeX.Avalonia/Views/LiveHeXView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class LiveHeXView : UserControl
+{
+    public LiveHeXView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -37,6 +37,7 @@
                     <MenuItem Header="Export All Boxes to Clipboard" Command="{Binding ExportShowdownAllBoxesCommand}" />
                 </MenuItem>
                 <MenuItem Header="Auto Legality Mod…" Command="{Binding OpenAutoLegalityModCommand}" />
+                <MenuItem Header="LiveHeX…" Command="{Binding OpenLiveHeXCommand}" />
                 <MenuItem Header="QR Code">
                     <MenuItem Header="Show Current Pokémon…" Command="{Binding ShowQrCodeCommand}" />
                     <MenuItem Header="Import from Image…" Command="{Binding ImportQrCodeCommand}" />

--- a/PKHeX.Infrastructure/DependencyInjection.cs
+++ b/PKHeX.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using PKHeX.Application.Abstractions;
+using PKHeX.Application.Abstractions.LiveHex;
 using PKHeX.Infrastructure.AutoLegality;
 using PKHeX.Infrastructure.Configuration;
+using PKHeX.Infrastructure.LiveHex;
 
 namespace PKHeX.Infrastructure;
 
@@ -15,6 +17,8 @@ public static class DependencyInjection
         services.AddSingleton<ISettingsStore, SettingsStore>();
         services.AddSingleton<IUpdateCheckService, GitHubUpdateCheckService>();
         services.AddSingleton<IAutoLegalityService, AutoLegalityService>();
+        services.AddSingleton<IConsoleConnectionFactory, SysBotConnectionFactory>();
+        services.AddSingleton<ILiveHexService, LiveHexService>();
         return services;
     }
 }

--- a/PKHeX.Infrastructure/LiveHex/HexCodec.cs
+++ b/PKHeX.Infrastructure/LiveHex/HexCodec.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// Hex encoding/decoding helpers for the sys-botbase wire protocol. Poke payloads are sent as
+/// upper-case hex; peek responses arrive as an ASCII hex string terminated by a newline.
+/// </summary>
+internal static class HexCodec
+{
+    /// <summary>Encodes <paramref name="data"/> as an upper-case hex string (no separators).</summary>
+    public static string ToHex(ReadOnlySpan<byte> data)
+    {
+        var sb = new StringBuilder(data.Length * 2);
+        foreach (var b in data)
+            sb.Append(b.ToString("X2"));
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Decodes an ASCII hex response (<paramref name="asciiHex"/>) into <paramref name="dest"/>.
+    /// The response length must be exactly twice the destination length.
+    /// </summary>
+    public static void DecodeInto(ReadOnlySpan<byte> asciiHex, Span<byte> dest)
+    {
+        if (asciiHex.Length != dest.Length * 2)
+            throw new FormatException($"Console returned {asciiHex.Length} hex chars; expected {dest.Length * 2}.");
+        Convert.FromHexString(asciiHex, dest, out _, out _);
+    }
+}

--- a/PKHeX.Infrastructure/LiveHex/LiveHexBoxAddressing.cs
+++ b/PKHeX.Infrastructure/LiveHex/LiveHexBoxAddressing.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Buffers.Binary;
+using PKHeX.Application.Abstractions.LiveHex;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// Reads and writes a single box of raw (encrypted, party-size) Pokémon bytes to/from console RAM
+/// according to a game's <see cref="LiveHexGameProfile"/>. The byte layout of a box in console RAM
+/// is identical to <see cref="PKHeX.Core.SaveFile.GetBoxBinary"/>/<c>SetBoxBinary</c> for the
+/// supported games, so callers can bridge directly through the loaded save.
+/// </summary>
+internal static class LiveHexBoxAddressing
+{
+    public static byte[] ReadBox(IConsoleConnection connection, LiveHexGameProfile profile, int box, int slotSize, int slotCount)
+    {
+        int boxLength = slotSize * slotCount;
+        switch (profile.Mode)
+        {
+            case BoxAddressingMode.HeapFlat:
+                return connection.ReadHeap(profile.HeapBoxStart + (ulong)(box * boxLength), boxLength);
+
+            case BoxAddressingMode.PointerContiguous:
+            {
+                var boxStart = ResolveBase(connection, profile) + (ulong)(box * boxLength);
+                return connection.ReadHeap(boxStart, boxLength);
+            }
+
+            case BoxAddressingMode.PointerScatter:
+            {
+                var pointers = GetMonPointers(connection, profile, box, slotCount);
+                var result = new byte[boxLength];
+                for (int i = 0; i < slotCount; i++)
+                {
+                    var mon = connection.ReadAbsolute(pointers[i] + 0x20, slotSize);
+                    mon.CopyTo(result.AsSpan(i * slotSize));
+                }
+                return result;
+            }
+
+            default:
+                throw new LiveHexConnectionException("Unsupported box addressing mode.");
+        }
+    }
+
+    public static void WriteBox(IConsoleConnection connection, LiveHexGameProfile profile, int box, ReadOnlySpan<byte> boxData, int slotSize, int slotCount)
+    {
+        int boxLength = slotSize * slotCount;
+        switch (profile.Mode)
+        {
+            case BoxAddressingMode.HeapFlat:
+                connection.WriteHeap(boxData, profile.HeapBoxStart + (ulong)(box * boxLength));
+                break;
+
+            case BoxAddressingMode.PointerContiguous:
+            {
+                var boxStart = ResolveBase(connection, profile) + (ulong)(box * boxLength);
+                connection.WriteHeap(boxData, boxStart);
+                break;
+            }
+
+            case BoxAddressingMode.PointerScatter:
+            {
+                var pointers = GetMonPointers(connection, profile, box, slotCount);
+                for (int i = 0; i < slotCount; i++)
+                    connection.WriteAbsolute(boxData.Slice(i * slotSize, slotSize), pointers[i] + 0x20);
+                break;
+            }
+
+            default:
+                throw new LiveHexConnectionException("Unsupported box addressing mode.");
+        }
+    }
+
+    private static ulong ResolveBase(IConsoleConnection connection, LiveHexGameProfile profile)
+    {
+        var address = PointerResolver.Resolve(connection, profile.PointerExpr);
+        if (address == PointerResolver.InvalidPointer)
+            throw new LiveHexConnectionException(
+                "Failed to resolve the box memory pointer. Make sure the game is running and you are past the title screen.");
+        return address;
+    }
+
+    private static ulong[] GetMonPointers(IConsoleConnection connection, LiveHexGameProfile profile, int box, int slotCount)
+    {
+        var listAddress = ResolveBase(connection, profile);
+        var table = connection.ReadHeap(listAddress, profile.ScatterPointerCount * 8);
+        if (table.Length == 0 || table[0] == 0)
+            throw new LiveHexConnectionException(
+                "The console returned an empty box list. Make sure the game is running and you are past the title screen.");
+
+        var boxObjectPointer = BinaryPrimitives.ReadUInt64LittleEndian(table.AsSpan(box * 8)) + 0x20;
+        var monTable = connection.ReadAbsolute(boxObjectPointer, slotCount * 8);
+        var pointers = new ulong[slotCount];
+        for (int i = 0; i < slotCount; i++)
+            pointers[i] = BinaryPrimitives.ReadUInt64LittleEndian(monTable.AsSpan(i * 8));
+        return pointers;
+    }
+}

--- a/PKHeX.Infrastructure/LiveHex/LiveHexGameProfiles.cs
+++ b/PKHeX.Infrastructure/LiveHex/LiveHexGameProfiles.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PKHeX.Core;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>How a game lays out its box data in console RAM.</summary>
+internal enum BoxAddressingMode
+{
+    /// <summary>Boxes are a contiguous region at a fixed heap offset (SwSh).</summary>
+    HeapFlat,
+
+    /// <summary>Boxes are a contiguous region behind a pointer chain (SV, PLA).</summary>
+    PointerContiguous,
+
+    /// <summary>Each stored Pokémon is behind its own pointer (BDSP managed heap objects).</summary>
+    PointerScatter,
+}
+
+/// <summary>
+/// Immutable addressing profile for one (game, firmware) pair. Sizes are taken from the loaded
+/// <see cref="SaveFile"/> at runtime; this record only carries the console-RAM addressing data.
+/// </summary>
+internal sealed record LiveHexGameProfile(
+    string GameName,
+    string GameVersion,
+    BoxAddressingMode Mode,
+    ulong HeapBoxStart,      // HeapFlat
+    string PointerExpr,      // PointerContiguous / PointerScatter box-list pointer
+    int ScatterPointerCount) // PointerScatter: entries in the box-list pointer table
+{
+    public string Label => $"{GameName} v{GameVersion}";
+}
+
+/// <summary>
+/// The LiveHeX game-support matrix. Every constant here is factual console-RAM offset data mirrored
+/// from the upstream PKHeX-Plugins <c>RamOffsets</c>/<c>LP*</c> tables at the pinned commit
+/// (see <c>NOTICE.LiveHeX.md</c>). Keys are the sys-botbase title id plus the reported game version.
+/// </summary>
+internal static class LiveHexGameProfiles
+{
+    // --- Switch title ids (from sys-botbase getTitleID) ---
+    private const string Sword = "0100ABF008968000";
+    private const string Shield = "01008DB008C2C000";
+    private const string BrilliantDiamond = "0100000011D90000";
+    private const string ShiningPearl = "010018E011D92000";
+    private const string LegendsArceus = "01001F5010DFA000";
+    private const string Scarlet = "0100A3D008C5C000";
+    private const string Violet = "01008F6008C5E000";
+
+    private static readonly HashSet<string> SwShTitles = [Sword, Shield];
+    private static readonly HashSet<string> BdspTitles = [BrilliantDiamond, ShiningPearl];
+    private static readonly HashSet<string> SvTitles = [Scarlet, Violet];
+
+    /// <summary>Whether the save type is supported by LiveHeX at all.</summary>
+    public static bool IsSupported(SaveFile sav) => sav is SAV8SWSH or SAV8BS or SAV8LA or SAV9SV;
+
+    public static string GetGameName(SaveFile sav) => sav switch
+    {
+        SAV8SWSH => "Sword/Shield",
+        SAV8BS => "Brilliant Diamond/Shining Pearl",
+        SAV8LA => "Legends: Arceus",
+        SAV9SV => "Scarlet/Violet",
+        _ => sav.Version.ToString(),
+    };
+
+    /// <summary>Human-readable list of firmware versions supported for the given save type.</summary>
+    public static string GetSupportedVersions(SaveFile sav) => sav switch
+    {
+        SAV8SWSH => "1.1.1, 1.2.1, 1.3.2",
+        SAV8BS => "1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.0, 1.3.0",
+        SAV8LA => "1.0.0, 1.0.1, 1.0.2, 1.1.1",
+        SAV9SV => "1.0.1, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.3.2, 2.0.1, 2.0.2, 3.0.0, 3.0.1, 4.0.0",
+        _ => "none",
+    };
+
+    /// <summary>Whether the console-reported <paramref name="titleId"/> belongs to the save's game family.</summary>
+    public static bool TitleMatchesSave(SaveFile sav, string titleId) => sav switch
+    {
+        SAV8SWSH => SwShTitles.Contains(titleId),
+        SAV8BS => BdspTitles.Contains(titleId),
+        SAV8LA => titleId == LegendsArceus,
+        SAV9SV => SvTitles.Contains(titleId),
+        _ => false,
+    };
+
+    /// <summary>
+    /// Resolves the addressing profile for the attached console, or <see langword="null"/> when the
+    /// firmware version is not in the support matrix.
+    /// </summary>
+    public static LiveHexGameProfile? Resolve(SaveFile sav, string titleId, string gameVersion)
+    {
+        var v = gameVersion.Trim();
+        return sav switch
+        {
+            SAV8SWSH => SwSh(v),
+            SAV8BS => Bdsp(titleId, v),
+            SAV8LA => Pla(v),
+            SAV9SV => Sv(v),
+            _ => null,
+        };
+    }
+
+    private static LiveHexGameProfile? SwSh(string v)
+    {
+        ulong start = v switch
+        {
+            "1.1.1" => 0x4293D8B0,
+            "1.2.1" => 0x4506D890,
+            "1.3.0" or "1.3.1" or "1.3.2" => 0x45075880,
+            _ => 0,
+        };
+        return start == 0 ? null : new("Sword/Shield", v, BoxAddressingMode.HeapFlat, start, string.Empty, 0);
+    }
+
+    private static LiveHexGameProfile? Sv(string v)
+    {
+        string ptr = v switch
+        {
+            "1.0.1" => "[[[main+42DA8E8]+128]+9B0]",
+            "1.1.0" => "[[[main+4384B18]+128]+9B0]",
+            "1.2.0" => "[[[main+44A98C8]+130]+9B0]",
+            "1.3.0" or "1.3.1" => "[[[main+44BFBA8]+130]+9B0]",
+            "1.3.2" => "[[[main+44C1C18]+130]+9B0]",
+            "2.0.1" => "[[[[main+4622A30]+198]+30]+9D0]",
+            "2.0.2" => "[[[[main+4623A30]+198]+30]+9D0]",
+            "3.0.0" or "3.0.1" or "4.0.0" => "[[[[main+47350d8]+1C0]+30]+9D0]",
+            _ => string.Empty,
+        };
+        return ptr.Length == 0 ? null : new("Scarlet/Violet", v, BoxAddressingMode.PointerContiguous, 0, ptr, 0);
+    }
+
+    private static LiveHexGameProfile? Pla(string v)
+    {
+        string ptr = v switch
+        {
+            "1.0.0" => "[[main+4275470]+1F0]+68",
+            "1.0.1" => "[[main+427B470]+1F0]+68",
+            "1.0.2" => "[[main+427C470]+1F0]+68",
+            "1.1.0" or "1.1.1" => "[[main+42BA6B0]+1F0]+68",
+            _ => string.Empty,
+        };
+        return ptr.Length == 0 ? null : new("Legends: Arceus", v, BoxAddressingMode.PointerContiguous, 0, ptr, 0);
+    }
+
+    private static LiveHexGameProfile? Bdsp(string titleId, string v)
+    {
+        bool sp = titleId == ShiningPearl;
+        string ptr = (sp, v) switch
+        {
+            (_, "1.0.0") => "[[[main+4C0ABD8]+520]+C0]+5E0",
+            (_, "1.1.0") => "[[[main+4E27C50]+B8]+170]+20",
+            (false, "1.1.1") => "[[[[main+4C1DCF8]+B8]+10]+A0]+20",
+            (true, "1.1.1") => "[[[[main+4E34DD0]+B8]+10]+A0]+20",
+            (_, "1.1.2") => "[[[[main+4E34DD0]+B8]+10]+A0]+20",
+            (_, "1.1.3") => "[[[[main+4E59E60]+B8]+10]+A0]+20",
+            (_, "1.2.0") => "[[[[main+4E36C58]+B8]+10]+A0]+20",
+            (false, "1.3.0") => "[[[[main+4C64DC0]+B8]+10]+A0]+20",
+            (true, "1.3.0") => "[[[[main+4E7BE98]+B8]+10]+A0]+20",
+            _ => string.Empty,
+        };
+        var name = sp ? "Shining Pearl" : "Brilliant Diamond";
+        return ptr.Length == 0 ? null : new(name, v, BoxAddressingMode.PointerScatter, 0, ptr, 40);
+    }
+}

--- a/PKHeX.Infrastructure/LiveHex/LiveHexService.cs
+++ b/PKHeX.Infrastructure/LiveHex/LiveHexService.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using PKHeX.Application.Abstractions.LiveHex;
+using PKHeX.Core;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// Infrastructure implementation of <see cref="ILiveHexService"/>. Orchestrates a sys-botbase
+/// connection (created via <see cref="IConsoleConnectionFactory"/>), validates the attached game,
+/// and bridges box bytes between console RAM and a <see cref="SaveFile"/>.
+/// </summary>
+public sealed class LiveHexService : ILiveHexService
+{
+    private const int TimeoutMs = 8000;
+
+    private readonly IConsoleConnectionFactory _factory;
+    private IConsoleConnection? _connection;
+    private LiveHexGameProfile? _profile;
+
+    public LiveHexService(IConsoleConnectionFactory factory) => _factory = factory;
+
+    public bool IsConnected => _connection is { Connected: true };
+
+    public LiveHexSessionInfo? Session { get; private set; }
+
+    public LiveHexGameSupport GetSupport(SaveFile sav)
+    {
+        var name = LiveHexGameProfiles.GetGameName(sav);
+        if (LiveHexGameProfiles.IsSupported(sav))
+            return new LiveHexGameSupport(true, name, $"Supported firmware: {LiveHexGameProfiles.GetSupportedVersions(sav)}");
+        return new LiveHexGameSupport(false, name,
+            "LiveHeX supports Sword/Shield, Brilliant Diamond/Shining Pearl, Legends: Arceus and Scarlet/Violet only.");
+    }
+
+    public Task ConnectAsync(string ip, int port, SaveFile sav, CancellationToken cancellationToken = default) =>
+        Task.Run(() => Connect(ip, port, sav), cancellationToken);
+
+    private void Connect(string ip, int port, SaveFile sav)
+    {
+        if (!LiveHexGameProfiles.IsSupported(sav))
+            throw new LiveHexConnectionException("This save type is not supported by LiveHeX.");
+
+        DisconnectInternal();
+
+        var connection = _factory.Create();
+        connection.Connect(ip, port, TimeoutMs); // throws LiveHexConnectionException on failure
+        try
+        {
+            var botbaseVersion = connection.GetBotbaseVersion();
+            var titleId = connection.GetTitleId();
+            if (!LiveHexGameProfiles.TitleMatchesSave(sav, titleId))
+            {
+                throw new LiveHexConnectionException(
+                    $"The console is running a different game (title {titleId}) than the loaded save " +
+                    $"({LiveHexGameProfiles.GetGameName(sav)}). Open the matching save and reconnect.");
+            }
+
+            var gameVersion = connection.GetGameInfo("version");
+            var profile = LiveHexGameProfiles.Resolve(sav, titleId, gameVersion)
+                ?? throw new LiveHexConnectionException(
+                    $"Unsupported game version '{gameVersion}'. Supported versions for " +
+                    $"{LiveHexGameProfiles.GetGameName(sav)}: {LiveHexGameProfiles.GetSupportedVersions(sav)}.");
+
+            _connection = connection;
+            _profile = profile;
+            Session = new LiveHexSessionInfo(titleId, botbaseVersion, gameVersion, profile.Label);
+        }
+        catch
+        {
+            connection.Dispose();
+            _connection = null;
+            _profile = null;
+            Session = null;
+            throw;
+        }
+    }
+
+    public Task DisconnectAsync() => Task.Run(DisconnectInternal);
+
+    private void DisconnectInternal()
+    {
+        _connection?.Dispose();
+        _connection = null;
+        _profile = null;
+        Session = null;
+    }
+
+    public Task ReadBoxAsync(SaveFile sav, int box, CancellationToken cancellationToken = default) =>
+        Task.Run(() =>
+        {
+            var (connection, profile) = RequireSession(sav, box);
+            var bytes = LiveHexBoxAddressing.ReadBox(connection, profile, box, sav.SIZE_BOXSLOT, sav.BoxSlotCount);
+            if (!sav.SetBoxBinary(bytes, box))
+            {
+                throw new LiveHexConnectionException(
+                    "The box data read from the console could not be applied (the box is overwrite-protected).");
+            }
+        }, cancellationToken);
+
+    public Task WriteBoxAsync(SaveFile sav, int box, CancellationToken cancellationToken = default) =>
+        Task.Run(() =>
+        {
+            var (connection, profile) = RequireSession(sav, box);
+            var bytes = sav.GetBoxBinary(box);
+            LiveHexBoxAddressing.WriteBox(connection, profile, box, bytes, sav.SIZE_BOXSLOT, sav.BoxSlotCount);
+        }, cancellationToken);
+
+    private (IConsoleConnection Connection, LiveHexGameProfile Profile) RequireSession(SaveFile sav, int box)
+    {
+        if (_connection is not { Connected: true } connection || _profile is null)
+            throw new LiveHexConnectionException("Not connected to a console.");
+        if ((uint)box >= (uint)sav.BoxCount)
+            throw new LiveHexConnectionException($"Box {box + 1} is out of range for this save (has {sav.BoxCount} boxes).");
+        return (connection, _profile);
+    }
+}

--- a/PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md
+++ b/PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md
@@ -1,0 +1,39 @@
+# LiveHeX: clean-room sys-botbase client (not vendored)
+
+## Decision: clean-room, not vendored
+
+Unlike the PKHeX.AutoMod legalization engine (which is vendored byte-for-byte from santacrab2/PKHeX-Plugins), the LiveHeX connectivity here is a CLEAN-ROOM re-implementation in this project's Infrastructure layer under namespace `PKHeX.Infrastructure.LiveHex`. The upstream `PKHeX.Core.Injection` project (same repo, commit b78bd4c274b75adf4454ad9cefebe0cbbbacfa19) was evaluated for vendoring but rejected because:
+
+1. It requires a `LibUsbDotNet` (v2.2.29) package reference for its USB controller (`UsbBotMini`); USB is explicitly out of scope for v1, and that package targets old frameworks and risks NU1701 restore warnings against net10.0, which would break this repo's 0-warning build requirement.
+2. It also carries 3DS `NTRClient`/`NTRAPIFramework` code (~500 LOC), dead weight for the Switch-only v1.
+3. `RamOffsets.GetSwitchInterface`/`GetCommunicator` hard-reference `UsbBotMini` and `NTRClient`, so a byte-for-byte subset excluding those files would not compile without editing vendored sources — breaking the byte-for-byte rule.
+4. The sys-botbase wire protocol is tiny and public (ASCII `peek`/`poke`/`peekMain`/`peekAbsolute`/`pokeAbsolute` + hex over TCP port 6000), so a clean-room TCP client is small, dependency-free, and fully unit-testable against a loopback fake — matching the required Application-port / Infrastructure-adapter architecture.
+
+## Attribution
+
+The sys-botbase text-command grammar and the per-game console-RAM offset/pointer constants (box-start heap offsets and pointer expressions for Sword/Shield, Brilliant Diamond/Shining Pearl, Legends: Arceus, Scarlet/Violet) are factual data mirrored from the upstream PKHeX-Plugins `PKHeX.Core.Injection` project (RamOffsets / LPBasic / LPPointer / LPBDSP) at commit b78bd4c274b75adf4454ad9cefebe0cbbbacfa19, and from the sys-botbase project by olliz0r. Credit: Auto-Legality / LiveHeX tooling by architdate, santacrab2 and contributors (GPL-3.0); sys-botbase by olliz0r. This repository is GPL-3.0, compatible.
+
+## Files (clean-room)
+
+- PKHeX.Infrastructure/LiveHex/SwitchCommand.cs — encodes sys-botbase text commands
+- PKHeX.Infrastructure/LiveHex/HexCodec.cs — hex encode/decode for payloads and responses
+- PKHeX.Infrastructure/LiveHex/SysBotConnection.cs — TCP client implementing IConsoleConnection
+- PKHeX.Infrastructure/LiveHex/SysBotConnectionFactory.cs — factory for real connections
+- PKHeX.Infrastructure/LiveHex/PointerResolver.cs — resolves pointer-expression chains
+- PKHeX.Infrastructure/LiveHex/LiveHexGameProfiles.cs — game-support matrix + RAM offset/pointer tables
+- PKHeX.Infrastructure/LiveHex/LiveHexBoxAddressing.cs — reads/writes a box via the three addressing modes
+- PKHeX.Infrastructure/LiveHex/LiveHexService.cs — ILiveHexService orchestration
+- Application-layer ports: PKHeX.Application/Abstractions/LiveHex/{IConsoleConnection,IConsoleConnectionFactory,ILiveHexService,LiveHexConnectionException}.cs
+
+## Game-support matrix (v1, Wi-Fi / sys-botbase TCP only; USB out of scope)
+
+| Game | Save type | Addressing | Firmware versions |
+| --- | --- | --- | --- |
+| Sword/Shield | SAV8SWSH | flat heap offset | 1.1.1, 1.2.1, 1.3.2 |
+| Brilliant Diamond/Shining Pearl | SAV8BS | per-Pokémon pointer table | 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.0, 1.3.0 |
+| Legends: Arceus | SAV8LA | pointer-resolved contiguous | 1.0.0, 1.0.1, 1.0.2, 1.1.1 |
+| Scarlet/Violet | SAV9SV | pointer-resolved contiguous | 1.0.1, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.3.2, 2.0.1, 2.0.2, 3.0.0, 3.0.1, 4.0.0 |
+
+## Re-sync note
+
+When PKHeX-Plugins is re-synced, re-check the offset/pointer tables in LiveHexGameProfiles.cs against upstream RamOffsets/LP* for the pinned commit and add any newly-supported firmware versions (data-only changes).

--- a/PKHeX.Infrastructure/LiveHex/PointerResolver.cs
+++ b/PKHeX.Infrastructure/LiveHex/PointerResolver.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Buffers.Binary;
+using System.Globalization;
+using PKHeX.Application.Abstractions.LiveHex;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// Resolves a sys-botbase pointer-expression string (e.g. <c>"[[main+44C1C18]+130]+9B0"</c>) to a
+/// concrete memory address by walking the pointer chain over the connection.
+/// </summary>
+/// <remarks>
+/// Clean-room re-implementation of the pointer-walk used by LiveHeX tooling. The pointer-expression
+/// grammar and the per-game offset constants are factual data mirrored from the upstream
+/// PKHeX-Plugins project (see <c>NOTICE.LiveHeX.md</c>).
+/// </remarks>
+internal static class PointerResolver
+{
+    public const ulong InvalidPointer = 0;
+
+    /// <summary>
+    /// Walks <paramref name="pointer"/> and returns the final address. When
+    /// <paramref name="heapRelative"/> is true (the default) the returned address is expressed
+    /// relative to the heap base so it can be used with heap <c>peek</c>/<c>poke</c> commands.
+    /// </summary>
+    public static ulong Resolve(IConsoleConnection connection, string pointer, bool heapRelative = true)
+    {
+        if (string.IsNullOrWhiteSpace(pointer) || pointer.AsSpan().IndexOfAny('-', '/', '*') != -1)
+            return InvalidPointer;
+
+        // "]]" means a dereference with a +0 offset; normalise it so the split below is uniform.
+        while (pointer.Contains("]]"))
+            pointer = pointer.Replace("]]", "]+0]");
+
+        uint finalAdd = 0;
+        if (!pointer.EndsWith(']'))
+        {
+            var tail = pointer[(pointer.LastIndexOf('+') + 1)..];
+            finalAdd = ParseHex(tail);
+            int lastPlus = pointer.LastIndexOf('+');
+            if (lastPlus != -1)
+                pointer = pointer[..lastPlus];
+        }
+
+        var jumps = pointer
+            .Replace("main", string.Empty)
+            .Replace("[", string.Empty)
+            .Replace("]", string.Empty)
+            .Split('+', StringSplitOptions.RemoveEmptyEntries);
+        if (jumps.Length == 0)
+            return InvalidPointer;
+
+        var initialAddress = ParseHex(jumps[0].Trim());
+        ulong address = BinaryPrimitives.ReadUInt64LittleEndian(connection.ReadMain(initialAddress, 0x8));
+        foreach (var jump in jumps)
+        {
+            var val = ParseHex(jump.Trim());
+            if (val == initialAddress)
+            {
+                if (jumps.Length == 1 && finalAdd == 0)
+                    return initialAddress;
+                continue;
+            }
+            address = BinaryPrimitives.ReadUInt64LittleEndian(connection.ReadAbsolute(address + val, 0x8));
+        }
+
+        address += finalAdd;
+        if (heapRelative)
+            address -= connection.GetHeapBase();
+        return address;
+    }
+
+    private static uint ParseHex(string value)
+    {
+        if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            value = value[2..];
+        return uint.Parse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+    }
+}

--- a/PKHeX.Infrastructure/LiveHex/SwitchCommand.cs
+++ b/PKHeX.Infrastructure/LiveHex/SwitchCommand.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// Encodes sys-botbase text commands as ASCII byte arrays for transmission to a Nintendo Switch
+/// running the sys-botbase sys-module.
+/// </summary>
+/// <remarks>
+/// Clean-room re-implementation of the small, well-documented sys-botbase wire protocol
+/// (peek/poke/peekMain/peekAbsolute/pokeAbsolute/getHeapBase/getTitleID/getVersion/game). The
+/// command grammar is a public protocol; see <c>NOTICE.LiveHeX.md</c> for attribution to the
+/// upstream PKHeX-Plugins / sys-botbase projects.
+/// </remarks>
+internal static class SwitchCommand
+{
+    private static byte[] Encode(string command) => Encoding.ASCII.GetBytes(command + "\r\n");
+
+    /// <summary>peek: read <paramref name="count"/> bytes from a heap-relative <paramref name="offset"/>.</summary>
+    public static byte[] Peek(ulong offset, int count) => Encode($"peek 0x{offset:X16} {count}");
+
+    /// <summary>poke: write <paramref name="data"/> to a heap-relative <paramref name="offset"/>.</summary>
+    public static byte[] Poke(ulong offset, ReadOnlySpan<byte> data) => Encode($"poke 0x{offset:X16} 0x{HexCodec.ToHex(data)}");
+
+    /// <summary>peekMain: read <paramref name="count"/> bytes from a main-NSO-relative <paramref name="offset"/>.</summary>
+    public static byte[] PeekMain(ulong offset, int count) => Encode($"peekMain 0x{offset:X16} {count}");
+
+    /// <summary>peekAbsolute: read <paramref name="count"/> bytes from an absolute <paramref name="offset"/>.</summary>
+    public static byte[] PeekAbsolute(ulong offset, int count) => Encode($"peekAbsolute 0x{offset:X16} {count}");
+
+    /// <summary>pokeAbsolute: write <paramref name="data"/> to an absolute <paramref name="offset"/>.</summary>
+    public static byte[] PokeAbsolute(ulong offset, ReadOnlySpan<byte> data) => Encode($"pokeAbsolute 0x{offset:X16} 0x{HexCodec.ToHex(data)}");
+
+    /// <summary>getHeapBase: request the heap base address of the attached process.</summary>
+    public static byte[] GetHeapBase() => Encode("getHeapBase");
+
+    /// <summary>getTitleID: request the title id of the attached process.</summary>
+    public static byte[] GetTitleId() => Encode("getTitleID");
+
+    /// <summary>getVersion: request the sys-botbase version.</summary>
+    public static byte[] GetBotbaseVersion() => Encode("getVersion");
+
+    /// <summary>game: request running-game information (e.g. "version").</summary>
+    public static byte[] GetGameInfo(string info) => Encode($"game {info}");
+}

--- a/PKHeX.Infrastructure/LiveHex/SysBotConnection.cs
+++ b/PKHeX.Infrastructure/LiveHex/SysBotConnection.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using PKHeX.Application.Abstractions.LiveHex;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>
+/// sys-botbase over TCP implementation of <see cref="IConsoleConnection"/>. Owns a single blocking
+/// socket and performs synchronous request/response exchanges guarded by a lock so overlapping
+/// calls from a background worker cannot interleave on the wire.
+/// </summary>
+/// <remarks>
+/// Clean-room implementation; the wire protocol grammar mirrors the public sys-botbase protocol.
+/// See <c>NOTICE.LiveHeX.md</c>.
+/// </remarks>
+public sealed class SysBotConnection : IConsoleConnection
+{
+    private readonly Lock _sync = new();
+    private Socket? _socket;
+    private int _timeoutMs = 8000;
+
+    public bool Connected => _socket is { Connected: true };
+
+    public void Connect(string ip, int port, int timeoutMs)
+    {
+        lock (_sync)
+        {
+            _timeoutMs = timeoutMs;
+            DisconnectInternal();
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+            {
+                ReceiveTimeout = timeoutMs,
+                SendTimeout = timeoutMs,
+                NoDelay = true,
+            };
+            try
+            {
+                var async = socket.BeginConnect(ip, port, null, null);
+                if (!async.AsyncWaitHandle.WaitOne(timeoutMs))
+                {
+                    socket.Close();
+                    throw new LiveHexConnectionException(
+                        $"Timed out connecting to {ip}:{port}. Check the IP address, that the console is on the same Wi-Fi network, and that sys-botbase is running.");
+                }
+                socket.EndConnect(async);
+            }
+            catch (LiveHexConnectionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                throw new LiveHexConnectionException(
+                    $"Could not connect to {ip}:{port}. {ex.Message}", ex);
+            }
+            _socket = socket;
+        }
+    }
+
+    public void Disconnect()
+    {
+        lock (_sync)
+            DisconnectInternal();
+    }
+
+    private void DisconnectInternal()
+    {
+        if (_socket is null)
+            return;
+        try
+        {
+            if (_socket.Connected)
+                _socket.Shutdown(SocketShutdown.Both);
+        }
+        catch
+        {
+            // best-effort; socket may already be torn down
+        }
+        _socket.Dispose();
+        _socket = null;
+    }
+
+    public byte[] ReadHeap(ulong offset, int length) => ReadBytes(SwitchCommand.Peek(offset, length), length);
+    public byte[] ReadMain(ulong offset, int length) => ReadBytes(SwitchCommand.PeekMain(offset, length), length);
+    public byte[] ReadAbsolute(ulong offset, int length) => ReadBytes(SwitchCommand.PeekAbsolute(offset, length), length);
+
+    public void WriteHeap(ReadOnlySpan<byte> data, ulong offset) => Send(SwitchCommand.Poke(offset, data));
+    public void WriteAbsolute(ReadOnlySpan<byte> data, ulong offset) => Send(SwitchCommand.PokeAbsolute(offset, data));
+
+    public ulong GetHeapBase()
+    {
+        var data = ReadBytes(SwitchCommand.GetHeapBase(), 8);
+        return BinaryPrimitives.ReadUInt64BigEndian(data);
+    }
+
+    public string GetTitleId() => ReadLine(SwitchCommand.GetTitleId());
+    public string GetBotbaseVersion() => ReadLine(SwitchCommand.GetBotbaseVersion());
+    public string GetGameInfo(string info) => ReadLine(SwitchCommand.GetGameInfo(info));
+
+    private byte[] ReadBytes(byte[] command, int length)
+    {
+        lock (_sync)
+        {
+            var socket = RequireSocket();
+            SendAll(socket, command);
+            var hex = ReadUntilNewline(socket);
+            var result = new byte[length];
+            HexCodec.DecodeInto(hex, result);
+            return result;
+        }
+    }
+
+    private string ReadLine(byte[] command)
+    {
+        lock (_sync)
+        {
+            var socket = RequireSocket();
+            SendAll(socket, command);
+            var line = ReadUntilNewline(socket);
+            return Encoding.ASCII.GetString(line).Trim('\0', '\r', ' ', '\t');
+        }
+    }
+
+    private void Send(byte[] command)
+    {
+        lock (_sync)
+            SendAll(RequireSocket(), command);
+    }
+
+    private Socket RequireSocket()
+    {
+        if (_socket is not { Connected: true } socket)
+            throw new LiveHexConnectionException("Not connected to a console.");
+        return socket;
+    }
+
+    private void SendAll(Socket socket, byte[] command)
+    {
+        try
+        {
+            int sent = 0;
+            while (sent < command.Length)
+                sent += socket.Send(command, sent, command.Length - sent, SocketFlags.None);
+        }
+        catch (SocketException ex)
+        {
+            throw new LiveHexConnectionException($"Lost connection while sending a command: {ex.SocketErrorCode}.", ex);
+        }
+    }
+
+    // sys-botbase terminates every response with '\n'; hex responses contain no other control chars.
+    private static byte[] ReadUntilNewline(Socket socket)
+    {
+        var buffer = new List<byte>(512);
+        var chunk = new byte[4096];
+        while (true)
+        {
+            int read;
+            try
+            {
+                read = socket.Receive(chunk, SocketFlags.None);
+            }
+            catch (SocketException ex)
+            {
+                if (ex.SocketErrorCode is SocketError.TimedOut or SocketError.WouldBlock)
+                    throw new LiveHexConnectionException("Timed out waiting for a response from the console.", ex);
+                throw new LiveHexConnectionException($"Lost connection while reading a response: {ex.SocketErrorCode}.", ex);
+            }
+
+            if (read == 0)
+                throw new LiveHexConnectionException("The console closed the connection unexpectedly.");
+
+            for (int i = 0; i < read; i++)
+            {
+                if (chunk[i] == (byte)'\n')
+                {
+                    for (int j = 0; j < i; j++)
+                        buffer.Add(chunk[j]);
+                    // trim a trailing carriage return if present
+                    if (buffer.Count > 0 && buffer[^1] == (byte)'\r')
+                        buffer.RemoveAt(buffer.Count - 1);
+                    return buffer.ToArray();
+                }
+            }
+            for (int i = 0; i < read; i++)
+                buffer.Add(chunk[i]);
+        }
+    }
+
+    public void Dispose() => Disconnect();
+}

--- a/PKHeX.Infrastructure/LiveHex/SysBotConnectionFactory.cs
+++ b/PKHeX.Infrastructure/LiveHex/SysBotConnectionFactory.cs
@@ -1,0 +1,9 @@
+using PKHeX.Application.Abstractions.LiveHex;
+
+namespace PKHeX.Infrastructure.LiveHex;
+
+/// <summary>Produces real sys-botbase TCP connections.</summary>
+public sealed class SysBotConnectionFactory : IConsoleConnectionFactory
+{
+    public IConsoleConnection Create() => new SysBotConnection();
+}

--- a/PKHeX.Infrastructure/PKHeX.Infrastructure.csproj
+++ b/PKHeX.Infrastructure/PKHeX.Infrastructure.csproj
@@ -5,6 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Expose internal LiveHeX protocol/addressing helpers to the test project for direct unit testing. -->
+    <InternalsVisibleTo Include="PKHeX.Avalonia.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <ProjectReference Include="..\PKHeX.Application\PKHeX.Application.csproj" />
     <ProjectReference Include="..\PKHeX.Core\PKHeX.Core.csproj" />

--- a/PKHeX.Presentation/ViewModels/LiveHeXViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/LiveHeXViewModel.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Abstractions.LiveHex;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// LiveHeX tool window: connect to a hacked console over Wi-Fi (sys-botbase TCP) and read/write the
+/// currently displayed box. Framework-free; all network IO is delegated to <see cref="ILiveHexService"/>
+/// and all writes are gated behind an explicit confirmation dialog.
+/// </summary>
+public partial class LiveHeXViewModel : ViewModelBase
+{
+    private readonly SaveFile _sav;
+    private readonly ILiveHexService _liveHex;
+    private readonly IDialogService _dialogs;
+    private readonly Func<int> _getCurrentBox;
+    private readonly Action _onBoxUpdated;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    private string _ipAddress = "192.168.0.1";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    private int _port = 6000;
+
+    [ObservableProperty] private string _status;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DisconnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ReadBoxCommand))]
+    [NotifyCanExecuteChangedFor(nameof(WriteBoxCommand))]
+    private bool _isConnected;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DisconnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ReadBoxCommand))]
+    [NotifyCanExecuteChangedFor(nameof(WriteBoxCommand))]
+    private bool _isBusy;
+
+    [ObservableProperty] private string _sessionInfo = string.Empty;
+
+    public LiveHeXViewModel(
+        SaveFile sav,
+        ILiveHexService liveHex,
+        IDialogService dialogs,
+        Func<int> getCurrentBox,
+        Action onBoxUpdated)
+    {
+        _sav = sav;
+        _liveHex = liveHex;
+        _dialogs = dialogs;
+        _getCurrentBox = getCurrentBox;
+        _onBoxUpdated = onBoxUpdated;
+
+        var support = _liveHex.GetSupport(sav);
+        GameName = support.GameName;
+        IsGameSupported = support.Supported;
+        SupportDetail = support.Detail;
+        _status = support.Supported
+            ? "Ready. Enter the console IP and connect."
+            : $"{support.GameName} is not supported by LiveHeX.";
+    }
+
+    /// <summary>Loaded game's display name.</summary>
+    public string GameName { get; }
+
+    /// <summary>Whether LiveHeX supports the loaded save type.</summary>
+    public bool IsGameSupported { get; }
+
+    /// <summary>Support note (supported firmware versions, or why unsupported).</summary>
+    public string SupportDetail { get; }
+
+    /// <summary>Static support matrix shown in the tool window.</summary>
+    public string SupportMatrix =>
+        "Sword/Shield — 1.1.1, 1.2.1, 1.3.2\n" +
+        "Brilliant Diamond/Shining Pearl — 1.0.0–1.3.0\n" +
+        "Legends: Arceus — 1.0.0, 1.0.1, 1.0.2, 1.1.1\n" +
+        "Scarlet/Violet — 1.0.1 through 4.0.0\n\n" +
+        "Connection: sys-botbase over Wi-Fi (TCP, default port 6000). USB is not supported in this version.";
+
+    private bool CanConnect => IsGameSupported && !IsConnected && !IsBusy
+                               && !string.IsNullOrWhiteSpace(IpAddress) && Port is > 0 and <= 65535;
+    private bool CanDisconnect => IsConnected && !IsBusy;
+    private bool CanTransfer => IsConnected && !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanConnect))]
+    private async Task ConnectAsync()
+    {
+        IsBusy = true;
+        Status = $"Connecting to {IpAddress}:{Port}…";
+        try
+        {
+            await _liveHex.ConnectAsync(IpAddress, Port, _sav);
+            IsConnected = _liveHex.IsConnected;
+            if (_liveHex.Session is { } s)
+            {
+                SessionInfo = $"Game: {s.ProfileLabel}   Title: {s.TitleId}   sys-botbase: {s.BotbaseVersion}";
+                Status = $"Connected to {s.ProfileLabel}.";
+            }
+            else
+            {
+                Status = "Connected.";
+            }
+        }
+        catch (LiveHexConnectionException ex)
+        {
+            IsConnected = false;
+            SessionInfo = string.Empty;
+            Status = $"Connection failed: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            IsConnected = false;
+            SessionInfo = string.Empty;
+            Status = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDisconnect))]
+    private async Task DisconnectAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            await _liveHex.DisconnectAsync();
+        }
+        finally
+        {
+            IsConnected = false;
+            SessionInfo = string.Empty;
+            Status = "Disconnected.";
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanTransfer))]
+    private async Task ReadBoxAsync()
+    {
+        var box = _getCurrentBox();
+        IsBusy = true;
+        Status = $"Reading Box {box + 1} from the console…";
+        try
+        {
+            await _liveHex.ReadBoxAsync(_sav, box);
+            _onBoxUpdated();
+            Status = $"Read Box {box + 1} from the console.";
+        }
+        catch (LiveHexConnectionException ex)
+        {
+            Status = $"Read failed: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanTransfer))]
+    private async Task WriteBoxAsync()
+    {
+        var box = _getCurrentBox();
+
+        // HARD REQUIREMENT: never write to the console without explicit user confirmation.
+        var confirmed = await _dialogs.ShowConfirmationAsync(
+            "Write box to console",
+            $"This will OVERWRITE Box {box + 1} on the connected console ({GameName}) with the " +
+            $"contents currently shown in PKHeX.\n\nThis cannot be undone on the console. Continue?",
+            confirmText: "Write to console",
+            cancelText: "Cancel");
+
+        if (!confirmed)
+        {
+            Status = "Write cancelled.";
+            return;
+        }
+
+        IsBusy = true;
+        Status = $"Writing Box {box + 1} to the console…";
+        try
+        {
+            await _liveHex.WriteBoxAsync(_sav, box);
+            Status = $"Wrote Box {box + 1} to the console.";
+        }
+        catch (LiveHexConnectionException ex)
+        {
+            Status = $"Write failed: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.LiveHeX.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.LiveHeX.cs
@@ -1,0 +1,35 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace PKHeX.Presentation.ViewModels;
+
+public partial class MainWindowViewModel
+{
+    // Cached so re-invoking the menu item focuses the existing tool window instead of opening a
+    // duplicate (ShowTool keys off the ViewModel instance). Reset on save change.
+    private LiveHeXViewModel? _liveHeX;
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private void OpenLiveHeX()
+    {
+        if (CurrentSave is null)
+            return;
+
+        _liveHeX ??= new LiveHeXViewModel(
+            CurrentSave,
+            _liveHexService,
+            _dialogService,
+            getCurrentBox: () => BoxViewer?.CurrentBox ?? 0,
+            onBoxUpdated: () => BoxViewer?.RefreshCurrentBox());
+
+        _windowService.ShowTool(_liveHeX, "LiveHeX");
+    }
+
+    // Called on save change: drop the cached tool VM and close any live console session.
+    private void DisposeLiveHeX()
+    {
+        if (_liveHeX is null)
+            return;
+        _ = _liveHexService.DisconnectAsync();
+        _liveHeX = null;
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using PKHeX.Application.Abstractions.LiveHex;
 using PKHeX.Core;
 
 namespace PKHeX.Presentation.ViewModels;
@@ -22,6 +23,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly UndoRedoService _undoRedo;
     private readonly LanguageService _languageService;
     private readonly IAutoLegalityService _autoLegalityService;
+    private readonly ILiveHexService _liveHexService;
     private readonly string _currentVersion;
 
     [ObservableProperty] private UpdateNotificationViewModel? _updateNotification;
@@ -37,6 +39,7 @@ public partial class MainWindowViewModel : ViewModelBase
     [NotifyCanExecuteChangedFor(nameof(OpenPKMDatabaseCommand))]
     [NotifyCanExecuteChangedFor(nameof(OpenBoxReportCommand))]
     [NotifyCanExecuteChangedFor(nameof(OpenAutoLegalityModCommand))]
+    [NotifyCanExecuteChangedFor(nameof(OpenLiveHeXCommand))]
     [NotifyCanExecuteChangedFor(nameof(UndoCommand))]
     [NotifyCanExecuteChangedFor(nameof(RedoCommand))]
     private SaveFile? _currentSave;
@@ -73,7 +76,8 @@ public partial class MainWindowViewModel : ViewModelBase
         ISettingsStore settingsStore,
         UndoRedoService undoRedo,
         LanguageService languageService,
-        IAutoLegalityService autoLegalityService)
+        IAutoLegalityService autoLegalityService,
+        ILiveHexService liveHexService)
     {
         _saveFileService = saveFileService;
         _dialogService = dialogService;
@@ -88,6 +92,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _undoRedo = undoRedo;
         _languageService = languageService;
         _autoLegalityService = autoLegalityService;
+        _liveHexService = liveHexService;
         _currentVersion = GetCurrentVersion();
 
         _saveFileService.SaveFileChanged += OnSaveFileChanged;
@@ -129,6 +134,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _boxReport = null;
         _legalityAudit = null;
         _autoLegalityMod = null;
+        DisposeLiveHeX();
 
         CurrentSave = sav;
         if (sav is not null)

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/FakeSwitchMemory.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/FakeSwitchMemory.cs
@@ -1,0 +1,68 @@
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using PKHeX.Application.Abstractions.LiveHex;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>
+/// In-memory fake console that models three address spaces (main, absolute, heap) so LiveHeX
+/// protocol, pointer-resolution and box-addressing logic can be exercised end-to-end without a
+/// real console. Heap and absolute spaces are independent sparse maps; unset bytes read as 0.
+/// </summary>
+internal sealed class FakeSwitchMemory : IConsoleConnection
+{
+    private readonly Dictionary<ulong, byte> _heap = new();
+    private readonly Dictionary<ulong, byte> _absolute = new();
+    private readonly Dictionary<ulong, byte> _main = new();
+
+    public ulong HeapBase { get; set; } = 0x8000000;
+    public string TitleId { get; set; } = "0100ABF008968000"; // Sword by default
+    public string GameVersion { get; set; } = "1.3.2";
+    public string BotbaseVersion { get; set; } = "2.5";
+
+    public bool Connected { get; private set; } = true;
+    public bool ConnectCalled { get; private set; }
+
+    public void Connect(string ip, int port, int timeoutMs) { ConnectCalled = true; Connected = true; }
+    public void Disconnect() => Connected = false;
+    public void Dispose() => Disconnect();
+
+    public byte[] ReadHeap(ulong offset, int length) => Read(_heap, offset, length);
+    public void WriteHeap(System.ReadOnlySpan<byte> data, ulong offset) => Write(_heap, data, offset);
+    public byte[] ReadMain(ulong offset, int length) => Read(_main, offset, length);
+    public byte[] ReadAbsolute(ulong offset, int length) => Read(_absolute, offset, length);
+    public void WriteAbsolute(System.ReadOnlySpan<byte> data, ulong offset) => Write(_absolute, data, offset);
+    public ulong GetHeapBase() => HeapBase;
+    public string GetTitleId() => TitleId;
+    public string GetBotbaseVersion() => BotbaseVersion;
+    public string GetGameInfo(string info) => GameVersion;
+
+    // --- test setup helpers ---
+    public void SetMainPointer(ulong offset, ulong value) => Write(_main, U64(value), offset);
+    public void SetAbsolutePointer(ulong offset, ulong value) => Write(_absolute, U64(value), offset);
+    public void SetAbsoluteBytes(ulong offset, byte[] data) => Write(_absolute, data, offset);
+    public byte[] GetAbsoluteBytes(ulong offset, int length) => Read(_absolute, offset, length);
+    public void SetHeapBytes(ulong offset, byte[] data) => Write(_heap, data, offset);
+    public byte[] GetHeapBytes(ulong offset, int length) => Read(_heap, offset, length);
+
+    private static byte[] Read(Dictionary<ulong, byte> space, ulong offset, int length)
+    {
+        var result = new byte[length];
+        for (int i = 0; i < length; i++)
+            space.TryGetValue(offset + (ulong)i, out result[i]);
+        return result;
+    }
+
+    private static void Write(Dictionary<ulong, byte> space, System.ReadOnlySpan<byte> data, ulong offset)
+    {
+        for (int i = 0; i < data.Length; i++)
+            space[offset + (ulong)i] = data[i];
+    }
+
+    private static byte[] U64(ulong value)
+    {
+        var b = new byte[8];
+        BinaryPrimitives.WriteUInt64LittleEndian(b, value);
+        return b;
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHeXViewModelTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHeXViewModelTests.cs
@@ -1,0 +1,85 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Abstractions.LiveHex;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>
+/// Verifies the LiveHeX ViewModel's write-gating: a write to the console must never happen without
+/// explicit user confirmation.
+/// </summary>
+public class LiveHeXViewModelTests
+{
+    private static (LiveHeXViewModel Vm, Mock<ILiveHexService> Live, Mock<IDialogService> Dialog) NewVm()
+    {
+        var live = new Mock<ILiveHexService>();
+        live.Setup(s => s.GetSupport(It.IsAny<SaveFile>()))
+            .Returns(new LiveHexGameSupport(true, "Sword/Shield", "Supported firmware: 1.3.2"));
+        var dialog = new Mock<IDialogService>();
+
+        var vm = new LiveHeXViewModel(new SAV8SWSH(), live.Object, dialog.Object,
+            getCurrentBox: () => 0, onBoxUpdated: () => { })
+        {
+            IsConnected = true,
+        };
+        return (vm, live, dialog);
+    }
+
+    [Fact]
+    public async Task WriteBox_does_not_write_when_confirmation_is_declined()
+    {
+        var (vm, live, dialog) = NewVm();
+        dialog.Setup(d => d.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+              .ReturnsAsync(false);
+
+        await vm.WriteBoxCommand.ExecuteAsync(null);
+
+        live.Verify(s => s.WriteBoxAsync(It.IsAny<SaveFile>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Equal("Write cancelled.", vm.Status);
+    }
+
+    [Fact]
+    public async Task WriteBox_writes_after_confirmation()
+    {
+        var (vm, live, dialog) = NewVm();
+        dialog.Setup(d => d.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+              .ReturnsAsync(true);
+        live.Setup(s => s.WriteBoxAsync(It.IsAny<SaveFile>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await vm.WriteBoxCommand.ExecuteAsync(null);
+
+        live.Verify(s => s.WriteBoxAsync(It.IsAny<SaveFile>(), 0, It.IsAny<CancellationToken>()), Times.Once);
+        dialog.Verify(d => d.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReadBox_does_not_require_confirmation()
+    {
+        var (vm, live, dialog) = NewVm();
+        live.Setup(s => s.ReadBoxAsync(It.IsAny<SaveFile>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await vm.ReadBoxCommand.ExecuteAsync(null);
+
+        live.Verify(s => s.ReadBoxAsync(It.IsAny<SaveFile>(), 0, It.IsAny<CancellationToken>()), Times.Once);
+        dialog.Verify(d => d.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Unsupported_save_disables_connect()
+    {
+        var live = new Mock<ILiveHexService>();
+        live.Setup(s => s.GetSupport(It.IsAny<SaveFile>()))
+            .Returns(new LiveHexGameSupport(false, "Gen 7", "Not supported."));
+        var vm = new LiveHeXViewModel(new SAV7SM(), live.Object, new Mock<IDialogService>().Object,
+            () => 0, () => { });
+
+        Assert.False(vm.IsGameSupported);
+        Assert.False(vm.ConnectCommand.CanExecute(null));
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexBoxTransferTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexBoxTransferTests.cs
@@ -1,0 +1,134 @@
+using System;
+using PKHeX.Core;
+using PKHeX.Infrastructure.LiveHex;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>
+/// Round-trip tests for <see cref="LiveHexBoxAddressing"/> across all three console-RAM addressing
+/// modes, using the in-memory <see cref="FakeSwitchMemory"/> console.
+/// </summary>
+public class LiveHexBoxTransferTests
+{
+    private static byte[] Pattern(int length)
+    {
+        var data = new byte[length];
+        for (int i = 0; i < length; i++)
+            data[i] = (byte)((i * 7) + 3);
+        return data;
+    }
+
+    [Fact]
+    public void HeapFlat_SwSh_write_then_read_roundtrips_at_expected_address()
+    {
+        var sav = new SAV8SWSH();
+        var profile = LiveHexGameProfiles.Resolve(sav, "0100ABF008968000", "1.3.2");
+        Assert.NotNull(profile);
+        Assert.Equal(BoxAddressingMode.HeapFlat, profile!.Mode);
+
+        int slotSize = sav.SIZE_BOXSLOT, slotCount = sav.BoxSlotCount;
+        int boxLen = slotSize * slotCount;
+        var data = Pattern(boxLen);
+        const int box = 2;
+
+        var mem = new FakeSwitchMemory();
+        LiveHexBoxAddressing.WriteBox(mem, profile, box, data, slotSize, slotCount);
+
+        // Data must land at the flat heap offset for that box.
+        ulong expected = profile.HeapBoxStart + (ulong)(box * boxLen);
+        Assert.Equal(data, mem.GetHeapBytes(expected, boxLen));
+
+        var read = LiveHexBoxAddressing.ReadBox(mem, profile, box, slotSize, slotCount);
+        Assert.Equal(data, read);
+    }
+
+    [Fact]
+    public void PointerContiguous_SV_write_then_read_roundtrips()
+    {
+        var sav = new SAV9SV();
+        var profile = LiveHexGameProfiles.Resolve(sav, "0100A3D008C5C000", "4.0.0");
+        Assert.NotNull(profile);
+        Assert.Equal(BoxAddressingMode.PointerContiguous, profile!.Mode);
+
+        int slotSize = sav.SIZE_BOXSLOT, slotCount = sav.BoxSlotCount;
+        int boxLen = slotSize * slotCount;
+
+        // Install the pointer chain for "[[[[main+47350d8]+1C0]+30]+9D0]".
+        var mem = new FakeSwitchMemory { HeapBase = 0x80000 };
+        mem.SetMainPointer(0x47350d8, 0x100000);
+        mem.SetAbsolutePointer(0x100000 + 0x1C0, 0x200000);
+        mem.SetAbsolutePointer(0x200000 + 0x30, 0x300000);
+        mem.SetAbsolutePointer(0x300000 + 0x9D0, 0x400000);
+        ulong boxBase = 0x400000 - 0x80000; // heap-relative base of Box 1 Slot 1
+
+        var data = Pattern(boxLen);
+        const int box = 0;
+        LiveHexBoxAddressing.WriteBox(mem, profile, box, data, slotSize, slotCount);
+        Assert.Equal(data, mem.GetHeapBytes(boxBase, boxLen));
+
+        var read = LiveHexBoxAddressing.ReadBox(mem, profile, box, slotSize, slotCount);
+        Assert.Equal(data, read);
+    }
+
+    [Fact]
+    public void PointerScatter_BDSP_write_then_read_roundtrips_per_mon()
+    {
+        var sav = new SAV8BS();
+        var profile = LiveHexGameProfiles.Resolve(sav, "0100000011D90000", "1.3.0"); // Brilliant Diamond
+        Assert.NotNull(profile);
+        Assert.Equal(BoxAddressingMode.PointerScatter, profile!.Mode);
+
+        int slotSize = sav.SIZE_BOXSLOT, slotCount = sav.BoxSlotCount;
+
+        // Install the box-list pointer chain "[[[[main+4C64DC0]+B8]+10]+A0]+20".
+        var mem = new FakeSwitchMemory { HeapBase = 0x80000 };
+        mem.SetMainPointer(0x4C64DC0, 0x1000000);
+        mem.SetAbsolutePointer(0x1000000 + 0xB8, 0x2000000);
+        mem.SetAbsolutePointer(0x2000000 + 0x10, 0x3000000);
+        mem.SetAbsolutePointer(0x3000000 + 0xA0, 0x4000000);
+        ulong listAddr = (0x4000000 + 0x20) - 0x80000; // heap-relative box-list table
+
+        const int box = 0;
+        // table[box] -> box object pointer (absolute); mon pointers live at boxObj + 0x20.
+        // Low byte must be non-zero: a zero first byte is treated as "box list not loaded".
+        ulong boxObjRaw = 0x5000010;
+        var table = new byte[profile.ScatterPointerCount * 8];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(table.AsSpan(box * 8), boxObjRaw);
+        mem.SetHeapBytes(listAddr, table);
+
+        // Per-mon absolute pointers.
+        var monTable = new byte[slotCount * 8];
+        var monPtrs = new ulong[slotCount];
+        for (int i = 0; i < slotCount; i++)
+        {
+            monPtrs[i] = 0x6000000UL + (ulong)(i * 0x1000);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(monTable.AsSpan(i * 8), monPtrs[i]);
+        }
+        mem.SetAbsoluteBytes(boxObjRaw + 0x20, monTable);
+
+        var data = Pattern(slotSize * slotCount);
+        LiveHexBoxAddressing.WriteBox(mem, profile, box, data, slotSize, slotCount);
+
+        // Each mon's bytes must land at its own pointer + 0x20.
+        for (int i = 0; i < slotCount; i++)
+        {
+            var expected = new byte[slotSize];
+            Array.Copy(data, i * slotSize, expected, 0, slotSize);
+            Assert.Equal(expected, mem.GetAbsoluteBytes(monPtrs[i] + 0x20, slotSize));
+        }
+
+        var read = LiveHexBoxAddressing.ReadBox(mem, profile, box, slotSize, slotCount);
+        Assert.Equal(data, read);
+    }
+
+    [Fact]
+    public void Save_box_binary_bridges_console_bytes_into_the_save()
+    {
+        // The console box byte layout equals SaveFile.GetBoxBinary/SetBoxBinary for supported games.
+        var sav = new SAV8SWSH();
+        int box = 0;
+        var original = sav.GetBoxBinary(box);
+        Assert.True(sav.SetBoxBinary(original, box)); // idempotent round-trip through Core
+        Assert.Equal(original.Length, sav.SIZE_BOXSLOT * sav.BoxSlotCount);
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexProtocolTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexProtocolTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Text;
+using PKHeX.Infrastructure.LiveHex;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>Unit tests for the clean-room sys-botbase protocol encoding/decoding and pointer walk.</summary>
+public class LiveHexProtocolTests
+{
+    private static string Ascii(byte[] b) => Encoding.ASCII.GetString(b);
+
+    [Fact]
+    public void Peek_formats_heap_read_command()
+    {
+        Assert.Equal("peek 0x0000000000001234 16\r\n", Ascii(SwitchCommand.Peek(0x1234, 16)));
+    }
+
+    [Fact]
+    public void PeekMain_and_PeekAbsolute_use_correct_verbs()
+    {
+        Assert.Equal("peekMain 0x00000000000000A0 8\r\n", Ascii(SwitchCommand.PeekMain(0xA0, 8)));
+        Assert.Equal("peekAbsolute 0x0000000000000010 4\r\n", Ascii(SwitchCommand.PeekAbsolute(0x10, 4)));
+    }
+
+    [Fact]
+    public void Poke_formats_payload_as_uppercase_hex()
+    {
+        Assert.Equal("poke 0x0000000000000010 0xABCD\r\n", Ascii(SwitchCommand.Poke(0x10, [0xAB, 0xCD])));
+        Assert.Equal("pokeAbsolute 0x0000000000000020 0x00FF\r\n", Ascii(SwitchCommand.PokeAbsolute(0x20, [0x00, 0xFF])));
+    }
+
+    [Fact]
+    public void Info_commands_are_encoded()
+    {
+        Assert.Equal("getHeapBase\r\n", Ascii(SwitchCommand.GetHeapBase()));
+        Assert.Equal("getTitleID\r\n", Ascii(SwitchCommand.GetTitleId()));
+        Assert.Equal("getVersion\r\n", Ascii(SwitchCommand.GetBotbaseVersion()));
+        Assert.Equal("game version\r\n", Ascii(SwitchCommand.GetGameInfo("version")));
+    }
+
+    [Fact]
+    public void HexCodec_roundtrips_bytes()
+    {
+        byte[] data = [0x00, 0x0A, 0xFF, 0x7F, 0x80];
+        var hex = HexCodec.ToHex(data);
+        Assert.Equal("000AFF7F80", hex);
+
+        var dest = new byte[data.Length];
+        HexCodec.DecodeInto(Encoding.ASCII.GetBytes(hex), dest);
+        Assert.Equal(data, dest);
+    }
+
+    [Fact]
+    public void HexCodec_rejects_wrong_length_response()
+    {
+        var dest = new byte[4];
+        Assert.Throws<FormatException>(() => HexCodec.DecodeInto("0AFF"u8, dest)); // 4 chars for 4 bytes
+    }
+
+    [Fact]
+    public void PointerResolver_walks_chain_and_returns_heap_relative_address()
+    {
+        var mem = new FakeSwitchMemory { HeapBase = 0x1000 };
+        mem.SetMainPointer(0x100, 0x5000);      // ReadMain(0x100) = 0x5000
+        mem.SetAbsolutePointer(0x5008, 0x9000); // ReadAbsolute(0x5000 + 8) = 0x9000
+
+        // "[[main+100]+8]+4" => ReadAbsolute(ReadMain(0x100)+8) + 4 - HeapBase
+        var resolved = PointerResolver.Resolve(mem, "[[main+100]+8]+4");
+        Assert.Equal(0x9000UL + 4 - 0x1000, resolved);
+    }
+
+    [Fact]
+    public void PointerResolver_can_return_absolute_address()
+    {
+        var mem = new FakeSwitchMemory { HeapBase = 0x1000 };
+        mem.SetMainPointer(0x100, 0x5000);
+        mem.SetAbsolutePointer(0x5008, 0x9000);
+
+        var resolved = PointerResolver.Resolve(mem, "[[main+100]+8]+4", heapRelative: false);
+        Assert.Equal(0x9004UL, resolved);
+    }
+
+    [Fact]
+    public void PointerResolver_rejects_arithmetic_expressions()
+    {
+        var mem = new FakeSwitchMemory();
+        Assert.Equal(PointerResolver.InvalidPointer, PointerResolver.Resolve(mem, "[main-100]"));
+        Assert.Equal(PointerResolver.InvalidPointer, PointerResolver.Resolve(mem, ""));
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexServiceTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/LiveHexServiceTests.cs
@@ -1,0 +1,128 @@
+using System.Threading.Tasks;
+using PKHeX.Application.Abstractions.LiveHex;
+using PKHeX.Core;
+using PKHeX.Infrastructure.LiveHex;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>Tests for <see cref="LiveHexService"/> connect validation and box bridging.</summary>
+public class LiveHexServiceTests
+{
+    private sealed class FakeFactory(FakeSwitchMemory memory) : IConsoleConnectionFactory
+    {
+        public IConsoleConnection Create() => memory;
+    }
+
+    private static (LiveHexService Service, FakeSwitchMemory Memory) NewService()
+    {
+        var mem = new FakeSwitchMemory();
+        return (new LiveHexService(new FakeFactory(mem)), mem);
+    }
+
+    [Fact]
+    public void GetSupport_classifies_save_types()
+    {
+        var (service, _) = NewService();
+        Assert.True(service.GetSupport(new SAV8SWSH()).Supported);
+        Assert.True(service.GetSupport(new SAV9SV()).Supported);
+        Assert.True(service.GetSupport(new SAV8BS()).Supported);
+        Assert.True(service.GetSupport(new SAV8LA()).Supported);
+
+        var unsupported = service.GetSupport(new SAV7SM());
+        Assert.False(unsupported.Supported);
+        Assert.False(string.IsNullOrWhiteSpace(unsupported.Detail));
+    }
+
+    [Fact]
+    public async Task ConnectAsync_succeeds_and_populates_session_for_matching_game()
+    {
+        var (service, mem) = NewService();
+        mem.TitleId = "0100ABF008968000"; // Sword
+        mem.GameVersion = "1.3.2";
+
+        await service.ConnectAsync("127.0.0.1", 6000, new SAV8SWSH());
+
+        Assert.True(service.IsConnected);
+        Assert.True(mem.ConnectCalled);
+        Assert.NotNull(service.Session);
+        Assert.Equal("1.3.2", service.Session!.Value.GameVersion);
+        Assert.Contains("Sword", service.Session!.Value.ProfileLabel);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_rejects_wrong_game()
+    {
+        var (service, mem) = NewService();
+        mem.TitleId = "0100A3D008C5C000"; // Scarlet
+        mem.GameVersion = "4.0.0";
+
+        var ex = await Assert.ThrowsAsync<LiveHexConnectionException>(
+            () => service.ConnectAsync("127.0.0.1", 6000, new SAV8SWSH()));
+        Assert.Contains("different game", ex.Message);
+        Assert.False(service.IsConnected);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_rejects_unsupported_firmware()
+    {
+        var (service, mem) = NewService();
+        mem.TitleId = "0100ABF008968000"; // Sword
+        mem.GameVersion = "9.9.9";
+
+        var ex = await Assert.ThrowsAsync<LiveHexConnectionException>(
+            () => service.ConnectAsync("127.0.0.1", 6000, new SAV8SWSH()));
+        Assert.Contains("Unsupported game version", ex.Message);
+        Assert.False(service.IsConnected);
+    }
+
+    [Fact]
+    public async Task WriteBox_then_ReadBox_roundtrips_through_console_and_save()
+    {
+        var (service, mem) = NewService();
+        mem.TitleId = "0100ABF008968000";
+        mem.GameVersion = "1.3.2";
+
+        var source = new SAV8SWSH();
+        // Seed a genuine (valid) Pokémon so the source box differs from a blank target box.
+        var pk = source.BlankPKM;
+        pk.Species = 25; // Pikachu
+        pk.RefreshChecksum();
+        source.SetBoxSlotAtIndex(pk, 0, 0);
+        var sourceBox = source.GetBoxBinary(0);
+        Assert.NotEqual(new SAV8SWSH().GetBoxBinary(0), sourceBox); // sanity: box is non-blank
+
+        await service.ConnectAsync("127.0.0.1", 6000, source);
+        await service.WriteBoxAsync(source, 0);
+
+        // The console heap now holds the exact box bytes we wrote.
+        Assert.Equal(sourceBox, mem.GetHeapBytes(0x45075880, sourceBox.Length));
+
+        // Read the console box into a fresh (blank) save; its box binary must now match the source.
+        var target = new SAV8SWSH();
+        await service.ReadBoxAsync(target, 0);
+        Assert.Equal(sourceBox, target.GetBoxBinary(0));
+    }
+
+    [Fact]
+    public async Task Operations_before_connect_throw_not_connected()
+    {
+        var (service, _) = NewService();
+        var ex = await Assert.ThrowsAsync<LiveHexConnectionException>(
+            () => service.ReadBoxAsync(new SAV8SWSH(), 0));
+        Assert.Contains("Not connected", ex.Message);
+    }
+
+    [Fact]
+    public async Task ReadBox_rejects_out_of_range_box()
+    {
+        var (service, mem) = NewService();
+        mem.TitleId = "0100ABF008968000";
+        mem.GameVersion = "1.3.2";
+        var sav = new SAV8SWSH();
+        await service.ConnectAsync("127.0.0.1", 6000, sav);
+
+        var ex = await Assert.ThrowsAsync<LiveHexConnectionException>(
+            () => service.ReadBoxAsync(sav, sav.BoxCount + 5));
+        Assert.Contains("out of range", ex.Message);
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/SysBotConnectionTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/SysBotConnectionTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using PKHeX.Application.Abstractions.LiveHex;
+using PKHeX.Infrastructure.LiveHex;
+
+namespace PKHeX.Avalonia.Tests.LiveHex;
+
+/// <summary>
+/// Exercises the real <see cref="SysBotConnection"/> socket path against an in-process loopback
+/// server that speaks the sys-botbase text protocol, plus the timeout/error paths.
+/// </summary>
+public class SysBotConnectionTests
+{
+    /// <summary>Minimal loopback sys-botbase server. Set <paramref name="mute"/> to never respond (timeout tests).</summary>
+    private sealed class FakeBotbaseServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        public readonly List<string> Received = [];
+        public int Port { get; }
+
+        public FakeBotbaseServer(bool mute = false)
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _ = Task.Run(() => AcceptLoop(mute, _cts.Token));
+        }
+
+        private async Task AcceptLoop(bool mute, CancellationToken ct)
+        {
+            try
+            {
+                using var client = await _listener.AcceptTcpClientAsync(ct);
+                using var stream = client.GetStream();
+                while (!ct.IsCancellationRequested)
+                {
+                    var line = ReadLine(stream);
+                    if (line is null)
+                        return;
+                    lock (Received) Received.Add(line);
+                    if (mute)
+                        continue;
+                    Respond(stream, line);
+                }
+            }
+            catch
+            {
+                // listener torn down
+            }
+        }
+
+        private static string? ReadLine(NetworkStream stream)
+        {
+            var sb = new StringBuilder();
+            var one = new byte[1];
+            while (true)
+            {
+                int read;
+                try { read = stream.Read(one, 0, 1); }
+                catch { return null; }
+                if (read == 0)
+                    return sb.Length == 0 ? null : sb.ToString();
+                if (one[0] == (byte)'\n')
+                    return sb.ToString().TrimEnd('\r');
+                sb.Append((char)one[0]);
+            }
+        }
+
+        private static void Respond(NetworkStream stream, string command)
+        {
+            string reply;
+            if (command.StartsWith("getTitleID"))
+                reply = "0100ABF008968000\n";
+            else if (command.StartsWith("getVersion"))
+                reply = "2.5\n";
+            else if (command.StartsWith("game "))
+                reply = "1.3.2\n";
+            else if (command.StartsWith("getHeapBase"))
+                reply = "0000000012345678\n"; // 8 bytes big-endian
+            else if (command.StartsWith("peek"))
+            {
+                // Echo a deterministic response of the requested length.
+                var parts = command.Split(' ');
+                int count = int.Parse(parts[^1]);
+                var sb = new StringBuilder();
+                for (int i = 0; i < count; i++)
+                    sb.Append(((byte)(i & 0xFF)).ToString("X2"));
+                sb.Append('\n');
+                reply = sb.ToString();
+            }
+            else
+                return; // poke commands have no response
+
+            var bytes = Encoding.ASCII.GetBytes(reply);
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            _cts.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Reads_and_decodes_a_peek_response()
+    {
+        using var server = new FakeBotbaseServer();
+        using var conn = new SysBotConnection();
+        conn.Connect("127.0.0.1", server.Port, 3000);
+
+        var data = conn.ReadHeap(0x1000, 8);
+        Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, data);
+    }
+
+    [Fact]
+    public void Reads_info_commands()
+    {
+        using var server = new FakeBotbaseServer();
+        using var conn = new SysBotConnection();
+        conn.Connect("127.0.0.1", server.Port, 3000);
+
+        Assert.Equal("0100ABF008968000", conn.GetTitleId());
+        Assert.Equal("2.5", conn.GetBotbaseVersion());
+        Assert.Equal("1.3.2", conn.GetGameInfo("version"));
+        Assert.Equal(0x12345678UL, conn.GetHeapBase());
+    }
+
+    [Fact]
+    public void Sends_correctly_formatted_poke_command()
+    {
+        using var server = new FakeBotbaseServer();
+        using var conn = new SysBotConnection();
+        conn.Connect("127.0.0.1", server.Port, 3000);
+
+        conn.WriteHeap([0xAB, 0xCD], 0x2000);
+
+        // Give the server a moment to record the line.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        string? poke = null;
+        while (DateTime.UtcNow < deadline && poke is null)
+        {
+            lock (server.Received)
+                poke = server.Received.Find(l => l.StartsWith("poke"));
+            if (poke is null) Thread.Sleep(10);
+        }
+        Assert.Equal("poke 0x0000000000002000 0xABCD", poke);
+    }
+
+    [Fact]
+    public void Connect_to_dead_endpoint_throws_clear_error()
+    {
+        using var conn = new SysBotConnection();
+        // Port 1 on loopback should refuse quickly; assert we surface a typed error, not a raw socket exception.
+        var ex = Assert.Throws<LiveHexConnectionException>(() => conn.Connect("127.0.0.1", 1, 800));
+        Assert.False(conn.Connected);
+        Assert.False(string.IsNullOrWhiteSpace(ex.Message));
+    }
+
+    [Fact]
+    public void Read_times_out_when_console_never_responds()
+    {
+        using var server = new FakeBotbaseServer(mute: true);
+        using var conn = new SysBotConnection();
+        conn.Connect("127.0.0.1", server.Port, 500);
+
+        var ex = Assert.Throws<LiveHexConnectionException>(() => conn.ReadHeap(0x1000, 8));
+        Assert.Contains("Timed out", ex.Message);
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -44,7 +44,8 @@ public class ShowdownIntegrationTests : IDisposable
             new FakeSettingsStore(),
             new UndoRedoService(),
             new LanguageService(),
-            new Mock<IAutoLegalityService>().Object
+            new Mock<IAutoLegalityService>().Object,
+            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object
         );
         
         // Simulate loading a save

--- a/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
@@ -171,7 +171,8 @@ public class MainWindowUpdateCheckTests
             new FakeSettingsStore(),
             new UndoRedoService(),
             new LanguageService(),
-            new Mock<IAutoLegalityService>().Object);
+            new Mock<IAutoLegalityService>().Object,
+            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object);
     }
 
     [Fact]


### PR DESCRIPTION
Implements **LiveHeX** (Auto-Legality Phase 3, #124): connect to a hacked console over Wi-Fi via sys-botbase (TCP, default port 6000) and read/write the currently displayed box directly into the app's box viewer.

## Clean-room, not vendored

Unlike the vendored `PKHeX.AutoMod` engine, LiveHeX connectivity is a **clean-room re-implementation** in `PKHeX.Infrastructure/LiveHex/`. Upstream `PKHeX.Core.Injection` (santacrab2/PKHeX-Plugins @ `b78bd4c274b75adf4454ad9cefebe0cbbbacfa19`) was evaluated and rejected for vendoring because:

1. **LibUsbDotNet dead weight** — it hard-requires `LibUsbDotNet 2.2.29` (native libusb P/Invoke) for its USB controller; USB is out of scope for v1 and that package risks **NU1701** warnings against net10.0, breaking the 0-warning build.
2. **3DS NTR dead weight** — `NTRClient`/`NTRAPIFramework` (~500 LOC) for 3DS, irrelevant to the Switch-only v1.
3. **Not byte-for-byte subsettable** — `RamOffsets.GetSwitchInterface`/`GetCommunicator` hard-reference `UsbBotMini`/`NTRClient`, so dropping those files would require editing vendored sources.
4. **Trivial public protocol** — sys-botbase is small ASCII text (`peek`/`poke`/`peekMain`/`peekAbsolute`/`pokeAbsolute` + hex), so a dependency-free TCP client is fully unit-testable against a loopback fake.

`PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md` documents the decision, GPL-3.0 attribution, and the provenance of the per-firmware RAM offsets/pointer expressions (mirrored from PKHeX-Plugins `RamOffsets`/`LP*` at the pinned commit).

## Game-support matrix (v1 — Wi-Fi/sys-botbase only; USB out of scope)

| Game | Save type | Box addressing | Firmware |
|---|---|---|---|
| Sword/Shield | `SAV8SWSH` | flat heap offset | 1.1.1, 1.2.1, 1.3.2 |
| Brilliant Diamond/Shining Pearl | `SAV8BS` | per-Pokémon pointer table (scatter) | 1.0.0, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.2.0, 1.3.0 |
| Legends: Arceus | `SAV8LA` | pointer-resolved contiguous | 1.0.0, 1.0.1, 1.0.2, 1.1.1 |
| Scarlet/Violet | `SAV9SV` | pointer-resolved contiguous | 1.0.1, 1.1.0, 1.2.0, 1.3.0/1/2, 2.0.1, 2.0.2, 3.0.0, 3.0.1, 4.0.0 |

## Architecture

- **Application ports** (Avalonia-free, mockable): `IConsoleConnection`, `IConsoleConnectionFactory`, `ILiveHexService`, `LiveHexConnectionException`.
- **Infrastructure** (all sockets confined here): `SysBotConnection` (TCP), `SwitchCommand`/`HexCodec` (protocol), `PointerResolver`, `LiveHexGameProfiles` (support matrix + offsets), `LiveHexBoxAddressing` (3 modes), `LiveHexService`.
- **Presentation**: `LiveHeXViewModel` — Avalonia-free; the ViewModel talks only to the port.
- **Avalonia**: `LiveHeXView`, `Tools > LiveHeX…` menu item, `ViewLocator` entry, `IDialogService.ShowConfirmationAsync`.
- **No console write without explicit confirmation** — every write is gated behind `ShowConfirmationAsync` stating exactly which box will be overwritten.
- No `PKHeX.Core` or vendored `PKHeX.AutoMod` changes; layering enforced by the architecture tests.

## Verification

- `dotnet build PKHeX.sln -c Release` → **0 warnings / 0 errors**
- `dotnet test PKHeX.sln -c Release` → **all green** (Architecture 5/5, Core 449/450 w/ 1 pre-existing skip, Avalonia 2042/2042)
- **29 new tests**: protocol encode/decode, pointer walk, box read/write round-trip across all 3 addressing modes, connect validation (wrong game / unsupported firmware), no-write-without-confirmation gating, and a real in-process **loopback TCP server** covering response parsing, poke formatting, dead-endpoint and **read-timeout** paths.

## Caveats

- ⚠️ **Real console testing was NOT performed** — no Switch/sys-botbase hardware in this environment. Everything is validated against an in-memory fake console and a loopback TCP server, not on-device. Live box read/write remains unverified until tested on real hardware.
- RAM offsets are pinned per firmware version and go stale as games update; the re-sync/refresh procedure is documented in `NOTICE.LiveHeX.md`.
- The **BDSP scatter** and **SV/PLA pointer** paths are the least field-tested; SwSh's flat-heap path is the most robust.

Closes #124
