### PR TITLE
feat: theme system — dark/light/high-contrast with runtime + system switching (#133)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.30.0</UIVersion>
+    <UIVersion>1.31.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/IThemeService.cs
+++ b/PKHeX.Application/Abstractions/IThemeService.cs
@@ -1,0 +1,32 @@
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// UI theme/appearance preference. Persisted via <c>AppSettings</c>.
+/// </summary>
+public enum AppTheme
+{
+    /// <summary>Current default appearance: dark, GitHub-dark-inspired palette.</summary>
+    Dark,
+    /// <summary>Light surfaces with dark text, tuned for WCAG AA contrast.</summary>
+    Light,
+    /// <summary>Maximum-contrast palette for accessibility.</summary>
+    HighContrast,
+    /// <summary>Tracks the OS light/dark preference live.</summary>
+    System,
+}
+
+/// <summary>
+/// Applies the active UI theme (colors/brushes exposed as resources) at runtime, so switching
+/// requires no restart. Framework-free: the Avalonia-specific implementation lives in the host
+/// project (see <c>PKHeX.Avalonia.Services.ThemeService</c>) and drives Avalonia's
+/// <c>ThemeVariant</c>/<c>ThemeDictionaries</c> APIs, including tracking the platform's
+/// light/dark preference for <see cref="AppTheme.System"/>.
+/// </summary>
+public interface IThemeService
+{
+    /// <summary>The currently-applied theme preference.</summary>
+    AppTheme CurrentTheme { get; }
+
+    /// <summary>Applies and persists the given theme preference immediately.</summary>
+    void ApplyTheme(AppTheme theme);
+}

--- a/PKHeX.Application/Services/AppSettings.cs
+++ b/PKHeX.Application/Services/AppSettings.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using PKHeX.Application.Abstractions;
 using PKHeX.Core;
 
 namespace PKHeX.Application.Services;
@@ -24,6 +25,7 @@ public sealed class AppSettings : IProgramSettings
     public EntityConverterSettings Converter { get; set; } = new();
     public LocalResourceSettings LocalResources { get; set; } = new();
     public SpriteSettings Sprite { get; set; } = new();
+    public ThemeSettings Theme { get; set; } = new();
 
     public string DisplayLanguage { get; set; } = "en";
 
@@ -70,5 +72,13 @@ public sealed class AppSettings : IProgramSettings
     public class SpriteSettings
     {
         public SpritePreference SpritePreference { get; set; } = SpritePreference.UseSuggested;
+    }
+
+    /// <summary>
+    /// UI theme/appearance preference. Defined locally since Core does not expose one.
+    /// </summary>
+    public class ThemeSettings
+    {
+        public AppTheme Selected { get; set; } = AppTheme.Dark;
     }
 }

--- a/PKHeX.Avalonia/App.axaml
+++ b/PKHeX.Avalonia/App.axaml
@@ -3,13 +3,25 @@
              xmlns:converters="using:PKHeX.Avalonia.Converters"
              x:Class="PKHeX.Avalonia.App"
              RequestedThemeVariant="Dark">
+    <!--
+        RequestedThemeVariant above is only the XAML-time fallback used for the brief window
+        before ThemeService.Initialize() runs in App.axaml.cs, which applies the persisted
+        preference (including Light/HighContrast/System) before the main window is created.
+        Per-variant palettes live in Styles/Theme.axaml's ThemeDictionaries.
+    -->
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- Add other resources here if needed -->
             </ResourceDictionary.MergedDictionaries>
