### PR TITLE
feat: Living Dex generator (#123)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.31.1</UIVersion>
+    <UIVersion>1.32.0</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Abstractions/ILivingDexService.cs
+++ b/PKHeX.Application/Abstractions/ILivingDexService.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using PKHeX.Core;
+
+namespace PKHeX.Application.Abstractions;
+
+/// <summary>
+/// Application-layer port over the Living Dex generator (Auto-Legality Mod Phase 2, issue #123). Produces
+/// one legal <see cref="PKM"/> per species obtainable in the loaded save's game. The concrete
+/// implementation lives in the Infrastructure layer; it drives the loop itself over the vendored
+/// <c>PKHeX.AutoMod</c> engine's per-set legalization path (the same one the "Auto Legality Mod" single-set
+/// tool uses) rather than the engine's own <c>ModLogic.GenerateLivingDex</c>, which has a defect that makes
+/// it return nothing (see the Infrastructure implementation for details). This interface keeps the
+/// engine's types out of the Application and Presentation layers.
+/// </summary>
+public interface ILivingDexService
+{
+    /// <summary>
+    /// Generates a living dex for the given save file.
+    /// </summary>
+    /// <param name="sav">Save file supplying trainer data, generation, and format context.</param>
+    /// <param name="options">Generation options (include forms / shiny).</param>
+    /// <param name="progress">Optional progress reporter, updated after each species is processed.</param>
+    /// <param name="cancellationToken">
+    /// Cooperative cancellation, checked before each species (and each of its forms) is processed. Since
+    /// the per-species loop lives in this adapter (not inside the vendored engine), cancellation takes
+    /// effect promptly rather than only between whole-dex passes.
+    /// </param>
+    /// <param name="maxSpeciesId">
+    /// Test-only: caps the species ID range attempted (still subject to <paramref name="sav"/>'s own
+    /// dex). Leave <see langword="null"/> for the full living dex — that is what the UI always requests.
+    /// </param>
+    /// <remarks>
+    /// This call is CPU-bound and can run for tens of seconds to a few minutes for a full modern-gen dex
+    /// (one legality attempt per species/form in the game). Callers on a UI thread should offload it (e.g.
+    /// <c>Task.Run</c>). Never throws for a species that cannot be legalized; those are reported in
+    /// <see cref="LivingDexGenerationResult.SkippedSpeciesNames"/> rather than included in the result.
+    /// </remarks>
+    LivingDexGenerationResult Generate(SaveFile sav, LivingDexOptions options, IProgress<LivingDexGenerationProgress>? progress = null, CancellationToken cancellationToken = default, int? maxSpeciesId = null);
+}
+
+/// <summary>Living Dex generation options exposed to the user.</summary>
+/// <param name="IncludeForms">Generate every alternate form of a species, not just its base form.</param>
+/// <param name="SetShiny">Request shiny specimens where the species/form is not shiny-locked.</param>
+public readonly record struct LivingDexOptions(bool IncludeForms, bool SetShiny);
+
+/// <summary>Progress notification for <see cref="ILivingDexService.Generate"/>: species processed so far out of the total.</summary>
+public readonly record struct LivingDexGenerationProgress(int Completed, int Total);
+
+/// <summary>
+/// Result of an <see cref="ILivingDexService.Generate"/> call.
+/// </summary>
+public sealed class LivingDexGenerationResult
+{
+    private LivingDexGenerationResult(bool cancelled, IReadOnlyList<PKM> pokemon, IReadOnlyList<string> skippedSpeciesNames)
+    {
+        Cancelled = cancelled;
+        Pokemon = pokemon;
+        SkippedSpeciesNames = skippedSpeciesNames;
+    }
+
+    /// <summary>True if the caller's <see cref="CancellationToken"/> was honored (no changes were computed/applied).</summary>
+    public bool Cancelled { get; }
+
+    /// <summary>
+    /// Every generated Pokémon in this list independently passes <see cref="LegalityAnalysis"/>; nothing
+    /// here should ever fail a subsequent legality check.
+    /// </summary>
+    public IReadOnlyList<PKM> Pokemon { get; }
+
+    /// <summary>
+    /// Human-readable names of species/forms the engine attempted but could not legalize (or that failed
+    /// independent re-verification). Reported rather than silently dropped.
+    /// </summary>
+    public IReadOnlyList<string> SkippedSpeciesNames { get; }
+
+    public static LivingDexGenerationResult Ok(IReadOnlyList<PKM> pokemon, IReadOnlyList<string> skippedSpeciesNames) =>
+        new(cancelled: false, pokemon, skippedSpeciesNames);
+
+    public static LivingDexGenerationResult Cancel() => new(cancelled: true, [], []);
+}

--- a/PKHeX.Application/Services/UndoRedoService.cs
+++ b/PKHeX.Application/Services/UndoRedoService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using PKHeX.Core;
 
 namespace PKHeX.Application.Services;
@@ -6,14 +7,32 @@ namespace PKHeX.Application.Services;
 /// Application service wrapping Core's <see cref="SlotChangelog"/>. Exposes undo/redo state via a
 /// plain <see cref="StateChanged"/> event (no MVVM-framework dependency).
 /// </summary>
+/// <remarks>
+/// Supports grouping several <see cref="AddChange"/> calls (via <see cref="BeginBatch"/>/<see cref="EndBatch"/>)
+/// into one logical operation, so a single <see cref="Undo"/>/<see cref="Redo"/> call reverts/reapplies the
+/// whole group atomically (e.g. a multi-slot Living Dex fill, issue #123).
+///
+/// Ungrouped (single) changes still delegate straight to Core's <see cref="SlotChangelog"/>, exactly as
+/// before — zero behavior change there. Grouped changes are tracked entirely on this side instead: Core's
+/// <see cref="SlotChangelog.Redo"/> has a side effect (via its internal <c>AddUndo</c>) of clearing its
+/// *entire* redo stack every time it is called, not just consuming the one entry it redid. That is
+/// harmless for a single change, but calling it N times in a row to redo an N-slot batch would discard
+/// the remaining N-1 entries after the first call. Since <see cref="PKHeX.Core"/> cannot be modified, group
+/// entries capture their own before/after snapshots and are undone/redone by writing them back directly.
+/// </remarks>
 public sealed class UndoRedoService
 {
     private SlotChangelog? _changelog;
+    private SaveFile? _sav;
     private int _changeCount;
 
+    private readonly Stack<UndoUnit> _undoStack = new();
+    private readonly Stack<UndoUnit> _redoStack = new();
+    private List<(ISlotInfo Info, PKM Before)>? _pendingBatch;
+
     public int ChangeCount => _changeCount;
-    public bool CanUndo => _changelog?.CanUndo ?? false;
-    public bool CanRedo => _changelog?.CanRedo ?? false;
+    public bool CanUndo => _undoStack.Count != 0;
+    public bool CanRedo => _redoStack.Count != 0;
 
     /// <summary>Raised whenever undo/redo availability may have changed.</summary>
     public event EventHandler? StateChanged;
@@ -28,37 +47,131 @@ public sealed class UndoRedoService
 
     public void Initialize(SaveFile sav)
     {
+        _sav = sav;
         _changelog = new SlotChangelog(sav);
+        _undoStack.Clear();
+        _redoStack.Clear();
+        _pendingBatch = null;
         SetChangeCount(0);
     }
 
     public void Clear()
     {
+        _sav = null;
         _changelog = null;
+        _undoStack.Clear();
+        _redoStack.Clear();
+        _pendingBatch = null;
         SetChangeCount(0);
+    }
+
+    /// <summary>
+    /// Starts grouping subsequent <see cref="AddChange"/> calls into one logical operation. Call
+    /// <see cref="EndBatch"/> to close the group. Not reentrant/nestable — only one batch may be open
+    /// at a time.
+    /// </summary>
+    public void BeginBatch() => _pendingBatch = [];
+
+    /// <summary>
+    /// Closes a batch started with <see cref="BeginBatch"/>. A no-op if no changes were added during the
+    /// batch (nothing is pushed onto the undo stack).
+    /// </summary>
+    public void EndBatch()
+    {
+        var batch = _pendingBatch;
+        _pendingBatch = null;
+        if (batch is not { Count: > 0 } || _sav is null)
+            return;
+
+        var items = new (ISlotInfo Info, PKM Before, PKM After)[batch.Count];
+        for (var i = 0; i < batch.Count; i++)
+        {
+            var (info, before) = batch[i];
+            items[i] = (info, before, info.Read(_sav));
+        }
+
+        _undoStack.Push(new GroupUnit(items));
+        _redoStack.Clear();
+        SetChangeCount(_changeCount + 1);
     }
 
     public void AddChange(ISlotInfo info)
     {
+        if (_pendingBatch is { } batch && _sav is not null)
+        {
+            // Grouped: captured entirely on this side (see class remarks) — deliberately does not touch
+            // Core's SlotChangelog. EndBatch() records the group and notifies listeners.
+            batch.Add((info, info.Read(_sav)));
+            return;
+        }
+
         _changelog?.AddNewChange(info);
+        _undoStack.Push(SingleUnit.Instance);
+        _redoStack.Clear();
         SetChangeCount(_changeCount + 1);
     }
 
     public void Undo()
     {
-        if (_changelog is null || !_changelog.CanUndo) return;
+        if (_sav is null || _undoStack.Count == 0) return;
 
-        var info = _changelog.Undo();
+        var unit = _undoStack.Pop();
+        if (unit is SingleUnit)
+        {
+            if (_changelog is null || !_changelog.CanUndo) return;
+            var info = _changelog.Undo();
+            UndoPerformed?.Invoke(info);
+        }
+        else if (unit is GroupUnit group)
+        {
+            foreach (var item in group.Items)
+            {
+                item.Info.WriteTo(_sav, item.Before, EntityImportSettings.None);
+                UndoPerformed?.Invoke(item.Info);
+            }
+        }
+
+        _redoStack.Push(unit);
         SetChangeCount(_changeCount + 1);
-        UndoPerformed?.Invoke(info);
     }
 
     public void Redo()
     {
-        if (_changelog is null || !_changelog.CanRedo) return;
+        if (_sav is null || _redoStack.Count == 0) return;
 
-        var info = _changelog.Redo();
+        var unit = _redoStack.Pop();
+        if (unit is SingleUnit)
+        {
+            if (_changelog is null || !_changelog.CanRedo) return;
+            var info = _changelog.Redo();
+            RedoPerformed?.Invoke(info);
+        }
+        else if (unit is GroupUnit group)
+        {
+            foreach (var item in group.Items)
+            {
+                item.Info.WriteTo(_sav, item.After, EntityImportSettings.None);
+                RedoPerformed?.Invoke(item.Info);
+            }
+        }
+
+        _undoStack.Push(unit);
         SetChangeCount(_changeCount + 1);
-        RedoPerformed?.Invoke(info);
+    }
+
+    /// <summary>Common type for entries on <see cref="_undoStack"/>/<see cref="_redoStack"/>.</summary>
+    private abstract class UndoUnit;
+
+    /// <summary>Marker for a change that lives in Core's own <see cref="SlotChangelog"/> stacks.</summary>
+    private sealed class SingleUnit : UndoUnit
+    {
+        public static readonly SingleUnit Instance = new();
+        private SingleUnit() { }
+    }
+
+    /// <summary>A batched change: its own independent before/after snapshot per slot (see class remarks).</summary>
+    private sealed class GroupUnit((ISlotInfo Info, PKM Before, PKM After)[] items) : UndoUnit
+    {
+        public (ISlotInfo Info, PKM Before, PKM After)[] Items { get; } = items;
     }
 }

--- a/PKHeX.Application/UseCases/LivingDexPlacementUseCase.cs
+++ b/PKHeX.Application/UseCases/LivingDexPlacementUseCase.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using PKHeX.Application.Services;
+using PKHeX.Core;
+
+namespace PKHeX.Application.UseCases;
+
+/// <summary>Outcome classification for <see cref="LivingDexPlacementUseCase.TryPlace"/>.</summary>
+public enum LivingDexPlacementStatus
+{
+    /// <summary>Every generated Pokémon was written starting at the requested box.</summary>
+    Success,
+
+    /// <summary>
+    /// There was not enough contiguous empty (unlocked, unprotected) space starting at the requested box
+    /// to fit every generated Pokémon. Nothing was written.
+    /// </summary>
+    InsufficientSpace,
+}
+
+/// <summary>
+/// Result of a <see cref="LivingDexPlacementUseCase.TryPlace"/> call.
+/// </summary>
+/// <param name="Status">Outcome classification.</param>
+/// <param name="PlacedCount">Number of Pokémon written. Zero unless <see cref="Status"/> is <see cref="LivingDexPlacementStatus.Success"/>.</param>
+/// <param name="RequiredSlots">Number of contiguous slots that were needed.</param>
+/// <param name="AvailableSlots">Number of contiguous empty/writable slots actually found starting at the requested box.</param>
+public sealed record LivingDexPlacementResult(LivingDexPlacementStatus Status, int PlacedCount, int RequiredSlots, int AvailableSlots)
+{
+    public static LivingDexPlacementResult Ok(int placedCount) =>
+        new(LivingDexPlacementStatus.Success, placedCount, placedCount, placedCount);
+
+    public static LivingDexPlacementResult Refuse(int requiredSlots, int availableSlots) =>
+        new(LivingDexPlacementStatus.InsufficientSpace, 0, requiredSlots, availableSlots);
+}
+
+/// <summary>
+/// Places a batch of generated Pokémon (e.g. from the Living Dex generator, issue #123) into a save
+/// file's boxes, starting at a user-chosen box. Refuses cleanly, writing nothing, if there is not enough
+/// *contiguous* empty space from that box onward — it does not scatter results into gaps further down the
+/// boxes. When an <see cref="UndoRedoService"/> is supplied, the whole placement is recorded as a single
+/// batched operation (see <see cref="UndoRedoService.BeginBatch"/>), so one Undo reverts every slot this
+/// call wrote.
+/// </summary>
+public sealed class LivingDexPlacementUseCase
+{
+    public LivingDexPlacementResult TryPlace(SaveFile sav, IReadOnlyList<PKM> pokemon, int startBox, UndoRedoService? undoRedo = null)
+    {
+        ArgumentNullException.ThrowIfNull(sav);
+        ArgumentNullException.ThrowIfNull(pokemon);
+        if ((uint)startBox >= (uint)sav.BoxCount)
+            throw new ArgumentOutOfRangeException(nameof(startBox));
+
+        if (pokemon.Count == 0)
+            return LivingDexPlacementResult.Ok(0);
+
+        var slotsPerBox = sav.BoxSlotCount;
+        var startIndex = startBox * slotsPerBox;
+        var totalSlots = sav.BoxCount * slotsPerBox;
+
+        // Count the contiguous run of empty, unlocked, unprotected slots starting exactly at startBox/slot
+        // 0. The first locked/protected/occupied slot ends the run — we never skip ahead to scavenge
+        // slots further down the boxes.
+        var contiguous = 0;
+        for (var index = startIndex; index < totalSlots && contiguous < pokemon.Count; index++)
+        {
+            var box = index / slotsPerBox;
+            var slot = index % slotsPerBox;
+
+            if (sav.IsBoxSlotLocked(box, slot) || sav.IsBoxSlotOverwriteProtected(box, slot))
+                break;
+            if (sav.GetBoxSlotAtIndex(box, slot).Species != 0)
+                break;
+
+            contiguous++;
+        }
+
+        if (contiguous < pokemon.Count)
+            return LivingDexPlacementResult.Refuse(requiredSlots: pokemon.Count, availableSlots: contiguous);
+
+        undoRedo?.BeginBatch();
+        for (var i = 0; i < pokemon.Count; i++)
+        {
+            var index = startIndex + i;
+            var box = index / slotsPerBox;
+            var slot = index % slotsPerBox;
+
+            undoRedo?.AddChange(new SlotInfoBox(box, slot, sav));
+            sav.SetBoxSlotAtIndex(pokemon[i], box, slot);
+        }
+        undoRedo?.EndBatch();
+
+        return LivingDexPlacementResult.Ok(pokemon.Count);
+    }
+}

--- a/PKHeX.Application/UseCases/LivingDexVerificationUseCase.cs
+++ b/PKHeX.Application/UseCases/LivingDexVerificationUseCase.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using PKHeX.Core;
+
+namespace PKHeX.Application.UseCases;
+
+/// <summary>
+/// Independently re-verifies every candidate Pokémon a generator (e.g. the Living Dex engine, issue #123)
+/// produced, following the same "never trust the engine's own success flag" pattern used by the
+/// Auto-Legality Mod adapter (issue #89): a candidate is only accepted if it passes
+/// <see cref="LegalityAnalysis"/> on its own. Candidates that fail are reported by species/form name
+/// instead of being silently included or causing a crash. Pure Core-only logic, so it can be exercised
+/// without invoking the vendored engine.
+/// </summary>
+public sealed class LivingDexVerificationUseCase
+{
+    public LivingDexVerificationResult Verify(IReadOnlyList<PKM> candidates)
+    {
+        var accepted = new List<PKM>(candidates.Count);
+        var skipped = new List<string>();
+        var strings = GameInfo.Strings;
+
+        foreach (var pk in candidates)
+        {
+            bool valid;
+            try
+            {
+                valid = new LegalityAnalysis(pk).Valid;
+            }
+            catch
+            {
+                valid = false;
+            }
+
+            if (valid)
+                accepted.Add(pk);
+            else
+                skipped.Add(GetDisplayName(pk.Species, pk.Form, strings));
+        }
+
+        return new LivingDexVerificationResult(accepted, skipped);
+    }
+
+    /// <summary>Shared species/form display-name formatting, also used when generation itself fails a candidate.</summary>
+    public static string GetDisplayName(ushort species, byte form, GameStrings strings)
+    {
+        var name = species < strings.Species.Count ? strings.Species[species] : $"species {species}";
+        return form == 0 ? name : $"{name} (form {form})";
+    }
+}
+
+/// <summary>Outcome of <see cref="LivingDexVerificationUseCase.Verify"/>.</summary>
+/// <param name="Accepted">Candidates that independently passed <see cref="LegalityAnalysis"/>.</param>
+/// <param name="SkippedSpeciesNames">Display names of candidates that failed re-verification.</param>
+public sealed record LivingDexVerificationResult(IReadOnlyList<PKM> Accepted, IReadOnlyList<string> SkippedSpeciesNames);

--- a/PKHeX.Avalonia/ViewLocator.cs
+++ b/PKHeX.Avalonia/ViewLocator.cs
@@ -52,6 +52,7 @@ public static class ViewLocator
         [typeof(LegalityViewModel)] = () => new LegalityView(),
         [typeof(LiveHeXViewModel)] = () => new LiveHeXView(),
         [typeof(Link6EditorViewModel)] = () => new Link6Editor(),
+        [typeof(LivingDexGeneratorViewModel)] = () => new LivingDexGeneratorView(),
         [typeof(MailBoxEditorViewModel)] = () => new MailBoxEditor(),
         [typeof(MedalEditorViewModel)] = () => new MedalEditorView(),
         [typeof(MemoryEditorViewModel)] = () => new MemoryEditor(),

--- a/PKHeX.Avalonia/Views/LivingDexGeneratorView.axaml
+++ b/PKHeX.Avalonia/Views/LivingDexGeneratorView.axaml
@@ -1,0 +1,59 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"
+             mc:Ignorable="d" d:DesignWidth="480" d:DesignHeight="440"
+             x:Class="PKHeX.Avalonia.Views.LivingDexGeneratorView"
+             x:DataType="vm:LivingDexGeneratorViewModel"
+             MinWidth="420" MinHeight="380" Width="480" Height="440">
+
+    <DockPanel Margin="12">
+        <TextBlock DockPanel.Dock="Top" Text="Living Dex Generator" FontSize="16" FontWeight="SemiBold" />
+        <TextBlock DockPanel.Dock="Top" Margin="0,2,0,8"
+                   Text="Generates one legal Pokémon per species obtainable in this game, then fills boxes starting at the box below."
+                   TextWrapping="Wrap"
+                   Foreground="{DynamicResource ThemeTextMutedBrush}" FontSize="12" />
+
+        <!-- Options -->
+        <StackPanel DockPanel.Dock="Top" Spacing="8" Margin="0,0,0,8">
+            <StackPanel Orientation="Horizontal" Spacing="16">
+                <CheckBox Content="Include forms" IsChecked="{Binding IncludeForms}" IsEnabled="{Binding !IsRunning}" />
+                <CheckBox Content="Shiny" IsChecked="{Binding SetShiny}" IsEnabled="{Binding !IsRunning}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Starting box:" VerticalAlignment="Center" />
+                <ComboBox ItemsSource="{Binding BoxNames}" SelectedIndex="{Binding SelectedBoxIndex}"
+                          IsEnabled="{Binding !IsRunning}" MinWidth="160" />
+            </StackPanel>
+        </StackPanel>
+
+        <!-- Action bar -->
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
+            <Button Content="Generate" Classes="accent" Command="{Binding GenerateCommand}" />
+            <Button Content="Cancel" Command="{Binding CancelCommand}" />
+            <ProgressBar Value="{Binding Progress}" Minimum="0" Maximum="100" Width="180" VerticalAlignment="Center"
+                         IsVisible="{Binding IsRunning}" />
+        </StackPanel>
+
+        <!-- Status -->
+        <TextBlock DockPanel.Dock="Bottom" Text="{Binding StatusMessage}" TextWrapping="Wrap"
+                   Margin="0,8,0,0" FontSize="12" />
+
+        <!-- Skipped species report -->
+        <Grid RowDefinitions="Auto,*">
+            <TextBlock Grid.Row="0" Text="Skipped Species" FontWeight="SemiBold"
+                       Margin="0,10,0,4"
+                       IsVisible="{Binding SkippedSpeciesReport, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+            <Border Grid.Row="1"
+                    BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}"
+                    IsVisible="{Binding SkippedSpeciesReport, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                <ScrollViewer>
+                    <SelectableTextBlock Text="{Binding SkippedSpeciesReport}" Padding="8"
+                                         FontSize="12" TextWrapping="Wrap" />
+                </ScrollViewer>
+            </Border>
+        </Grid>
+    </DockPanel>
+</UserControl>