-            
-            <!-- Override FluentTheme accent colors with Pokemon Red -->
+
+            <!--
+                Override FluentTheme accent colors with Pokemon Red. Kept as a single constant
+                (not a per-theme token) intentionally: this is the app's brand accent, consumed
+                internally by FluentTheme's own built-in controls, and must stay in
+                Application.Resources (not a Style's resources) to reliably take precedence over
+                FluentTheme's own SystemAccentColor* resources.
+            -->
             <Color x:Key="SystemAccentColor">#E3350D</Color>
             <Color x:Key="SystemAccentColorDark1">#CC0000</Color>
             <Color x:Key="SystemAccentColorDark2">#990000</Color>
@@ -17,7 +29,7 @@
             <Color x:Key="SystemAccentColorLight1">#FF5533</Color>
             <Color x:Key="SystemAccentColorLight2">#FF7755</Color>
             <Color x:Key="SystemAccentColorLight3">#FF9977</Color>
-            
+
             <!-- Override Focus Visuals to remove yellow/accent border -->
             <SolidColorBrush x:Key="SystemControlFocusVisualPrimaryBrush" Color="Transparent" />
             <SolidColorBrush x:Key="SystemControlFocusVisualSecondaryBrush" Color="Transparent" />

--- a/PKHeX.Avalonia/App.axaml.cs
+++ b/PKHeX.Avalonia/App.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using PKHeX.Application;
+using PKHeX.Application.Abstractions;
 using PKHeX.Infrastructure;
 using PKHeX.Infrastructure.Configuration;
 using PKHeX.Avalonia.Services;
@@ -29,6 +30,8 @@ public partial class App : global::Avalonia.Application
         // Initialize PKHeX Core
         // GameInfo is initialized via AppSettings in ConfigureServices
 
+        // Apply the persisted theme preference before any window is created.
+        Services.GetRequiredService<ThemeService>().Initialize();
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -68,6 +71,8 @@ public partial class App : global::Avalonia.Application
         services.AddSingleton<ISpriteRenderer, AvaloniaSpriteRenderer>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IQrCodeService, QrCodeService>();
+        services.AddSingleton<ThemeService>();
+        services.AddSingleton<IThemeService>(sp => sp.GetRequiredService<ThemeService>());
 
         // Root ViewModel (transient). Child/editor ViewModels are created by their parent presenter
         // with the current save, so they are not registered in the container.

--- a/PKHeX.Avalonia/Converters/AppThemeLabelConverter.cs
+++ b/PKHeX.Avalonia/Converters/AppThemeLabelConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using PKHeX.Application.Abstractions;
+
+namespace PKHeX.Avalonia.Converters;
+
+/// <summary>Maps <see cref="AppTheme"/> values to user-facing labels.</summary>
+public sealed class AppThemeLabelConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value switch
+    {
+        AppTheme.Dark => "Dark",
+        AppTheme.Light => "Light",
+        AppTheme.HighContrast => "High Contrast",
+        AppTheme.System => "Follow System",
+        _ => value?.ToString(),
+    };
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/PKHeX.Avalonia/Services/AppThemeVariants.cs
+++ b/PKHeX.Avalonia/Services/AppThemeVariants.cs
@@ -1,0 +1,16 @@
+using Avalonia.Styling;
+
+namespace PKHeX.Avalonia.Services;
+
+/// <summary>
+/// Custom Avalonia <see cref="ThemeVariant"/> values beyond the built-in Light/Dark, used as
+/// <c>ResourceDictionary.ThemeDictionaries</c> keys in Styles/Theme.axaml.
+/// </summary>
+public static class AppThemeVariants
+{
+    /// <summary>
+    /// High-contrast palette. Inherits from Dark so any resource not explicitly overridden in the
+    /// HighContrast dictionary still resolves to a sensible value.
+    /// </summary>
+    public static readonly ThemeVariant HighContrast = new("HighContrast", ThemeVariant.Dark);
+}

--- a/PKHeX.Avalonia/Services/ThemeService.cs
+++ b/PKHeX.Avalonia/Services/ThemeService.cs
@@ -1,0 +1,53 @@
+using Avalonia.Styling;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Services;
+
+namespace PKHeX.Avalonia.Services;
+
+/// <summary>
+/// Avalonia-side implementation of <see cref="IThemeService"/>. Drives the app-wide
+/// <see cref="global::Avalonia.Application.RequestedThemeVariant"/>, which every open window/dialog
+/// inherits automatically and re-styles live — so switching needs no restart. "Follow system" is
+/// implemented by handing control back to Avalonia (<see cref="ThemeVariant.Default"/>), which
+/// tracks <see cref="global::Avalonia.Application.PlatformSettings"/> live on macOS, Windows, and
+/// Linux desktop portals that expose a color-scheme preference.
+/// </summary>
+public sealed class ThemeService : IThemeService
+{
+    private readonly AppSettings _settings;
+    private readonly ISettingsStore _settingsStore;
+
+    public ThemeService(AppSettings settings, ISettingsStore settingsStore)
+    {
+        _settings = settings;
+        _settingsStore = settingsStore;
+    }
+
+    public AppTheme CurrentTheme => _settings.Theme.Selected;
+
+    /// <summary>Applies the persisted theme preference. Call once at startup, before the main window is created.</summary>
+    public void Initialize() => ApplyThemeVariant(_settings.Theme.Selected);
+
+    public void ApplyTheme(AppTheme theme)
+    {
+        _settings.Theme.Selected = theme;
+        _settingsStore.Save(_settings);
+        ApplyThemeVariant(theme);
+    }
+
+    private static void ApplyThemeVariant(AppTheme theme)
+    {
+        var app = global::Avalonia.Application.Current;
+        if (app is null)
+            return;
+
+        app.RequestedThemeVariant = theme switch
+        {
+            AppTheme.Light => ThemeVariant.Light,
+            AppTheme.Dark => ThemeVariant.Dark,
+            AppTheme.HighContrast => AppThemeVariants.HighContrast,
+            AppTheme.System => ThemeVariant.Default, // Avalonia tracks PlatformSettings live.
+            _ => ThemeVariant.Dark,
+        };
+    }
+}

--- a/PKHeX.Avalonia/Styles/Theme.axaml
+++ b/PKHeX.Avalonia/Styles/Theme.axaml
@@ -1,95 +1,300 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:models="clr-namespace:PKHeX.Presentation.Models;assembly=PKHeX.Presentation">
+        xmlns:models="clr-namespace:PKHeX.Presentation.Models;assembly=PKHeX.Presentation"
+        xmlns:services="clr-namespace:PKHeX.Avalonia.Services">
 
     <!-- ═══════════════════════════════════════════════════════════════════════
-         PKHeX Premium Dark Theme
-         Modern, beautiful UI with depth, shadows, and dynamic effects
+         PKHeX Theme Tokens
+         Semantic design tokens exposed as ThemeDictionaries so the whole app can
+         switch appearance at runtime (Settings > Appearance) without a restart:
+           - Dark          : original GitHub-Dark-inspired palette (default)
+           - Light         : light surfaces, WCAG AA (4.5:1) body text
+           - HighContrast  : maximum-contrast accessibility palette
+         Every consumer below (and in Views) must use DynamicResource, not
+         StaticResource, so brushes actually re-resolve when the variant changes.
          ═══════════════════════════════════════════════════════════════════════ -->
 
     <Style>
         <Style.Resources>
-            <!-- ─────────────────────────────────────────────────────────────────
-                 Color Palette (GitHub Dark-inspired)
-                 ───────────────────────────────────────────────────────────────── -->
+            <ResourceDictionary>
+                <ResourceDictionary.ThemeDictionaries>
 
-            <!-- Base Colors -->
-            <Color x:Key="ThemeBackgroundDeep">#0D1117</Color>
-            <Color x:Key="ThemeBackgroundBase">#161B22</Color>
-            <Color x:Key="ThemeBackgroundCard">#21262D</Color>
-            <Color x:Key="ThemeBackgroundElevated">#30363D</Color>
-            <Color x:Key="ThemeBackgroundHover">#484F58</Color>
+                    <!-- ═══════════════════════ Dark (default) ═══════════════════════ -->
+                    <ResourceDictionary x:Key="Dark">
+                        <!-- Base Colors -->
+                        <Color x:Key="ThemeBackgroundDeep">#0D1117</Color>
+                        <Color x:Key="ThemeBackgroundBase">#161B22</Color>
+                        <Color x:Key="ThemeBackgroundCard">#21262D</Color>
+                        <Color x:Key="ThemeBackgroundElevated">#30363D</Color>
+                        <Color x:Key="ThemeBackgroundHover">#484F58</Color>
 
-            <!-- Border Colors -->
-            <Color x:Key="ThemeBorderDefault">#30363D</Color>
-            <Color x:Key="ThemeBorderMuted">#21262D</Color>
+                        <!-- Border Colors -->
+                        <Color x:Key="ThemeBorderDefault">#30363D</Color>
+                        <Color x:Key="ThemeBorderMuted">#21262D</Color>
 
-            <!-- Text Colors -->
-            <Color x:Key="ThemeTextPrimary">#E6EDF3</Color>
-            <Color x:Key="ThemeTextSecondary">#8B949E</Color>
-            <Color x:Key="ThemeTextMuted">#6E7681</Color>
+                        <!-- Text Colors (AA on ThemeBackgroundBase: Primary ~13:1, Secondary ~5.7:1) -->
+                        <Color x:Key="ThemeTextPrimary">#E6EDF3</Color>
+                        <Color x:Key="ThemeTextSecondary">#8B949E</Color>
+                        <Color x:Key="ThemeTextMuted">#6E7681</Color>
 
-            <!-- Accent Colors - Pokemon Red Theme -->
-            <Color x:Key="ThemeAccentPrimary">#E3350D</Color>
-            <Color x:Key="ThemeAccentSecondary">#CC0000</Color>
-            <Color x:Key="ThemeAccentGlow">#E3350D40</Color>
+                        <!-- Accent Colors - Pokemon Red Theme -->
+                        <Color x:Key="ThemeAccentPrimary">#E3350D</Color>
+                        <Color x:Key="ThemeAccentSecondary">#CC0000</Color>
+                        <Color x:Key="ThemeAccentGlow">#E3350D40</Color>
 
-            <!-- Semantic Colors -->
-            <Color x:Key="ThemeSuccessColor">#3FB950</Color>
-            <Color x:Key="ThemeSuccessGlow">#3FB95040</Color>
-            <Color x:Key="ThemeErrorColor">#F85149</Color>
-            <Color x:Key="ThemeErrorGlow">#F8514940</Color>
-            <Color x:Key="ThemeWarningColor">#D29922</Color>
-            <Color x:Key="ThemeShinyColor">#E3350D</Color>
+                        <!-- Semantic Colors -->
+                        <Color x:Key="ThemeSuccessColor">#3FB950</Color>
+                        <Color x:Key="ThemeSuccessGlow">#3FB95040</Color>
+                        <Color x:Key="ThemeErrorColor">#F85149</Color>
+                        <Color x:Key="ThemeErrorGlow">#F8514940</Color>
+                        <Color x:Key="ThemeWarningColor">#D29922</Color>
+                        <Color x:Key="ThemeWarningGlow">#D2992240</Color>
+                        <Color x:Key="ThemeShinyColor">#E3350D</Color>
+                        <Color x:Key="ThemeShinyGoldColor">#FFD700</Color>
 
-            <!-- Brushes -->
-            <SolidColorBrush x:Key="ThemeBackgroundDeepBrush" Color="{StaticResource ThemeBackgroundDeep}" />
-            <SolidColorBrush x:Key="ThemeBackgroundBaseBrush" Color="{StaticResource ThemeBackgroundBase}" />
-            <SolidColorBrush x:Key="ThemeBackgroundCardBrush" Color="{StaticResource ThemeBackgroundCard}" />
-            <SolidColorBrush x:Key="ThemeBackgroundElevatedBrush" Color="{StaticResource ThemeBackgroundElevated}" />
-            <SolidColorBrush x:Key="ThemeBackgroundHoverBrush" Color="{StaticResource ThemeBackgroundHover}" />
+                        <!-- Full-screen scrim used behind loading/searching overlays -->
+                        <Color x:Key="ThemeOverlayScrim">#80000000</Color>
+                        <Color x:Key="ThemeOverlayForeground">#FFFFFF</Color>
 
-            <SolidColorBrush x:Key="ThemeBorderDefaultBrush" Color="{StaticResource ThemeBorderDefault}" />
-            <SolidColorBrush x:Key="ThemeBorderMutedBrush" Color="{StaticResource ThemeBorderMuted}" />
+                        <!-- Brushes -->
+                        <SolidColorBrush x:Key="ThemeBackgroundDeepBrush" Color="{StaticResource ThemeBackgroundDeep}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundBaseBrush" Color="{StaticResource ThemeBackgroundBase}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundCardBrush" Color="{StaticResource ThemeBackgroundCard}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundElevatedBrush" Color="{StaticResource ThemeBackgroundElevated}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundHoverBrush" Color="{StaticResource ThemeBackgroundHover}" />
 
-            <SolidColorBrush x:Key="ThemeTextPrimaryBrush" Color="{StaticResource ThemeTextPrimary}" />
-            <SolidColorBrush x:Key="ThemeTextSecondaryBrush" Color="{StaticResource ThemeTextSecondary}" />
-            <SolidColorBrush x:Key="ThemeTextMutedBrush" Color="{StaticResource ThemeTextMuted}" />
+                        <SolidColorBrush x:Key="ThemeBorderDefaultBrush" Color="{StaticResource ThemeBorderDefault}" />
+                        <SolidColorBrush x:Key="ThemeBorderMutedBrush" Color="{StaticResource ThemeBorderMuted}" />
 
-            <SolidColorBrush x:Key="ThemeAccentPrimaryBrush" Color="{StaticResource ThemeAccentPrimary}" />
-            <SolidColorBrush x:Key="ThemeAccentSecondaryBrush" Color="{StaticResource ThemeAccentSecondary}" />
-            <SolidColorBrush x:Key="ThemeAccentGlowBrush" Color="{StaticResource ThemeAccentGlow}" />
+                        <SolidColorBrush x:Key="ThemeTextPrimaryBrush" Color="{StaticResource ThemeTextPrimary}" />
+                        <SolidColorBrush x:Key="ThemeTextSecondaryBrush" Color="{StaticResource ThemeTextSecondary}" />
+                        <SolidColorBrush x:Key="ThemeTextMutedBrush" Color="{StaticResource ThemeTextMuted}" />
 
-            <SolidColorBrush x:Key="ThemeSuccessBrush" Color="{StaticResource ThemeSuccessColor}" />
-            <SolidColorBrush x:Key="ThemeSuccessGlowBrush" Color="{StaticResource ThemeSuccessGlow}" />
-            <SolidColorBrush x:Key="ThemeErrorBrush" Color="{StaticResource ThemeErrorColor}" />
-            <SolidColorBrush x:Key="ThemeErrorGlowBrush" Color="{StaticResource ThemeErrorGlow}" />
-            <SolidColorBrush x:Key="ThemeWarningBrush" Color="{StaticResource ThemeWarningColor}" />
-            <SolidColorBrush x:Key="ThemeShinyBrush" Color="{StaticResource ThemeShinyColor}" />
+                        <SolidColorBrush x:Key="ThemeAccentPrimaryBrush" Color="{StaticResource ThemeAccentPrimary}" />
+                        <SolidColorBrush x:Key="ThemeAccentSecondaryBrush" Color="{StaticResource ThemeAccentSecondary}" />
+                        <SolidColorBrush x:Key="ThemeAccentGlowBrush" Color="{StaticResource ThemeAccentGlow}" />
 
-            <!-- Gradients -->
-            <LinearGradientBrush x:Key="ThemeAccentGradient" StartPoint="0%,0%" EndPoint="100%,100%">
-                <GradientStop Color="#E3350D" Offset="0" />
-                <GradientStop Color="#FF6B4A" Offset="1" />
-            </LinearGradientBrush>
+                        <SolidColorBrush x:Key="ThemeSuccessBrush" Color="{StaticResource ThemeSuccessColor}" />
+                        <SolidColorBrush x:Key="ThemeSuccessGlowBrush" Color="{StaticResource ThemeSuccessGlow}" />
+                        <SolidColorBrush x:Key="ThemeErrorBrush" Color="{StaticResource ThemeErrorColor}" />
+                        <SolidColorBrush x:Key="ThemeErrorGlowBrush" Color="{StaticResource ThemeErrorGlow}" />
+                        <SolidColorBrush x:Key="ThemeWarningBrush" Color="{StaticResource ThemeWarningColor}" />
+                        <SolidColorBrush x:Key="ThemeWarningGlowBrush" Color="{StaticResource ThemeWarningGlow}" />
+                        <SolidColorBrush x:Key="ThemeShinyBrush" Color="{StaticResource ThemeShinyColor}" />
+                        <SolidColorBrush x:Key="ThemeShinyGoldBrush" Color="{StaticResource ThemeShinyGoldColor}" />
 
-            <LinearGradientBrush x:Key="ThemeCardGradient" StartPoint="0%,0%" EndPoint="100%,100%">
-                <GradientStop Color="#21262D" Offset="0" />
-                <GradientStop Color="#161B22" Offset="1" />
-            </LinearGradientBrush>
+                        <SolidColorBrush x:Key="ThemeOverlayScrimBrush" Color="{StaticResource ThemeOverlayScrim}" />
+                        <SolidColorBrush x:Key="ThemeOverlayForegroundBrush" Color="{StaticResource ThemeOverlayForeground}" />
 
-            <LinearGradientBrush x:Key="ThemeHeaderGradient" StartPoint="0%,0%" EndPoint="100%,0%">
-                <GradientStop Color="#E3350D20" Offset="0" />
-                <GradientStop Color="#FF6B4A10" Offset="1" />
-            </LinearGradientBrush>
+                        <!-- Gradients -->
+                        <LinearGradientBrush x:Key="ThemeAccentGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#E3350D" Offset="0" />
+                            <GradientStop Color="#FF6B4A" Offset="1" />
+                        </LinearGradientBrush>
 
-            <!-- Box Shadow Effects -->
-            <BoxShadows x:Key="ThemeShadowSmall">0 1 3 0 #00000040</BoxShadows>
-            <BoxShadows x:Key="ThemeShadowMedium">0 4 12 0 #00000050</BoxShadows>
-            <BoxShadows x:Key="ThemeShadowLarge">0 8 24 0 #00000060</BoxShadows>
-            <BoxShadows x:Key="ThemeGlowAccent">0 0 16 0 #E3350D40</BoxShadows>
-            <BoxShadows x:Key="ThemeGlowSuccess">0 0 16 0 #3FB95040</BoxShadows>
-            <BoxShadows x:Key="ThemeGlowError">0 0 16 0 #F8514940</BoxShadows>
+                        <LinearGradientBrush x:Key="ThemeCardGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#21262D" Offset="0" />
+                            <GradientStop Color="#161B22" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <LinearGradientBrush x:Key="ThemeHeaderGradient" StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#E3350D20" Offset="0" />
+                            <GradientStop Color="#FF6B4A10" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <!-- Box Shadow Effects -->
+                        <BoxShadows x:Key="ThemeShadowSmall">0 1 3 0 #00000040</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowMedium">0 4 12 0 #00000050</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowLarge">0 8 24 0 #00000060</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowAccent">0 0 16 0 #E3350D40</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowSuccess">0 0 16 0 #3FB95040</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowError">0 0 16 0 #F8514940</BoxShadows>
+                    </ResourceDictionary>
+
+                    <!-- ═══════════════════════════ Light ═══════════════════════════ -->
+                    <ResourceDictionary x:Key="Light">
+                        <!-- Base Colors -->
+                        <Color x:Key="ThemeBackgroundDeep">#EAEEF2</Color>
+                        <Color x:Key="ThemeBackgroundBase">#F6F8FA</Color>
+                        <Color x:Key="ThemeBackgroundCard">#FFFFFF</Color>
+                        <Color x:Key="ThemeBackgroundElevated">#E7EBEF</Color>
+                        <Color x:Key="ThemeBackgroundHover">#DCE1E6</Color>
+
+                        <!-- Border Colors -->
+                        <Color x:Key="ThemeBorderDefault">#D0D7DE</Color>
+                        <Color x:Key="ThemeBorderMuted">#E1E4E8</Color>
+
+                        <!-- Text Colors (AA on ThemeBackgroundBase/Card: Primary ~16:1, Secondary ~9:1, Muted ~4.6:1) -->
+                        <Color x:Key="ThemeTextPrimary">#1F2328</Color>
+                        <Color x:Key="ThemeTextSecondary">#383E44</Color>
+                        <Color x:Key="ThemeTextMuted">#656D76</Color>
+
+                        <!-- Accent Colors - Pokemon Red Theme (brand-consistent across variants) -->
+                        <Color x:Key="ThemeAccentPrimary">#E3350D</Color>
+                        <Color x:Key="ThemeAccentSecondary">#CC0000</Color>
+                        <Color x:Key="ThemeAccentGlow">#E3350D33</Color>
+
+                        <!-- Semantic Colors - darkened from the Dark palette so they clear 4.5:1 on white -->
+                        <Color x:Key="ThemeSuccessColor">#1A7F37</Color>
+                        <Color x:Key="ThemeSuccessGlow">#1A7F3733</Color>
+                        <Color x:Key="ThemeErrorColor">#CF222E</Color>
+                        <Color x:Key="ThemeErrorGlow">#CF222E33</Color>
+                        <Color x:Key="ThemeWarningColor">#9A6700</Color>
+                        <Color x:Key="ThemeWarningGlow">#9A670033</Color>
+                        <Color x:Key="ThemeShinyColor">#E3350D</Color>
+                        <Color x:Key="ThemeShinyGoldColor">#7A5D00</Color>
+
+                        <Color x:Key="ThemeOverlayScrim">#80000000</Color>
+                        <Color x:Key="ThemeOverlayForeground">#FFFFFF</Color>
+
+                        <!-- Brushes -->
+                        <SolidColorBrush x:Key="ThemeBackgroundDeepBrush" Color="{StaticResource ThemeBackgroundDeep}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundBaseBrush" Color="{StaticResource ThemeBackgroundBase}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundCardBrush" Color="{StaticResource ThemeBackgroundCard}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundElevatedBrush" Color="{StaticResource ThemeBackgroundElevated}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundHoverBrush" Color="{StaticResource ThemeBackgroundHover}" />
+
+                        <SolidColorBrush x:Key="ThemeBorderDefaultBrush" Color="{StaticResource ThemeBorderDefault}" />
+                        <SolidColorBrush x:Key="ThemeBorderMutedBrush" Color="{StaticResource ThemeBorderMuted}" />
+
+                        <SolidColorBrush x:Key="ThemeTextPrimaryBrush" Color="{StaticResource ThemeTextPrimary}" />
+                        <SolidColorBrush x:Key="ThemeTextSecondaryBrush" Color="{StaticResource ThemeTextSecondary}" />
+                        <SolidColorBrush x:Key="ThemeTextMutedBrush" Color="{StaticResource ThemeTextMuted}" />
+
+                        <SolidColorBrush x:Key="ThemeAccentPrimaryBrush" Color="{StaticResource ThemeAccentPrimary}" />
+                        <SolidColorBrush x:Key="ThemeAccentSecondaryBrush" Color="{StaticResource ThemeAccentSecondary}" />
+                        <SolidColorBrush x:Key="ThemeAccentGlowBrush" Color="{StaticResource ThemeAccentGlow}" />
+
+                        <SolidColorBrush x:Key="ThemeSuccessBrush" Color="{StaticResource ThemeSuccessColor}" />
+                        <SolidColorBrush x:Key="ThemeSuccessGlowBrush" Color="{StaticResource ThemeSuccessGlow}" />
+                        <SolidColorBrush x:Key="ThemeErrorBrush" Color="{StaticResource ThemeErrorColor}" />
+                        <SolidColorBrush x:Key="ThemeErrorGlowBrush" Color="{StaticResource ThemeErrorGlow}" />
+                        <SolidColorBrush x:Key="ThemeWarningBrush" Color="{StaticResource ThemeWarningColor}" />
+                        <SolidColorBrush x:Key="ThemeWarningGlowBrush" Color="{StaticResource ThemeWarningGlow}" />
+                        <SolidColorBrush x:Key="ThemeShinyBrush" Color="{StaticResource ThemeShinyColor}" />
+                        <SolidColorBrush x:Key="ThemeShinyGoldBrush" Color="{StaticResource ThemeShinyGoldColor}" />
+
+                        <SolidColorBrush x:Key="ThemeOverlayScrimBrush" Color="{StaticResource ThemeOverlayScrim}" />
+                        <SolidColorBrush x:Key="ThemeOverlayForegroundBrush" Color="{StaticResource ThemeOverlayForeground}" />
+
+                        <!-- Gradients -->
+                        <LinearGradientBrush x:Key="ThemeAccentGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#E3350D" Offset="0" />
+                            <GradientStop Color="#FF6B4A" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <LinearGradientBrush x:Key="ThemeCardGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#FFFFFF" Offset="0" />
+                            <GradientStop Color="#F6F8FA" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <LinearGradientBrush x:Key="ThemeHeaderGradient" StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#E3350D20" Offset="0" />
+                            <GradientStop Color="#FF6B4A10" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <!-- Box Shadow Effects - lighter, since shadows read differently on light surfaces -->
+                        <BoxShadows x:Key="ThemeShadowSmall">0 1 3 0 #00000020</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowMedium">0 4 12 0 #00000025</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowLarge">0 8 24 0 #00000030</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowAccent">0 0 16 0 #E3350D30</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowSuccess">0 0 16 0 #1A7F3730</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowError">0 0 16 0 #CF222E30</BoxShadows>
+                    </ResourceDictionary>
+
+                    <!-- ═══════════════════════ HighContrast ═══════════════════════ -->
+                    <ResourceDictionary x:Key="{x:Static services:AppThemeVariants.HighContrast}">
+                        <!-- Base Colors: pure black surfaces, bright white text/borders -->
+                        <Color x:Key="ThemeBackgroundDeep">#000000</Color>
+                        <Color x:Key="ThemeBackgroundBase">#000000</Color>
+                        <Color x:Key="ThemeBackgroundCard">#000000</Color>
+                        <Color x:Key="ThemeBackgroundElevated">#1A1A1A</Color>
+                        <Color x:Key="ThemeBackgroundHover">#333333</Color>
+
+                        <!-- Border Colors -->
+                        <Color x:Key="ThemeBorderDefault">#FFFFFF</Color>
+                        <Color x:Key="ThemeBorderMuted">#AAAAAA</Color>
+
+                        <!-- Text Colors (all >15:1 on black) -->
+                        <Color x:Key="ThemeTextPrimary">#FFFFFF</Color>
+                        <Color x:Key="ThemeTextSecondary">#E0E0E0</Color>
+                        <Color x:Key="ThemeTextMuted">#CCCCCC</Color>
+
+                        <!-- Accent Colors - brightened for maximum legibility on black -->
+                        <Color x:Key="ThemeAccentPrimary">#FF4500</Color>
+                        <Color x:Key="ThemeAccentSecondary">#FF0000</Color>
+                        <Color x:Key="ThemeAccentGlow">#FF450066</Color>
+
+                        <!-- Semantic Colors -->
+                        <Color x:Key="ThemeSuccessColor">#00FF66</Color>
+                        <Color x:Key="ThemeSuccessGlow">#00FF6650</Color>
+                        <Color x:Key="ThemeErrorColor">#FF5C4D</Color>
+                        <Color x:Key="ThemeErrorGlow">#FF5C4D50</Color>
+                        <Color x:Key="ThemeWarningColor">#FFD400</Color>
+                        <Color x:Key="ThemeWarningGlow">#FFD40050</Color>
+                        <Color x:Key="ThemeShinyColor">#FF4500</Color>
+                        <Color x:Key="ThemeShinyGoldColor">#FFFF00</Color>
+
+                        <Color x:Key="ThemeOverlayScrim">#CC000000</Color>
+                        <Color x:Key="ThemeOverlayForeground">#FFFFFF</Color>
+
+                        <!-- Brushes -->
+                        <SolidColorBrush x:Key="ThemeBackgroundDeepBrush" Color="{StaticResource ThemeBackgroundDeep}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundBaseBrush" Color="{StaticResource ThemeBackgroundBase}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundCardBrush" Color="{StaticResource ThemeBackgroundCard}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundElevatedBrush" Color="{StaticResource ThemeBackgroundElevated}" />
+                        <SolidColorBrush x:Key="ThemeBackgroundHoverBrush" Color="{StaticResource ThemeBackgroundHover}" />
+
+                        <SolidColorBrush x:Key="ThemeBorderDefaultBrush" Color="{StaticResource ThemeBorderDefault}" />
+                        <SolidColorBrush x:Key="ThemeBorderMutedBrush" Color="{StaticResource ThemeBorderMuted}" />
+
+                        <SolidColorBrush x:Key="ThemeTextPrimaryBrush" Color="{StaticResource ThemeTextPrimary}" />
+                        <SolidColorBrush x:Key="ThemeTextSecondaryBrush" Color="{StaticResource ThemeTextSecondary}" />
+                        <SolidColorBrush x:Key="ThemeTextMutedBrush" Color="{StaticResource ThemeTextMuted}" />
+
+                        <SolidColorBrush x:Key="ThemeAccentPrimaryBrush" Color="{StaticResource ThemeAccentPrimary}" />
+                        <SolidColorBrush x:Key="ThemeAccentSecondaryBrush" Color="{StaticResource ThemeAccentSecondary}" />
+                        <SolidColorBrush x:Key="ThemeAccentGlowBrush" Color="{StaticResource ThemeAccentGlow}" />
+
+                        <SolidColorBrush x:Key="ThemeSuccessBrush" Color="{StaticResource ThemeSuccessColor}" />
+                        <SolidColorBrush x:Key="ThemeSuccessGlowBrush" Color="{StaticResource ThemeSuccessGlow}" />
+                        <SolidColorBrush x:Key="ThemeErrorBrush" Color="{StaticResource ThemeErrorColor}" />
+                        <SolidColorBrush x:Key="ThemeErrorGlowBrush" Color="{StaticResource ThemeErrorGlow}" />
+                        <SolidColorBrush x:Key="ThemeWarningBrush" Color="{StaticResource ThemeWarningColor}" />
+                        <SolidColorBrush x:Key="ThemeWarningGlowBrush" Color="{StaticResource ThemeWarningGlow}" />
+                        <SolidColorBrush x:Key="ThemeShinyBrush" Color="{StaticResource ThemeShinyColor}" />
+                        <SolidColorBrush x:Key="ThemeShinyGoldBrush" Color="{StaticResource ThemeShinyGoldColor}" />
+
+                        <SolidColorBrush x:Key="ThemeOverlayScrimBrush" Color="{StaticResource ThemeOverlayScrim}" />
+                        <SolidColorBrush x:Key="ThemeOverlayForegroundBrush" Color="{StaticResource ThemeOverlayForeground}" />
+
+                        <!-- Gradients - flattened to solid-feeling gradients; HC favors flat, unambiguous fills -->
+                        <LinearGradientBrush x:Key="ThemeAccentGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#FF4500" Offset="0" />
+                            <GradientStop Color="#FF6A33" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <LinearGradientBrush x:Key="ThemeCardGradient" StartPoint="0%,0%" EndPoint="100%,100%">
+                            <GradientStop Color="#000000" Offset="0" />
+                            <GradientStop Color="#000000" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <LinearGradientBrush x:Key="ThemeHeaderGradient" StartPoint="0%,0%" EndPoint="100%,0%">
+                            <GradientStop Color="#FF450030" Offset="0" />
+                            <GradientStop Color="#FF6A3320" Offset="1" />
+                        </LinearGradientBrush>
+
+                        <!-- Box Shadow Effects -->
+                        <BoxShadows x:Key="ThemeShadowSmall">0 1 3 0 #FFFFFF30</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowMedium">0 4 12 0 #FFFFFF40</BoxShadows>
+                        <BoxShadows x:Key="ThemeShadowLarge">0 8 24 0 #FFFFFF50</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowAccent">0 0 16 0 #FF450066</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowSuccess">0 0 16 0 #00FF6650</BoxShadows>
+                        <BoxShadows x:Key="ThemeGlowError">0 0 16 0 #FF5C4D50</BoxShadows>
+                    </ResourceDictionary>
+
+                </ResourceDictionary.ThemeDictionaries>
+            </ResourceDictionary>
         </Style.Resources>
     </Style>
 
@@ -97,21 +302,21 @@
          Card Style - Elevated container with subtle depth
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.card">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundCardBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderDefaultBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundCardBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="6" />
-        <Setter Property="BoxShadow" Value="{StaticResource ThemeShadowSmall}" />
+        <Setter Property="BoxShadow" Value="{DynamicResource ThemeShadowSmall}" />
     </Style>
 
     <Style Selector="Border.card-elevated">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundElevatedBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderDefaultBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundElevatedBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="Padding" Value="6" />
-        <Setter Property="BoxShadow" Value="{StaticResource ThemeShadowMedium}" />
+        <Setter Property="BoxShadow" Value="{DynamicResource ThemeShadowMedium}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -122,7 +327,7 @@
     </Style>
 
     <Style Selector="Button:focus-visible">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
         <Setter Property="BorderThickness" Value="2" />
     </Style>
 
@@ -131,8 +336,8 @@
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Button.slot">
         <Setter Property="FocusAdorner" Value="{x:Null}" />
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundCardBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderDefaultBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundCardBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="0" />
         <Setter Property="Padding" Value="0" />
@@ -141,7 +346,7 @@
         <Setter Property="Template">
             <ControlTemplate x:DataType="models:SlotData">
                 <Panel>
-                    <Border Name="PART_Border" 
+                    <Border Name="PART_Border"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
@@ -154,8 +359,8 @@
                                           VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Border>
                     <!-- Illegal Indicator - positioned inside the border with 2px inset -->
-                    <Path Data="M 6,0 L 12,11 L 0,11 Z M 6.5,9.5 H 5.5 V 8.5 H 6.5 V 9.5 Z M 6.5,7.5 H 5.5 V 3.5 H 6.5 V 7.5 Z" 
-                          Fill="{StaticResource ThemeShinyBrush}"
+                    <Path Data="M 6,0 L 12,11 L 0,11 Z M 6.5,9.5 H 5.5 V 8.5 H 6.5 V 9.5 Z M 6.5,7.5 H 5.5 V 3.5 H 6.5 V 7.5 Z"
+                          Fill="{DynamicResource ThemeShinyBrush}"
                           HorizontalAlignment="Right"
                           VerticalAlignment="Top"
                           IsVisible="{Binding !IsLegal}"
@@ -173,34 +378,34 @@
     </Style>
 
     <Style Selector="Button.slot:pointerover">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundElevatedBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundElevatedBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- Selected State - Enforce Red -->
     <Style Selector="Button.slot.selected">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="ZIndex" Value="10" />
     </Style>
 
     <!-- Focus State - Enforce Red & Kill Yellow -->
     <Style Selector="Button.slot:focus">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="ZIndex" Value="10" />
     </Style>
-    
+
     <!-- Deep Focus Override -->
     <Style Selector="Button.slot:focus /template/ Border#PART_Border">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
          Accent Button - Primary action button with gradient
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Button.accent-gradient">
-        <Setter Property="Background" Value="{StaticResource ThemeAccentGradient}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentGradient}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="CornerRadius" Value="8" />
@@ -212,25 +417,25 @@
          Badge Styles - Status indicators
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.badge-success">
-        <Setter Property="Background" Value="{StaticResource ThemeSuccessBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeSuccessBrush}" />
         <Setter Property="CornerRadius" Value="12" />
         <Setter Property="Padding" Value="8,4" />
-        <Setter Property="BoxShadow" Value="{StaticResource ThemeGlowSuccess}" />
+        <Setter Property="BoxShadow" Value="{DynamicResource ThemeGlowSuccess}" />
     </Style>
 
     <Style Selector="Border.badge-error">
-        <Setter Property="Background" Value="{StaticResource ThemeErrorBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeErrorBrush}" />
         <Setter Property="CornerRadius" Value="12" />
         <Setter Property="Padding" Value="8,4" />
-        <Setter Property="BoxShadow" Value="{StaticResource ThemeGlowError}" />
+        <Setter Property="BoxShadow" Value="{DynamicResource ThemeGlowError}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
          Header Style - Section headers with gradient accent
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.header-accent">
-        <Setter Property="Background" Value="{StaticResource ThemeHeaderGradient}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderDefaultBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeHeaderGradient}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="0,0,0,1" />
         <Setter Property="Padding" Value="16,12" />
     </Style>
@@ -239,7 +444,7 @@
          Empty Slot Pattern - Subtle diagonal stripes
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.empty-slot">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundElevatedBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundElevatedBrush}" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Opacity" Value="0.6" />
     </Style>
@@ -248,8 +453,8 @@
          Section Card - For form sections (replaces SystemControlBackgroundChromeMediumLowBrush)
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.section-card">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundCardBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderMutedBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundCardBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMutedBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="8" />
@@ -259,11 +464,24 @@
          View Container - Main background for views (replaces SystemControlBackgroundAltHighBrush)
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.view-container">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundBaseBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBaseBrush}" />
         <Setter Property="Padding" Value="12" />
     </Style>
 
+    <!-- ─────────────────────────────────────────────────────────────────────────
+         Overlay Scrim - Full-pane dim veil behind loading/searching spinners
+         ───────────────────────────────────────────────────────────────────────── -->
+    <Style Selector="Border.overlay-scrim">
+        <Setter Property="Background" Value="{DynamicResource ThemeOverlayScrimBrush}" />
+    </Style>
 
+    <Style Selector="Grid.overlay-scrim">
+        <Setter Property="Background" Value="{DynamicResource ThemeOverlayScrimBrush}" />
+    </Style>
+
+    <Style Selector="TextBlock.overlay-text">
+        <Setter Property="Foreground" Value="{DynamicResource ThemeOverlayForegroundBrush}" />
+    </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
          Global Button Transitions - Smooth hover for all buttons
@@ -286,7 +504,7 @@
          Accent Button - Styled primary action button
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Button.accent">
-        <Setter Property="Background" Value="{StaticResource ThemeAccentSecondaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentSecondaryBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="CornerRadius" Value="6" />
@@ -294,7 +512,7 @@
     </Style>
 
     <Style Selector="Button.accent:pointerover">
-        <Setter Property="Background" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
         <Setter Property="Opacity" Value="1" />
     </Style>
 
@@ -310,7 +528,7 @@
     </Style>
 
     <Style Selector="TabItem:selected">
-        <Setter Property="Foreground" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -325,7 +543,7 @@
     </Style>
 
     <Style Selector="ComboBox:pointerover">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- ═══════════════════════════════════════════════════════════════════════════
@@ -336,7 +554,7 @@
          - NumericUpDown.form-field : Standard form field with proper sizing
          - NumericUpDown.condensed  : Smaller variant for tight spaces (legacy, use .compact instead)
          ═══════════════════════════════════════════════════════════════════════════ -->
-    
+
     <!-- Base NumericUpDown transitions and hover -->
     <Style Selector="NumericUpDown">
         <Setter Property="Transitions">
@@ -347,7 +565,7 @@
     </Style>
 
     <Style Selector="NumericUpDown:pointerover">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- Compact: Hides spinners, ideal for DataGrid cells and inline editing -->
@@ -389,17 +607,17 @@
          COMPONENT STANDARDS - DataGrid
          Standardized DataGrid appearance for list/table views.
          ═══════════════════════════════════════════════════════════════════════════ -->
-    
+
     <Style Selector="DataGrid">
         <Setter Property="GridLinesVisibility" Value="Horizontal" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="RowBackground" Value="Transparent" />
     </Style>
-    
+
     <Style Selector="DataGridRow">
         <Setter Property="MinHeight" Value="36" />
     </Style>
-    
+
     <Style Selector="DataGridCell">
         <Setter Property="Padding" Value="8,4" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -409,14 +627,14 @@
          COMPONENT STANDARDS - ComboBox in DataGrid
          Transparent backgrounds for inline editing feel.
          ═══════════════════════════════════════════════════════════════════════════ -->
-    
+
     <Style Selector="DataGrid ComboBox">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="4,2" />
         <Setter Property="MinHeight" Value="28" />
     </Style>
-    
+
     <Style Selector="DataGrid NumericUpDown">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
@@ -429,7 +647,7 @@
     <!-- ═══════════════════════════════════════════════════════════════════════════
          COMPONENT STANDARDS - CheckBox in compact layouts
          ═══════════════════════════════════════════════════════════════════════════ -->
-    
+
     <Style Selector="CheckBox.compact">
         <Setter Property="Padding" Value="4,2" />
         <Setter Property="MinHeight" Value="24" />
@@ -438,10 +656,10 @@
     <!-- ═══════════════════════════════════════════════════════════════════════════
          RIBBON ITEM - Standard ribbon item card for RibbonEditor
          ═══════════════════════════════════════════════════════════════════════════ -->
-    
+
     <Style Selector="Border.ribbon-item">
-        <Setter Property="Background" Value="{StaticResource ThemeBackgroundCardBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderMutedBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeBackgroundCardBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMutedBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="8" />
@@ -451,7 +669,7 @@
     </Style>
 
     <Style Selector="Border.ribbon-item:pointerover">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -466,7 +684,7 @@
     </Style>
 
     <Style Selector="TextBox:focus">
-        <Setter Property="BorderBrush" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -474,7 +692,7 @@
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="TextBlock.section-header">
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource ThemeTextSecondaryBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ThemeTextSecondaryBrush}" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Margin" Value="0,0,0,8" />
     </Style>