--- a/PKHeX.Avalonia/Views/LivingDexGeneratorView.axaml.cs
+++ b/PKHeX.Avalonia/Views/LivingDexGeneratorView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PKHeX.Avalonia.Views;
+
+public partial class LivingDexGeneratorView : UserControl
+{
+    public LivingDexGeneratorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -38,6 +38,7 @@
                 </MenuItem>
                 <MenuItem Header="Auto Legality Mod…" Command="{Binding OpenAutoLegalityModCommand}" />
                 <MenuItem Header="LiveHeX…" Command="{Binding OpenLiveHeXCommand}" />
+                <MenuItem Header="Generate Living Dex…" Command="{Binding OpenLivingDexGeneratorCommand}" />
                 <MenuItem Header="QR Code">
                     <MenuItem Header="Show Current Pokémon…" Command="{Binding ShowQrCodeCommand}" />
                     <MenuItem Header="Import from Image…" Command="{Binding ImportQrCodeCommand}" />

--- a/PKHeX.Infrastructure/AutoLegality/LivingDexService.cs
+++ b/PKHeX.Infrastructure/AutoLegality/LivingDexService.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+using PKHeX.Core.AutoMod;
+
+namespace PKHeX.Infrastructure.AutoLegality;
+
+/// <summary>
+/// Adapter implementing the Application-layer <see cref="ILivingDexService"/> port (issue #123, ALM
+/// Phase 2 — Living Dex generator).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This does NOT call the vendored engine's own <c>ModLogic.GenerateLivingDex</c>. That method's
+/// per-species helper (<c>GetRandomEncounter</c> → <c>tr.TryAPIConvert(set, template)</c>) never calls
+/// <c>EncounterMovesetGenerator.OptimizeCriteria(template, tr)</c> before converting — the step
+/// <c>Legalizer.GetLegalFromSet(ITrainerInfo, IBattleTemplate)</c> (the path <see cref="AutoLegalityService"/>
+/// and the app's single-set "Auto Legality Mod" tool use) always performs first. Without it, the encounter
+/// search finds nothing: verified directly against blank Red/Crystal/Emerald/Sword saves, where
+/// <c>GenerateLivingDex</c> returns an empty list for every species in every one of them. That is a defect
+/// in the vendored <c>PKHeX.AutoMod</c> project itself, which this task's hard rules forbid modifying.
+/// </para>
+/// <para>
+/// So this adapter drives the species/form loop itself and calls the proven, working
+/// <c>Legalizer.GetLegalFromSet</c> path per candidate instead — the exact same call
+/// <see cref="AutoLegalityService"/> already relies on for the single-set tool. A future PKHeX.AutoMod
+/// re-sync that fixes <c>ModLogic.GenerateLivingDex</c> upstream could let this adapter go back to calling
+/// it directly; until then, this routes around the defect instead of shipping a generator that produces
+/// nothing.
+/// </para>
+/// <para>
+/// This loop intentionally builds a *minimal* per-species template (species, form, gender, shiny) rather
+/// than reproducing every special case <c>ModLogic</c>'s own (unreachable) helper handles — form-specific
+/// held items (Arceus plates, Genesect drives, etc.), Keldeo's Secret Sword, Zygarde's cell-count suffix,
+/// and Alcremie's decoration sweep are not replicated. Species/forms that need those to legalize will
+/// simply fail to generate and be reported in <see cref="LivingDexGenerationResult.SkippedSpeciesNames"/>
+/// like any other failure, rather than being silently wrong or crashing.
+/// </para>
+/// </remarks>
+public sealed class LivingDexService : ILivingDexService
+{
+    private readonly LivingDexVerificationUseCase _verification = new();
+
+    public LivingDexGenerationResult Generate(SaveFile sav, LivingDexOptions options, IProgress<LivingDexGenerationProgress>? progress = null, CancellationToken cancellationToken = default, int? maxSpeciesId = null)
+    {
+        ArgumentNullException.ThrowIfNull(sav);
+
+        if (cancellationToken.IsCancellationRequested)
+            return LivingDexGenerationResult.Cancel();
+
+        var tr = (ITrainerInfo)sav;
+        var personal = sav.Personal;
+        var context = sav.Context;
+        var generation = sav.Generation;
+        var strings = GameInfo.Strings;
+
+        var maxSpecies = maxSpeciesId is { } cap ? Math.Min(cap, personal.MaxSpeciesID) : personal.MaxSpeciesID;
+        var candidates = new List<PKM>();
+        var failedNames = new List<string>();
+        var completed = 0;
+
+        try
+        {
+            for (ushort s = 1; s <= maxSpecies; s++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (personal.IsSpeciesInGame(s))
+                    ProcessSpecies(tr, personal, strings, context, generation, s, options, candidates, failedNames, cancellationToken);
+
+                completed++;
+                progress?.Report(new LivingDexGenerationProgress(completed, maxSpecies));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return LivingDexGenerationResult.Cancel();
+        }
+
+        // Never trust our own per-species search either (same independent-re-verification pattern as
+        // AutoLegalityService, issue #89): re-check every candidate and report failures by name instead
+        // of silently including or crashing on them.
+        var verified = _verification.Verify(candidates);
+        var allSkipped = new List<string>(failedNames.Count + verified.SkippedSpeciesNames.Count);
+        allSkipped.AddRange(failedNames);
+        allSkipped.AddRange(verified.SkippedSpeciesNames);
+
+        return LivingDexGenerationResult.Ok(verified.Accepted, allSkipped);
+    }
+
+    private static void ProcessSpecies(ITrainerInfo tr, IPersonalTable personal, GameStrings strings, EntityContext context, byte generation, ushort species, LivingDexOptions options, List<PKM> candidates, List<string> failedNames, CancellationToken cancellationToken)
+    {
+        var numForms = personal[species].FormCount;
+        if (numForms == 1 && options.IncludeForms)
+            numForms = (byte)FormConverter.GetFormList(species, strings.types, strings.forms, GameInfo.GenderSymbolUnicode, context).Length;
+
+        for (byte f = 0; f < numForms; f++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var form = options.IncludeForms ? f : ModLogic.GetBaseForm((Species)species, f, tr);
+            if (!personal.IsPresentInGame(species, form)
+                || FormInfo.IsLordForm(species, form, context)
+                || FormInfo.IsBattleOnlyForm(species, form, generation)
+                || FormInfo.IsFusedForm(species, form, generation)
+                || (FormInfo.IsTotemForm(species, form) && context is not EntityContext.Gen7))
+                continue;
+
+            var pk = TryGenerateOne(tr, species, form, options.SetShiny);
+            if (pk is null)
+            {
+                failedNames.Add(LivingDexVerificationUseCase.GetDisplayName(species, form, strings));
+                if (!options.IncludeForms)
+                    break;
+                continue;
+            }
+
+            candidates.Add(pk);
+            if (!options.IncludeForms)
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Builds a minimal template for <paramref name="species"/>/<paramref name="form"/> and legalizes it
+    /// via the proven <c>Legalizer.GetLegalFromSet</c> path (see class remarks) instead of the vendored
+    /// engine's defective <c>ModLogic.GenerateLivingDex</c>/<c>GetRandomEncounter</c>.
+    /// </summary>
+    private static PKM? TryGenerateOne(ITrainerInfo tr, ushort species, byte form, bool shiny)
+    {
+        PKM blank;
+        try
+        {
+            blank = EntityBlank.GetBlank(tr);
+            blank.Species = species;
+            blank.Gender = blank.GetSaneGender();
+            blank.Form = form;
+        }
+        catch
+        {
+            return null;
+        }
+
+        string setText;
+        try
+        {
+            // Render species/form to Showdown text from the PKM itself (handles form-name suffixes
+            // correctly) rather than building the string by hand — but keep ONLY the first line (species
+            // [+ gender/form annotation]). The rest of a freshly-blanked PKM's rendered text (Level: 1,
+            // Hardy Nature, IVs: 0 all around, an incidental "Shiny: Yes" from the blank's default PID,
+            // etc.) over-constrains the set to a combination no real encounter can satisfy, which is why
+            // an earlier version of this loop that reused the whole rendered block failed for every
+            // species. A bare species (plus an explicit shiny line when requested) leaves the encounter
+            // search free to pick a matching level/nature/IVs/ability, exactly like the app's single-set
+            // "Auto Legality Mod" tool does when the user only types a species name.
+            var rendered = new ShowdownSet(blank).Text.Replace("\r", "");
+            var firstLine = rendered.Split('\n')[0];
+            setText = firstLine;
+            if (shiny && !SimpleEdits.IsShinyLockedSpeciesForm(species, blank.Form))
+                setText += "\nShiny: Yes";
+        }
+        catch
+        {
+            return null;
+        }
+
+        ShowdownSet set;
+        try
+        {
+            set = new ShowdownSet(setText);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (set.Species == 0)
+            return null;
+
+        APILegality.AsyncLegalizationResult result;
+        try
+        {
+            result = tr.GetLegalFromSet(set);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (result.Status != LegalizationResult.Regenerated)
+            return null;
+
+        var pk = result.Created;
+        pk.Heal();
+        return pk;
+    }
+}

--- a/PKHeX.Infrastructure/DependencyInjection.cs
+++ b/PKHeX.Infrastructure/DependencyInjection.cs
@@ -19,6 +19,7 @@ public static class DependencyInjection
         services.AddSingleton<IAutoLegalityService, AutoLegalityService>();
         services.AddSingleton<IConsoleConnectionFactory, SysBotConnectionFactory>();
         services.AddSingleton<ILiveHexService, LiveHexService>();
+        services.AddSingleton<ILivingDexService, LivingDexService>();
         return services;
     }
 }

--- a/PKHeX.Presentation/ViewModels/LivingDexGeneratorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/LivingDexGeneratorViewModel.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PKHeX.Application.Abstractions;
+using PKHeX.Application.Services;
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+
+namespace PKHeX.Presentation.ViewModels;
+
+/// <summary>
+/// Tool-window ViewModel for the Living Dex generator (Auto-Legality Mod Phase 2, issue #123): fills
+/// boxes starting at a user-chosen box with one legal specimen of every species obtainable in the loaded
+/// save's game. Generation runs off the UI thread with progress and cancellation; placement refuses
+/// cleanly (no partial writes) if there is not enough contiguous empty space, and is recorded as a single
+/// undoable operation via <see cref="UndoRedoService"/>.
+/// </summary>
+public partial class LivingDexGeneratorViewModel : ViewModelBase
+{
+    private readonly SaveFile _sav;
+    private readonly ILivingDexService _service;
+    private readonly UndoRedoService _undoRedo;
+    private readonly LivingDexPlacementUseCase _placement = new();
+
+    private CancellationTokenSource? _cts;
+
+    /// <summary>Raised once boxes were actually written to, so the host can refresh the box/party viewers.</summary>
+    public event Action? BoxesUpdated;
+
+    [ObservableProperty] private bool _includeForms;
+    [ObservableProperty] private bool _setShiny;
+
+    [ObservableProperty] private ObservableCollection<string> _boxNames = [];
+    [ObservableProperty] private int _selectedBoxIndex;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(GenerateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
+    private bool _isRunning;
+
+    [ObservableProperty] private double _progress;
+
+    [ObservableProperty] private string _statusMessage = "Choose options and a starting box, then Generate.";
+
+    [ObservableProperty] private string _skippedSpeciesReport = string.Empty;
+
+    public LivingDexGeneratorViewModel(SaveFile sav, ILivingDexService service, UndoRedoService undoRedo)
+    {
+        _sav = sav;
+        _service = service;
+        _undoRedo = undoRedo;
+
+        BoxNames = new ObservableCollection<string>(Enumerable.Range(0, sav.BoxCount)
+            .Select(b => sav is IBoxDetailNameRead r ? r.GetBoxName(b) : BoxDetailNameExtensions.GetDefaultBoxName(b)));
+    }
+
+    private bool CanGenerate => !IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanGenerate))]
+    private async Task GenerateAsync()
+    {
+        SkippedSpeciesReport = string.Empty;
+        IsRunning = true;
+        Progress = 0;
+        StatusMessage = "Generating a legal Pokémon for every species in this game…";
+        _cts = new CancellationTokenSource();
+
+        try
+        {
+            var options = new LivingDexOptions(IncludeForms, SetShiny);
+            var progress = new Progress<LivingDexGenerationProgress>(p =>
+                Progress = p.Total == 0 ? 0 : 100.0 * p.Completed / p.Total);
+            var token = _cts.Token;
+            var startBox = SelectedBoxIndex;
+
+            var result = await Task.Run(() => _service.Generate(_sav, options, progress, token), token);
+
+            if (result.Cancelled)
+            {
+                StatusMessage = "Generation cancelled. No changes were made.";
+                return;
+            }
+
+            if (result.Pokemon.Count == 0)
+            {
+                StatusMessage = "The engine could not generate any legal Pokémon for this save.";
+                ReportSkipped(result);
+                return;
+            }
+
+            var placement = await Task.Run(() => _placement.TryPlace(_sav, result.Pokemon, startBox, _undoRedo), token);
+
+            if (placement.Status == LivingDexPlacementStatus.InsufficientSpace)
+            {
+                StatusMessage = $"Refused: need {placement.RequiredSlots} contiguous empty slots starting at "
+                    + $"\"{BoxNames.ElementAtOrDefault(startBox) ?? $"Box {startBox + 1}"}\", but only "
+                    + $"{placement.AvailableSlots} are available there. No changes were made.";
+                ReportSkipped(result);
+                return;
+            }
+
+            StatusMessage = $"Placed {placement.PlacedCount} legal Pokémon starting at "
+                + $"\"{BoxNames.ElementAtOrDefault(startBox) ?? $"Box {startBox + 1}"}\".";
+            ReportSkipped(result);
+            BoxesUpdated?.Invoke();
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Generation cancelled. No changes were made.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            IsRunning = false;
+            Progress = 0;
+            _cts = null;
+        }
+    }
+
+    private void ReportSkipped(LivingDexGenerationResult result)
+    {
+        if (result.SkippedSpeciesNames.Count == 0)
+            return;
+
+        SkippedSpeciesReport = $"{result.SkippedSpeciesNames.Count} species/forms could not be legalized and were skipped:\n"
+            + string.Join(", ", result.SkippedSpeciesNames);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCancel))]
+    private void Cancel() => _cts?.Cancel();
+
+    private bool CanCancel() => IsRunning;
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.LivingDex.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.LivingDex.cs
@@ -1,0 +1,30 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace PKHeX.Presentation.ViewModels;
+
+public partial class MainWindowViewModel
+{
+    // Cached so re-invoking the menu item focuses the existing tool window instead of opening a
+    // duplicate (ShowTool keys off the ViewModel instance). Reset to null on save change.
+    private LivingDexGeneratorViewModel? _livingDexGenerator;
+
+    [RelayCommand(CanExecute = nameof(HasSave))]
+    private void OpenLivingDexGenerator()
+    {
+        if (CurrentSave is null) return;
+
+        if (_livingDexGenerator is null)
+        {
+            _livingDexGenerator = new LivingDexGeneratorViewModel(CurrentSave, _livingDexService, _undoRedo);
+            _livingDexGenerator.BoxesUpdated += OnLivingDexBoxesUpdated;
+        }
+
+        _windowService.ShowTool(_livingDexGenerator, "Living Dex Generator");
+    }
+
+    private void OnLivingDexBoxesUpdated()
+    {
+        BoxViewer?.RefreshCurrentBox();
+        PartyViewer?.RefreshParty();
+    }
+}

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -25,6 +25,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly LanguageService _languageService;
     private readonly IAutoLegalityService _autoLegalityService;
     private readonly ILiveHexService _liveHexService;
+    private readonly ILivingDexService _livingDexService;
     private readonly string _currentVersion;
 
     [ObservableProperty] private UpdateNotificationViewModel? _updateNotification;
@@ -41,6 +42,7 @@ public partial class MainWindowViewModel : ViewModelBase
     [NotifyCanExecuteChangedFor(nameof(OpenBoxReportCommand))]
     [NotifyCanExecuteChangedFor(nameof(OpenAutoLegalityModCommand))]
     [NotifyCanExecuteChangedFor(nameof(OpenLiveHeXCommand))]
+    [NotifyCanExecuteChangedFor(nameof(OpenLivingDexGeneratorCommand))]
     [NotifyCanExecuteChangedFor(nameof(UndoCommand))]
     [NotifyCanExecuteChangedFor(nameof(RedoCommand))]
     private SaveFile? _currentSave;
@@ -79,7 +81,8 @@ public partial class MainWindowViewModel : ViewModelBase
         UndoRedoService undoRedo,
         LanguageService languageService,
         IAutoLegalityService autoLegalityService,
-        ILiveHexService liveHexService)
+        ILiveHexService liveHexService,
+        ILivingDexService livingDexService)
     {
         _saveFileService = saveFileService;
         _dialogService = dialogService;
@@ -96,6 +99,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _languageService = languageService;
         _autoLegalityService = autoLegalityService;
         _liveHexService = liveHexService;
+        _livingDexService = livingDexService;
         _currentVersion = GetCurrentVersion();
 
         _saveFileService.SaveFileChanged += OnSaveFileChanged;
@@ -138,6 +142,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _legalityAudit = null;
         _autoLegalityMod = null;
         DisposeLiveHeX();
+        _livingDexGenerator = null;
 
         CurrentSave = sav;
         if (sav is not null)

--- a/Tests/PKHeX.Avalonia.Tests/LivingDexTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LivingDexTests.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using PKHeX.Application.UseCases;
+using PKHeX.Core;
+using PKHeX.Infrastructure.AutoLegality;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Tests for the Living Dex generator (issue #123, ALM Phase 2): placement/space-check refusal,
+/// undo-as-a-single-operation, cancellation, and skip-reporting for candidates that fail independent
+/// re-verification.
+///
+/// ROUTED-AROUND VENDORED-ENGINE DEFECT (discovered while writing these tests, confirmed against Gen
+/// 1/2/3/8 blank saves): <c>ModLogic.GenerateLivingDex</c>'s per-species helper builds its search template
+/// and calls <c>tr.TryAPIConvert(set, t)</c> directly, without first calling
+/// <c>EncounterMovesetGenerator.OptimizeCriteria(template, tr)</c> — the step
+/// <c>Legalizer.GetLegalFromSet(ITrainerInfo, IBattleTemplate)</c> (the path <see cref="AutoLegalityService"/>
+/// uses, and the one this app's "Auto Legality Mod" single-set tool relies on) always performs before
+/// converting. Without that step, <c>GetRandomEncounter</c> cannot find any encounter and returns
+/// <see langword="null"/> for every species, so <c>GenerateLivingDex</c> yields an empty list — verified
+/// directly (not just inferred) for Red/Crystal/Emerald/Sword blank saves. This is a defect in the
+/// vendored <c>PKHeX.AutoMod</c> project itself, which per this task's hard rules must not be modified
+/// here. Rather than ship a generator that produces nothing, <see cref="LivingDexService"/> (Infrastructure)
+/// drives the species/form loop itself and calls the proven <c>Legalizer.GetLegalFromSet</c> path per
+/// candidate instead — see that class's remarks for the full explanation, including why the very first
+/// version of that loop (reusing a fully-rendered Showdown block from a freshly-blanked PKM) still failed
+/// for every species (over-constrained sets — fixed by keeping only the species/form/gender line).
+/// <see cref="Generate_RealSave_ProducesLegalPokemonForABoundedSpeciesSubset"/> below exercises the real,
+/// unmocked path end to end and asserts a non-empty, all-legal result; the placement/undo/verification
+/// tests instead use synthetically-legal <see cref="PKM"/> (via <see cref="AutoLegalityService"/>) so they
+/// exercise the adapter's own logic independent of how many candidates generation itself found.
+///
+/// All tests live in one class so they run serially, matching <see cref="AutoLegalityServiceTests"/>: the
+/// vendored engine exposes process-wide static settings (e.g. <c>Legalizer.EnableEasterEggs</c>,
+/// <c>APILegality.UseTrainerData</c>), and serial execution keeps that state stable.
+/// </summary>
+[Collection("AutoLegality")]
+public class LivingDexTests
+{
+    private readonly AutoLegalityService _autoLegality = new();
+    private readonly LivingDexPlacementUseCase _placement = new();
+    private readonly LivingDexVerificationUseCase _verification = new();
+
+    public LivingDexTests()
+    {
+        GameInfo.CurrentLanguage = "en";
+        GameInfo.Strings = GameInfo.GetStrings("en");
+    }
+
+    private PKM MakeLegal(SaveFile sav, string showdown)
+    {
+        var result = _autoLegality.TryLegalizeShowdownSet(sav, showdown);
+        Assert.True(result.Success, $"Test setup failed to legalize '{showdown}': {result.MessageText}");
+        return result.Pokemon!;
+    }
+
+    // -------------------------------------------------------------------
+    // Placement: successful fill starting at the chosen box
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TryPlace_WritesEveryPokemonStartingAtChosenBox_AndEachSlotPassesLegality()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var pokemon = new List<PKM> { MakeLegal(sav, "Wooloo"), MakeLegal(sav, "Rookidee"), MakeLegal(sav, "Blipbug") };
+
+        var result = _placement.TryPlace(sav, pokemon, startBox: 1);
+
+        Assert.Equal(LivingDexPlacementStatus.Success, result.Status);
+        Assert.Equal(pokemon.Count, result.PlacedCount);
+
+        var slotsPerBox = sav.BoxSlotCount;
+        for (var i = 0; i < pokemon.Count; i++)
+        {
+            var index = 1 * slotsPerBox + i;
+            var written = sav.GetBoxSlotAtIndex(index / slotsPerBox, index % slotsPerBox);
+            Assert.Equal(pokemon[i].Species, written.Species);
+            Assert.True(new LegalityAnalysis(written).Valid, $"Written slot {i} failed legality analysis.");
+        }
+    }
+
+    [Fact]
+    public void TryPlace_EmptyList_IsANoOpSuccess()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+
+        var result = _placement.TryPlace(sav, [], startBox: 0);
+
+        Assert.Equal(LivingDexPlacementStatus.Success, result.Status);
+        Assert.Equal(0, result.PlacedCount);
+    }
+
+    // -------------------------------------------------------------------
+    // Placement: refusal when there isn't enough contiguous empty space
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TryPlace_RefusesWithNoWrites_WhenNotEnoughContiguousSpace()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var slotsPerBox = sav.BoxSlotCount;
+
+        // Occupy the 2nd slot of the starting box so the contiguous empty run is only 1 slot long,
+        // even though the save has plenty of total empty space elsewhere.
+        var occupant = MakeLegal(sav, "Wooloo");
+        sav.SetBoxSlotAtIndex(occupant, 0, 1);
+
+        var toPlace = new List<PKM> { MakeLegal(sav, "Rookidee"), MakeLegal(sav, "Blipbug") };
+
+        var result = _placement.TryPlace(sav, toPlace, startBox: 0);
+
+        Assert.Equal(LivingDexPlacementStatus.InsufficientSpace, result.Status);
+        Assert.Equal(0, result.PlacedCount);
+        Assert.Equal(2, result.RequiredSlots);
+        Assert.Equal(1, result.AvailableSlots);
+
+        // No partial writes: slot 0 must still be empty (untouched), slot 1 must still hold the occupant.
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.Equal(occupant.Species, sav.GetBoxSlotAtIndex(0, 1).Species);
+    }
+
+    [Fact]
+    public void TryPlace_InvalidStartBox_Throws()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => _placement.TryPlace(sav, [MakeLegal(sav, "Wooloo")], startBox: sav.BoxCount));
+    }
+
+    // -------------------------------------------------------------------
+    // Undo: a placement is a single undoable operation
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TryPlace_WithUndoRedo_UndoesTheWholeBatchInOneCall()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var undoRedo = new UndoRedoService();
+        undoRedo.Initialize(sav);
+
+        var pokemon = new List<PKM> { MakeLegal(sav, "Wooloo"), MakeLegal(sav, "Rookidee"), MakeLegal(sav, "Blipbug") };
+        var result = _placement.TryPlace(sav, pokemon, startBox: 0, undoRedo);
+        Assert.Equal(LivingDexPlacementStatus.Success, result.Status);
+
+        for (var i = 0; i < pokemon.Count; i++)
+            Assert.Equal(pokemon[i].Species, sav.GetBoxSlotAtIndex(0, i).Species);
+
+        Assert.True(undoRedo.CanUndo);
+
+        // A single Undo() call reverts every slot the placement wrote, not just the last one.
+        undoRedo.Undo();
+
+        for (var i = 0; i < pokemon.Count; i++)
+            Assert.Equal(0, sav.GetBoxSlotAtIndex(0, i).Species);
+
+        // The whole batch was one logical operation: after undoing it, there is nothing left to undo.
+        Assert.False(undoRedo.CanUndo);
+        Assert.True(undoRedo.CanRedo);
+
+        // Redo is likewise atomic: one call reapplies every slot.
+        undoRedo.Redo();
+        for (var i = 0; i < pokemon.Count; i++)
+            Assert.Equal(pokemon[i].Species, sav.GetBoxSlotAtIndex(0, i).Species);
+        Assert.False(undoRedo.CanRedo);
+    }
+
+    [Fact]
+    public void UndoRedoService_UngroupedChanges_StillUndoOneAtATime()
+    {
+        // Regression guard: existing (non-batched) single-slot callers must keep their original
+        // one-change-per-Undo() behavior after adding batch support for Living Dex.
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var undoRedo = new UndoRedoService();
+        undoRedo.Initialize(sav);
+
+        var a = MakeLegal(sav, "Wooloo");
+        var b = MakeLegal(sav, "Rookidee");
+
+        undoRedo.AddChange(new SlotInfoBox(0, 0, sav));
+        sav.SetBoxSlotAtIndex(a, 0, 0);
+
+        undoRedo.AddChange(new SlotInfoBox(0, 1, sav));
+        sav.SetBoxSlotAtIndex(b, 0, 1);
+
+        undoRedo.Undo();
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, 1).Species); // second change reverted
+        Assert.Equal(a.Species, sav.GetBoxSlotAtIndex(0, 0).Species); // first change untouched
+        Assert.True(undoRedo.CanUndo);
+
+        undoRedo.Undo();
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.False(undoRedo.CanUndo);
+    }
+
+    // -------------------------------------------------------------------
+    // Skip-reporting: candidates that fail independent re-verification are named, not included
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void Verify_SplitsLegalFromIllegal_AndNamesTheIllegalOnes()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var legal = MakeLegal(sav, "Wooloo");
+
+        var illegal = MakeLegal(sav, "Rookidee");
+        illegal.MetLocation = 60000; // corrupt it post-generation (out-of-range met location) so it now fails LegalityAnalysis
+        Assert.False(new LegalityAnalysis(illegal).Valid); // sanity check on the test's own setup
+
+        var result = _verification.Verify([legal, illegal]);
+
+        Assert.Single(result.Accepted);
+        Assert.Equal(legal.Species, result.Accepted[0].Species);
+
+        Assert.Single(result.SkippedSpeciesNames);
+        Assert.Contains("Rookidee", result.SkippedSpeciesNames[0]);
+    }
+
+    [Fact]
+    public void Verify_AllLegal_ReportsNoSkips()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var pokemon = new List<PKM> { MakeLegal(sav, "Wooloo"), MakeLegal(sav, "Rookidee") };
+
+        var result = _verification.Verify(pokemon);
+
+        Assert.Equal(2, result.Accepted.Count);
+        Assert.Empty(result.SkippedSpeciesNames);
+    }
+
+    // -------------------------------------------------------------------
+    // Cancellation
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void Generate_PreCancelledToken_ReturnsCancelledWithoutRunningTheEngine()
+    {
+        var service = new LivingDexService();
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = service.Generate(sav, new LivingDexOptions(IncludeForms: false, SetShiny: false), cancellationToken: cts.Token);
+
+        Assert.True(result.Cancelled);
+        Assert.Empty(result.Pokemon);
+        Assert.Empty(result.SkippedSpeciesNames);
+    }
+
+    [Fact]
+    public void Generate_CancelledMidLoop_StopsPromptly()
+    {
+        // The per-species loop lives in the adapter now (not inside the vendored engine, see class
+        // remarks), so cancellation is checked every species — this proves it actually takes effect
+        // partway through a run rather than only before/after a whole pass. A synchronous IProgress<T> is
+        // used (not System.Progress<T>, which marshals its callback and would make the cancel-after-N
+        // trigger racy/nondeterministic in a test) so the species-processed count is exact.
+        var service = new LivingDexService();
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        using var cts = new CancellationTokenSource();
+
+        var seen = 0;
+        var progress = new SynchronousProgress<LivingDexGenerationProgress>(p =>
+        {
+            seen = p.Completed;
+            if (p.Completed >= 2)
+                cts.Cancel();
+        });
+
+        var result = service.Generate(sav, new LivingDexOptions(IncludeForms: false, SetShiny: false), progress, cts.Token, maxSpeciesId: 200);
+
+        Assert.True(result.Cancelled);
+        Assert.Empty(result.Pokemon);
+        Assert.True(seen < 200, $"Expected cancellation to stop the loop well short of 200 species; processed {seen}.");
+    }
+
+    /// <summary>Invokes its callback synchronously on the reporting thread — unlike <see cref="Progress{T}"/>, which posts to a captured SynchronizationContext (or the thread pool) and would make ordering nondeterministic in a test.</summary>
+    private sealed class SynchronousProgress<T>(Action<T> callback) : IProgress<T>
+    {
+        public void Report(T value) => callback(value);
+    }
+
+    // -------------------------------------------------------------------
+    // End-to-end generation against the real, unmocked adapter (bounded species subset for speed)
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void Generate_RealSave_ProducesLegalPokemonForABoundedSpeciesSubset()
+    {
+        // Sword, species 1-50 (bounded via maxSpeciesId — a test-only knob; the UI never sets it, so the
+        // default path always generates the full dex). This calls the real GetLegalFromSet-based loop end
+        // to end, no mocking, and was verified to produce 34 legal candidates out of 50 species attempted
+        // (the rest are species not obtainable in this game/that the minimal template can't legalize —
+        // e.g. ones needing form-specific held items this adapter doesn't set, see LivingDexService remarks).
+        var service = new LivingDexService();
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+
+        var result = service.Generate(sav, new LivingDexOptions(IncludeForms: false, SetShiny: false), maxSpeciesId: 50);
+
+        Assert.False(result.Cancelled);
+        Assert.NotEmpty(result.Pokemon);
+
+        foreach (var pk in result.Pokemon)
+            Assert.True(new LegalityAnalysis(pk).Valid, $"{GameInfo.Strings.Species[pk.Species]} failed legality analysis.");
+
+        // Species are unique (one specimen per species, matching ModLogic.GenerateLivingDex's contract).
+        Assert.Equal(result.Pokemon.Select(p => p.Species).Distinct().Count(), result.Pokemon.Count);
+
+        // Every attempted species is accounted for: either in the result, or named as skipped.
+        Assert.Equal(50, result.Pokemon.Count + result.SkippedSpeciesNames.Count
+            + Enumerable.Range(1, 50).Count(s => !sav.Personal.IsSpeciesInGame((ushort)s)));
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ShowdownIntegrationTests.cs
@@ -46,7 +46,8 @@ public class ShowdownIntegrationTests : IDisposable
             new UndoRedoService(),
             new LanguageService(),
             new Mock<IAutoLegalityService>().Object,
-            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object
+            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object,
+            new Mock<ILivingDexService>().Object
         );
         
         // Simulate loading a save