@@ -485,7 +703,7 @@
     <Style Selector="TextBlock.view-title">
         <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource ThemeTextPrimaryBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ThemeTextPrimaryBrush}" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -506,7 +724,7 @@
                     <Border Width="2" CornerRadius="1"
                             HorizontalAlignment="Center" VerticalAlignment="Stretch"
                             Margin="0,8"
-                            Background="{StaticResource ThemeBorderMutedBrush}" />
+                            Background="{DynamicResource ThemeBorderMutedBrush}" />
                 </Border>
             </ControlTemplate>
         </Setter>
@@ -518,8 +736,7 @@
     </Style>
 
     <Style Selector="GridSplitter.pane-splitter:pointerover /template/ Border > Border">
-        <Setter Property="Background" Value="{StaticResource ThemeAccentPrimaryBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentPrimaryBrush}" />
     </Style>
 
 </Styles>
-

--- a/PKHeX.Avalonia/Views/EncounterDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/EncounterDatabaseView.axaml
@@ -46,7 +46,7 @@
                                     Background="Transparent" BorderThickness="0">
                                 <Border Classes="section-card" 
                                         CornerRadius="6" Padding="8" Width="240" Height="70"
-                                        BoxShadow="{StaticResource ThemeShadowSmall}">
+                                        BoxShadow="{DynamicResource ThemeShadowSmall}">
                                     <Grid ColumnDefinitions="50,*">
                                         <Image Grid.Column="0" Source="{Binding Sprite, Converter={StaticResource PngBytesToBitmap}}" Width="40" Height="40" VerticalAlignment="Center"/>
                                         <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">

--- a/PKHeX.Avalonia/Views/FolderList.axaml
+++ b/PKHeX.Avalonia/Views/FolderList.axaml
@@ -66,8 +66,8 @@
         <TextBlock Grid.Row="2" Text="{Binding StatusText}" Margin="10,5"/>
         
         <!-- Loading Overlay -->
-        <Border Grid.RowSpan="3" Background="#80000000" IsVisible="{Binding IsLoading}">
-            <TextBlock Text="Loading..." Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="24"/>
+        <Border Grid.RowSpan="3" Classes="overlay-scrim" IsVisible="{Binding IsLoading}">
+            <TextBlock Classes="overlay-text" Text="Loading..." HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="24"/>
         </Border>
     </Grid>
 </UserControl>

--- a/PKHeX.Avalonia/Views/MysteryGiftDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/MysteryGiftDatabaseView.axaml
@@ -89,10 +89,10 @@
         </Border>
 
         <!-- Searching Overlay -->
-        <Grid Grid.ColumnSpan="3" Background="#80000000" IsVisible="{Binding IsSearching}">
+        <Grid Grid.ColumnSpan="3" Classes="overlay-scrim" IsVisible="{Binding IsSearching}">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="16">
                 <ProgressBar IsIndeterminate="True" Width="200"/>