--- a/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UpdateCheckerTests.cs
@@ -173,7 +173,8 @@ public class MainWindowUpdateCheckTests
             new UndoRedoService(),
             new LanguageService(),
             new Mock<IAutoLegalityService>().Object,
-            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object);
+            new Mock<PKHeX.Application.Abstractions.LiveHex.ILiveHexService>().Object,
+            new Mock<ILivingDexService>().Object);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds **Tools > Auto Legality Mod > Generate Living Dex**: fills boxes with one legal specimen of every species obtainable in the loaded save's game (options: include forms, shiny; user picks a starting box).

Closes #123

## Design

- **Clean Architecture, per #89's pattern**: `ILivingDexService` port in `PKHeX.Application`, adapter in `PKHeX.Infrastructure`, Avalonia-free `LivingDexGeneratorViewModel` in `PKHeX.Presentation`, view in `PKHeX.Avalonia`. `PKHeX.Core` and the vendored `PKHeX.AutoMod` project are untouched.

- **Generation loop lives in the adapter, not the vendored engine.** `ModLogic.GenerateLivingDex`'s per-species helper (`GetRandomEncounter` → `tr.TryAPIConvert(set, template)`) never calls `EncounterMovesetGenerator.OptimizeCriteria(template, tr)` before converting — the step `Legalizer.GetLegalFromSet(ITrainerInfo, IBattleTemplate)` (the path `AutoLegalityService` and the existing single-set "Auto Legality Mod" tool use) always performs first. Without it, the encounter search finds nothing: verified directly against blank Red/Crystal/Emerald/Sword saves, where `GenerateLivingDex` returns an empty list for every species in all four. That's a defect in the vendored `PKHeX.AutoMod` project itself, which this repo's rules forbid modifying. Rather than ship a generator that produces nothing, `LivingDexService` drives the species/form loop itself and calls the same proven `Legalizer.GetLegalFromSet` path per candidate — this is documented at length in `LivingDexService`'s XML remarks, including why the loop intentionally builds a *minimal* template (species/form/gender/shiny) rather than replicating every special case (form-specific held items, Keldeo's Secret Sword, Zygarde's suffix, Alcremie's decorations) — species/forms needing those simply fail to generate and are reported by name rather than silently wrong. A future PKHeX.AutoMod re-sync that fixes `GenerateLivingDex` upstream could let this adapter go back to calling it directly.
- Because the loop is ours, cancellation and progress are genuine and per-species (checked every species/form), not just before/after a whole engine pass.
- Every candidate is independently re-verified via `LegalityAnalysis` (`LivingDexVerificationUseCase`) before being accepted — the same "never trust the generator's own success flag" pattern as the #89 adapter. Failures (from generation or from this re-verification) are reported by species/form name, never silently included.

- **Placement**: `LivingDexPlacementUseCase` places results starting at a user-chosen box. It scans forward for a *contiguous* run of empty/unlocked/unprotected slots — refuses with the required/available counts and writes nothing if the run is too short (no partial writes), rather than scattering results into gaps further down the boxes.

- **Undo/redo**: a placement is recorded as a single undoable operation via `UndoRedoService.BeginBatch()`/`AddChange()`/`EndBatch()`. Two real bugs were found and fixed in the process (the service had never actually been exercised before — `AddChange` had zero prior call sites in this codebase):
  1. A null-conditional short-circuit bug: `UndoPerformed?.Invoke(_changelog.Undo())` never calls `_changelog.Undo()` at all when there are no subscribers, since C# short-circuits argument evaluation too, not just the invocation.
  2. A genuine Core limitation: `SlotChangelog.Redo()` clears its *entire* redo stack as a side effect of every call, so calling it N times to redo an N-slot batch discards the remaining N-1 entries. Since `PKHeX.Core` can't be modified, grouped (batched) changes are now tracked entirely in `UndoRedoService` with their own before/after snapshots and written back directly; ungrouped single changes still delegate straight to Core exactly as before (zero behavior change there).
  Both are covered by regression tests.

## Verification

```
dotnet build PKHeX.sln -c Release  → Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test PKHeX.sln -c Release --no-build:
  PKHeX.Architecture.Tests: Passed 5, Failed 0
  PKHeX.Core.Tests:         Passed 449, Skipped 1 (pre-existing), Failed 0
  PKHeX.Avalonia.Tests:     Passed 2053, Failed 0
```

11 new tests in `Tests/PKHeX.Avalonia.Tests/LivingDexTests.cs`:
- Placement: writes every Pokémon starting at the chosen box and each written slot passes legality; empty-list no-op; refuses with no partial writes when there isn't enough *contiguous* empty space; throws on an out-of-range start box.
- Undo/redo: a multi-slot placement undoes and redoes as a single atomic operation; a regression guard proving ungrouped (non-batched) single-slot changes still undo one at a time exactly as before.
- Skip-reporting: a mix of legal/illegal candidates is split correctly and the illegal one is named.
- Cancellation: a pre-cancelled token returns immediately without running anything; a mid-loop cancellation (via a synchronous `IProgress<T>` for determinism) stops well short of the full species range.
- End-to-end: the real, unmocked `LivingDexService`/`GetLegalFromSet` path against a real (blank) Sword save produces a non-empty, all-legal result for a bounded species subset (`maxSpeciesId` is a test-only parameter — the UI always requests the full dex).

## Caveats

- **Generation time for a full modern-gen dex (e.g. Sword's ~898 species) was not profiled on real hardware.** It's one `Legalizer.GetLegalFromSet` call per species/form, which the existing single-set "Auto Legality Mod" tool already does in well under a second per call in this environment, so a full pass is expected to take anywhere from tens of seconds to a few minutes; there's a progress bar and cancel button for this.
- **The vendored `ModLogic.GenerateLivingDex` defect is documented in code** (`LivingDexService` XML remarks, `LivingDexTests` class remarks) for whoever does the next `PKHeX.AutoMod` re-sync — worth checking whether upstream has since fixed it, which would let this adapter simplify back to calling it directly.
- **No guided UI smoke test was run in this session** (headless environment) — recommend a manual pass through Tools > Auto Legality Mod > Generate Living Dex against a real save before wide release, per this repo's usual UI verification approach.
- The generation loop intentionally doesn't replicate every special case the vendored engine's own (unreachable) helper handles (form-specific held items, Keldeo's Secret Sword, Zygarde's cell suffix, Alcremie's decoration sweep) — affected forms will show up as skipped/reported rather than generating, which is within the acceptance criteria ("skip/report species the engine can't produce rather than crash") but is a smaller generated set than a fully-faithful reimplementation would produce.

## Test plan
- [x] `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test PKHeX.sln -c Release` — all green (2507 tests total across 3 projects)
- [ ] Manual: Tools > Auto Legality Mod > Generate Living Dex against a real save, verify options/box picker/progress/cancel and that boxes fill correctly