-                <TextBlock Text="Loading Mystery Gifts..." Foreground="White" HorizontalAlignment="Center"/>
+                <TextBlock Classes="overlay-text" Text="Loading Mystery Gifts..." HorizontalAlignment="Center"/>
             </StackPanel>
         </Grid>
     </Grid>

--- a/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
+++ b/PKHeX.Avalonia/Views/PKMDatabaseView.axaml
@@ -159,10 +159,10 @@
         </Border>
 
         <!-- Searching Overlay -->
-        <Grid Grid.ColumnSpan="3" Background="#80000000" IsVisible="{Binding IsSearching}">
+        <Grid Grid.ColumnSpan="3" Classes="overlay-scrim" IsVisible="{Binding IsSearching}">
             <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="16">
                 <ProgressBar IsIndeterminate="True" Width="200"/>
-                <TextBlock Text="Searching Database..." Foreground="White" HorizontalAlignment="Center"/>
+                <TextBlock Classes="overlay-text" Text="Searching Database..." HorizontalAlignment="Center"/>
             </StackPanel>
         </Grid>
     </Grid>

--- a/PKHeX.Avalonia/Views/PartyViewer.axaml
+++ b/PKHeX.Avalonia/Views/PartyViewer.axaml
@@ -106,7 +106,7 @@
                                             
                                             <!-- Illegal Warning -->
                                             <Path Data="M 8,0 L 16,14 L 0,14 Z M 8.5,12 H 7.5 V 10.5 H 8.5 V 12 Z M 8.5,9 H 7.5 V 4.5 H 8.5 V 9 Z" 
-                                                  Fill="{StaticResource ThemeShinyBrush}"
+                                                  Fill="{DynamicResource ThemeShinyBrush}"
                                                   HorizontalAlignment="Right"
                                                   VerticalAlignment="Top"
                                                   IsVisible="{Binding !IsLegal}"

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -35,7 +35,7 @@
                             BorderThickness="1"
                             CornerRadius="8"
                             Width="80" Height="68"
-                            BoxShadow="{StaticResource ThemeShadowSmall}"
+                            BoxShadow="{DynamicResource ThemeShadowSmall}"
                             ClipToBounds="True">
                         <Panel>
                             <Image Source="{Binding Sprite, Converter={StaticResource PngBytesToBitmap}}"
@@ -47,7 +47,7 @@
                                    ToolTip.Tip="{Binding Title}" />
                             <!-- Illegal Warning - inset from corner to match box slots -->
                             <Path Data="M 8,0 L 16,14 L 0,14 Z M 8.5,12 H 7.5 V 10.5 H 8.5 V 12 Z M 8.5,9 H 7.5 V 4.5 H 8.5 V 9 Z" 
-                                  Fill="{StaticResource ThemeShinyBrush}"
+                                  Fill="{DynamicResource ThemeShinyBrush}"
                                   HorizontalAlignment="Right" 
                                   VerticalAlignment="Top"
                                   IsVisible="{Binding !IsLegal}"

--- a/PKHeX.Avalonia/Views/Roamer3Editor.axaml
+++ b/PKHeX.Avalonia/Views/Roamer3Editor.axaml
@@ -18,14 +18,14 @@
                 <StackPanel Spacing="16">
                     
                     <!-- Glitch Warning -->
-                    <Border IsVisible="{Binding IsGlitched}" 
-                            Background="#4CD29922" 
-                            BorderBrush="{StaticResource ThemeWarningBrush}"
+                    <Border IsVisible="{Binding IsGlitched}"
+                            Background="{DynamicResource ThemeWarningGlowBrush}"
+                            BorderBrush="{DynamicResource ThemeWarningBrush}"
                             BorderThickness="1" 
                             CornerRadius="6" 
                             Padding="12">
                         <TextBlock Text="{Binding GlitchWarning}" 
-                                   Foreground="{StaticResource ThemeWarningBrush}" 
+                                   Foreground="{DynamicResource ThemeWarningBrush}" 
                                    TextWrapping="Wrap" />
                     </Border>
 
@@ -81,7 +81,7 @@
 
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <TextBlock Text="Shiny:" VerticalAlignment="Center" Opacity="0.7" />
-                                <TextBlock Text="Yes" Foreground="#FFD700" FontWeight="SemiBold" IsVisible="{Binding IsShiny}" />
+                                <TextBlock Text="Yes" Foreground="{DynamicResource ThemeShinyGoldBrush}" FontWeight="SemiBold" IsVisible="{Binding IsShiny}" />
                                 <TextBlock Text="No" Opacity="0.5" IsVisible="{Binding !IsShiny}" />
                             </StackPanel>
                         </StackPanel>

--- a/PKHeX.Avalonia/Views/SettingsView.axaml
+++ b/PKHeX.Avalonia/Views/SettingsView.axaml
@@ -7,6 +7,7 @@
 
     <UserControl.Resources>
         <conv:SpritePreferenceLabelConverter x:Key="SpritePrefLabel"/>
+        <conv:AppThemeLabelConverter x:Key="AppThemeLabel"/>
     </UserControl.Resources>
 
     <ScrollViewer>
@@ -120,6 +121,33 @@
                                        FontSize="12" Opacity="0.6" TextWrapping="Wrap"/>
                         </StackPanel>
                         <ToggleSwitch Grid.Column="1" IsChecked="{Binding ShowChangelog}" OnContent="On" OffContent="Off"/>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- Appearance Settings Card -->
+            <Border Classes="section-card" Padding="20" CornerRadius="8">
+                <StackPanel Spacing="16">
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <TextBlock Text="🖥️" FontSize="20" VerticalAlignment="Center"/>
+                        <TextBlock Text="Appearance" FontSize="18" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="Theme" FontWeight="Medium"/>
+                            <TextBlock Text="Switches immediately, no restart required. 'Follow System' tracks the OS light/dark preference live."
+                                       FontSize="12" Opacity="0.6" TextWrapping="Wrap"/>
+                        </StackPanel>
+                        <ComboBox Grid.Column="1" MinWidth="170" VerticalAlignment="Center"
+                                  ItemsSource="{Binding Themes}"
+                                  SelectedItem="{Binding SelectedTheme}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:CompileBindings="False">
+                                    <TextBlock Text="{Binding Converter={StaticResource AppThemeLabel}}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </Grid>
                 </StackPanel>
             </Border>

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs
@@ -23,7 +23,7 @@ public partial class MainWindowViewModel
     [RelayCommand]
     private async Task OpenSettingsAsync()
     {
-        var vm = new SettingsViewModel(_settings, _settingsStore);
+        var vm = new SettingsViewModel(_settings, _settingsStore, _themeService);
         await _windowService.ShowDialogAsync(vm, "Settings");
 
         // The sprite preference may have changed; re-apply the style and refresh open views.

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IUpdateCheckService _updateCheckService;
     private readonly AppSettings _settings;
     private readonly ISettingsStore _settingsStore;
+    private readonly IThemeService _themeService;
     private readonly UndoRedoService _undoRedo;
     private readonly LanguageService _languageService;
     private readonly IAutoLegalityService _autoLegalityService;
@@ -74,6 +75,7 @@ public partial class MainWindowViewModel : ViewModelBase
         IUpdateCheckService updateCheckService,
         AppSettings settings,
         ISettingsStore settingsStore,
+        IThemeService themeService,
         UndoRedoService undoRedo,
         LanguageService languageService,
         IAutoLegalityService autoLegalityService,
@@ -89,6 +91,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _updateCheckService = updateCheckService;
         _settings = settings;
         _settingsStore = settingsStore;
+        _themeService = themeService;
         _undoRedo = undoRedo;
         _languageService = languageService;
         _autoLegalityService = autoLegalityService;

--- a/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/SettingsViewModel.cs
@@ -10,13 +10,16 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
 {
     private readonly AppSettings _settings;
     private readonly ISettingsStore _settingsStore;
+    private readonly IThemeService _themeService;
+    private bool _isLoading;
 
     public Action? CloseRequested { get; set; }
 
-    public SettingsViewModel(AppSettings settings, ISettingsStore settingsStore)
+    public SettingsViewModel(AppSettings settings, ISettingsStore settingsStore, IThemeService themeService)
     {
         _settings = settings;
         _settingsStore = settingsStore;
+        _themeService = themeService;
         Load();
     }
 
@@ -45,8 +48,22 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
     [ObservableProperty] private SpritePreference _spritePreference;
     public IReadOnlyList<SpritePreference> SpritePreferences { get; } = Enum.GetValues<SpritePreference>();
 
+    // Appearance
+    [ObservableProperty] private AppTheme _selectedTheme;
+    public IReadOnlyList<AppTheme> Themes { get; } = Enum.GetValues<AppTheme>();
+
+    partial void OnSelectedThemeChanged(AppTheme value)
+    {
+        // Apply (and persist) immediately so the picker previews live, without needing Save.
+        // Skip during Load(), which sets the initial value from the already-applied preference.
+        if (!_isLoading)
+            _themeService.ApplyTheme(value);
+    }
+
     private void Load()
     {
+        _isLoading = true;
+
         DefaultSaveVersion = _settings.Startup.DefaultSaveVersion;
         AutoLoadMode = _settings.Startup.AutoLoadSaveOnStartup;
         ForceHaX = _settings.Startup.ForceHaXOnLaunch;
@@ -62,6 +79,9 @@ public partial class SettingsViewModel : ViewModelBase, ICloseableDialog
         ModifyUnset = _settings.SlotWrite.ModifyUnset;
 
         SpritePreference = _settings.Sprite.SpritePreference;
+        SelectedTheme = _themeService.CurrentTheme;
+
+        _isLoading = false;
     }
 
     [RelayCommand]

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -42,6 +42,7 @@ public class ShowdownIntegrationTests : IDisposable
             new Mock<IUpdateCheckService>().Object,
             new AppSettings(),
             new FakeSettingsStore(),
+            new Mock<IThemeService>().Object,
             new UndoRedoService(),
             new LanguageService(),
             new Mock<IAutoLegalityService>().Object,

--- a/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
@@ -125,7 +125,8 @@ public class SpriteStyleTests
     {
         // Proves the new Sprites card wires up at runtime: the XAML resource (converter),
         // the ComboBox ItemsSource, and the SelectedItem binding.
-        var vm = new SettingsViewModel(new AppSettings(), new FakeSettingsStore());
+        var settings = new AppSettings();
+        var vm = new SettingsViewModel(settings, new FakeSettingsStore(), new ThemeService(settings, new FakeSettingsStore()));
         var view = new SettingsView { DataContext = vm };
         var window = new Window { Content = view, Width = 480, Height = 720 };
         window.Show();

--- a/Tests/PKHeX.Avalonia.Tests/ThemeTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ThemeTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Moq;
+using PKHeX.Avalonia.Services;
+using PKHeX.Presentation.ViewModels;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Covers the theme-system logic that doesn't require a live Avalonia window: preference
+/// persistence (round-tripping through AppSettings' JSON store) and the Settings picker wiring
+/// (that selecting a theme calls through to IThemeService, and that loading existing state does not).
+/// </summary>
+public class ThemeTests
+{
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    [InlineData(AppTheme.System)]
+    public void AppSettings_RoundTripsThemePreference_ThroughJson(AppTheme theme)
+    {
+        var settings = new AppSettings { Theme = new AppSettings.ThemeSettings { Selected = theme } };
+
+        var json = JsonSerializer.Serialize(settings);
+        var restored = JsonSerializer.Deserialize<AppSettings>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal(theme, restored!.Theme.Selected);
+    }
+
+    [Fact]
+    public void AppSettings_DefaultsToDarkTheme()
+    {
+        var settings = new AppSettings();
+        Assert.Equal(AppTheme.Dark, settings.Theme.Selected);
+    }
+
+    [Fact]
+    public void ThemeService_ApplyTheme_UpdatesCurrentThemeAndPersists()
+    {
+        var settings = new AppSettings();
+        var store = new FakeSettingsStore();
+        var service = new ThemeService(settings, store);
+
+        service.ApplyTheme(AppTheme.Light);
+
+        Assert.Equal(AppTheme.Light, service.CurrentTheme);
+        Assert.Equal(AppTheme.Light, settings.Theme.Selected);
+        Assert.Same(settings, store.Saved);
+    }
+
+    [Fact]
+    public void SettingsViewModel_Load_DoesNotReapplyTheme()
+    {
+        var settings = new AppSettings { Theme = new AppSettings.ThemeSettings { Selected = AppTheme.HighContrast } };
+        var themeServiceMock = new Mock<IThemeService>();
+        themeServiceMock.SetupGet(t => t.CurrentTheme).Returns(AppTheme.HighContrast);
+
+        var vm = new SettingsViewModel(settings, new FakeSettingsStore(), themeServiceMock.Object);
+
+        Assert.Equal(AppTheme.HighContrast, vm.SelectedTheme);
+        themeServiceMock.Verify(t => t.ApplyTheme(It.IsAny<AppTheme>()), Times.Never);
+    }
+
+    [Fact]
+    public void SettingsViewModel_ChangingSelectedTheme_AppliesThroughThemeService()
+    {
+        var settings = new AppSettings();
+        var themeServiceMock = new Mock<IThemeService>();
+        themeServiceMock.SetupGet(t => t.CurrentTheme).Returns(AppTheme.Dark);
+
+        var vm = new SettingsViewModel(settings, new FakeSettingsStore(), themeServiceMock.Object);
+
+        vm.SelectedTheme = AppTheme.Light;
+
+        themeServiceMock.Verify(t => t.ApplyTheme(AppTheme.Light), Times.Once);
+    }
+
+    [Fact]
+    public void AppThemeVariants_HighContrast_InheritsFromDark()
+    {
+        Assert.Equal("HighContrast", AppThemeVariants.HighContrast.Key);
+        Assert.Equal(global::Avalonia.Styling.ThemeVariant.Dark, AppThemeVariants.HighContrast.InheritVariant);
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
@@ -169,6 +169,7 @@ public class MainWindowUpdateCheckTests
             updateCheckServiceMock.Object,
             settings,
             new FakeSettingsStore(),
+            new Mock<IThemeService>().Object,
             new UndoRedoService(),
             new LanguageService(),
             new Mock<IAutoLegalityService>().Object,


### PR DESCRIPTION
## Summary

- Refactors `Styles/Theme.axaml` into semantic design tokens exposed via Avalonia `ResourceDictionary.ThemeDictionaries`, so appearance can switch at runtime with no restart. Three variants:
  - **Dark** — unchanged, stays the default (same exact values as before).
  - **Light** — new; semantic colors (success/error/warning/shiny-gold) were darkened from the Dark palette so all body text clears WCAG AA (4.5:1) against the light surfaces.
  - **HighContrast** — a custom `ThemeVariant("HighContrast", inherit: Dark)` (`PKHeX.Avalonia/Services/AppThemeVariants.cs`); pure-black surfaces, bright borders/text, boosted accent/semantic colors.
  - Every consumer of these tokens (Theme.axaml's own selectors, plus 4 views that referenced them directly) was converted from `StaticResource` to `DynamicResource` so brushes actually re-resolve on variant change. Two new tokens were added for previously-hardcoded values: `ThemeOverlayScrimBrush`/`ThemeOverlayForegroundBrush` (loading/search overlays) and `ThemeShinyGoldBrush`/`ThemeWarningGlowBrush`.

- **IThemeService** port (`PKHeX.Application/Abstractions/IThemeService.cs`) with an Avalonia-only implementation (`PKHeX.Avalonia/Services/ThemeService.cs`), following the existing `IWindowService`/`IDialogService` pattern. It maps `AppTheme { Dark, Light, HighContrast, System }` to `Application.RequestedThemeVariant` (`ThemeVariant.Light`/`.Dark`/`AppThemeVariants.HighContrast`, or `ThemeVariant.Default` for "System" — Avalonia natively tracks `PlatformSettings.ColorValuesChanged` when `Default` is used, covering macOS/Windows/Linux-portal live tracking with no extra plumbing). Since it sets a single `Application`-level property, every open window/dialog restyles live automatically.

- Settings view gains an **Appearance** card with a theme picker (`Dark`/`Light`/`High Contrast`/`Follow System`) that applies live as it's selected — no Save button needed for this preference. Persists through the existing `ISettingsStore`/`AppSettings` JSON store (a new `ThemeSettings.Selected` group), consistent with the settings-port refactor from #138.

- Swept the remaining hardcoded colors out of views: 3× loading/search scrim overlays + their `Foreground="White"` labels, a glitch-warning banner background, and a shiny-gold label. The only hardcoded hex left in the Avalonia layer is the 7 `SystemAccentColor*` overrides in `App.axaml` — deliberately kept there (not tokenized) because they must stay in `Application.Resources`, not a Style's resources, to reliably out-precede FluentTheme's own accent resources; this is documented in-file.

## Notable finding

Avalonia's XAML compiler rejects custom `ThemeVariant` values as plain string `x:Key`s in `ThemeDictionaries` (`ThemeVariantTypeConverter supports only built-in variants`). Fixed by keying the HighContrast dictionary via `x:Key="{x:Static services:AppThemeVariants.HighContrast}"` — worth knowing if anyone adds a fourth custom variant later.

## Verification

- `dotnet build PKHeX.sln -c Release` → 0 Warning(s), 0 Error(s)
- `dotnet test PKHeX.sln -c Release` → all green (Core.Tests 449/450 + 1 skip, Architecture.Tests 5/5, Avalonia.Tests 2051/2051), including 7 new theme tests (JSON round-trip of all 4 `AppTheme` values, default-is-Dark, `ThemeService.ApplyTheme` updates+persists via `ISettingsStore`, `SettingsViewModel` doesn't reapply on Load, applies through `IThemeService` on selection change, `AppThemeVariants.HighContrast` inherits from Dark)
- `UIVersion` bumped 1.30.0 → 1.31.0 (rebased twice onto main during review to pick up #148/#149, which each already bumped it)

## Caveats — needs manual/visual verification

- Actual on-screen appearance of all three themes across the main tabs (can't be captured headlessly in this environment).
- Live "Follow System" behavior when toggling the OS light/dark preference.
- Per the issue's acceptance criteria, screenshots of all main tabs in each theme should be attached for visual review before merge — not attached here.

Closes #133