### PR TITLE
fix: deflake LiveHeX socket test connect timeout

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.31.0</UIVersion>
+    <UIVersion>1.31.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/Tests/PKHeX.Avalonia.Tests/LiveHex/SysBotConnectionTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LiveHex/SysBotConnectionTests.cs
@@ -16,6 +16,31 @@ namespace PKHeX.Avalonia.Tests.LiveHex;
 /// </summary>
 public class SysBotConnectionTests
 {
+    /// <summary>
+    /// Connects with retries so the connect phase gets a generous overall budget even when a
+    /// contended CI runner makes the loopback handshake occasionally exceed <paramref name="timeoutMs"/>.
+    /// Each attempt still uses the caller's short <paramref name="timeoutMs"/>, so the socket's
+    /// ReceiveTimeout/SendTimeout (set from that same value by <see cref="SysBotConnection.Connect"/>)
+    /// stays tight for whatever read/write the test performs afterward - only the connect phase
+    /// is made generous, via retrying rather than inflating the per-attempt timeout.
+    /// </summary>
+    private static void ConnectGenerously(SysBotConnection conn, string ip, int port, int timeoutMs, int connectBudgetMs = 10_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(connectBudgetMs);
+        while (true)
+        {
+            try
+            {
+                conn.Connect(ip, port, timeoutMs);
+                return;
+            }
+            catch (LiveHexConnectionException) when (DateTime.UtcNow < deadline)
+            {
+                // Transient contention on the loopback handshake; retry until the generous budget is spent.
+            }
+        }
+    }
+
     /// <summary>Minimal loopback sys-botbase server. Set <paramref name="mute"/> to never respond (timeout tests).</summary>
     private sealed class FakeBotbaseServer : IDisposable
     {
@@ -114,7 +139,7 @@ public class SysBotConnectionTests
     {
         using var server = new FakeBotbaseServer();
         using var conn = new SysBotConnection();
-        conn.Connect("127.0.0.1", server.Port, 3000);
+        ConnectGenerously(conn, "127.0.0.1", server.Port, 3000);
 
         var data = conn.ReadHeap(0x1000, 8);
         Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, data);
@@ -125,7 +150,7 @@ public class SysBotConnectionTests
     {
         using var server = new FakeBotbaseServer();
         using var conn = new SysBotConnection();
-        conn.Connect("127.0.0.1", server.Port, 3000);
+        ConnectGenerously(conn, "127.0.0.1", server.Port, 3000);
 
         Assert.Equal("0100ABF008968000", conn.GetTitleId());
         Assert.Equal("2.5", conn.GetBotbaseVersion());
@@ -138,7 +163,7 @@ public class SysBotConnectionTests
     {
         using var server = new FakeBotbaseServer();
         using var conn = new SysBotConnection();
-        conn.Connect("127.0.0.1", server.Port, 3000);
+        ConnectGenerously(conn, "127.0.0.1", server.Port, 3000);
 
         conn.WriteHeap([0xAB, 0xCD], 0x2000);
 
@@ -169,9 +194,14 @@ public class SysBotConnectionTests
     {
         using var server = new FakeBotbaseServer(mute: true);
         using var conn = new SysBotConnection();
-        conn.Connect("127.0.0.1", server.Port, 500);
+        // Connect phase gets a generous overall budget via retries (contended CI runners can make the
+        // loopback handshake exceed the short timeout below); each attempt still uses 500ms, so
+        // ReceiveTimeout/SendTimeout - set from that same value by Connect - stay short for the read below.
+        ConnectGenerously(conn, "127.0.0.1", server.Port, 500);
 
         var ex = Assert.Throws<LiveHexConnectionException>(() => conn.ReadHeap(0x1000, 8));
-        Assert.Contains("Timed out", ex.Message);
+        // Assert the read-timeout message specifically, not just "Timed out", so this test can't pass
+        // by silently catching a connect-phase timeout instead of the read-phase timeout it targets.
+        Assert.Contains("Timed out waiting for a response", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary

`SysBotConnectionTests.Read_times_out_when_console_never_responds` was flaky on CI (false-red on two prior PRs). Root cause: `SysBotConnection.Connect(ip, port, timeoutMs)` uses a single `timeoutMs` value for both the connect-phase wait (`BeginConnect`/`WaitOne`) and the socket's `ReceiveTimeout`/`SendTimeout` used by subsequent reads. The test passed 500ms for both. On contended ubuntu-latest runners, the loopback connect handshake occasionally took longer than 500ms, so `Connect()` itself threw a connect-timeout `LiveHexConnectionException` before the test ever reached its `Assert.Throws` around `ReadHeap` — an unrelated false failure, not the read-timeout behavior the test is meant to exercise.

- Added a `ConnectGenerously` test helper that retries `Connect` with the caller's original short `timeoutMs` per attempt (so `ReceiveTimeout`/`SendTimeout` stay tight for the read/write that follows) but gives the overall connect phase a generous 10s budget across retries. Applied it to all four tests in the file that connect to the in-process `FakeBotbaseServer`. `Connect_to_dead_endpoint_throws_clear_error` is untouched since it intentionally tests immediate connection refusal on a non-listening port, not loopback-handshake contention.
- Tightened the timeout test's assertion from `Assert.Contains("Timed out", ex.Message)` to `Assert.Contains("Timed out waiting for a response", ex.Message)` — the connect-timeout and read-timeout exception messages both contained "Timed out", so the old assertion could not have caught a connect-phase timeout leaking through as a false pass.
- Bumped `UIVersion` 1.31.0 -> 1.31.1 (patch, per project convention) in `Directory.Build.props`.

No production code changes — `PKHeX.Infrastructure/LiveHex/SysBotConnection.cs` and the `IConsoleConnection` interface are untouched.

## Test plan

- [x] `dotnet test --filter SysBotConnectionTests -c Release` x5 consecutive runs, all green (~530ms each, no slowdown from retries)
- [x] `dotnet test PKHeX.sln -c Release` full solution run, all green (2051 tests in Avalonia.Tests, 449 + 1 skipped in Core.Tests, 5 in Architecture.Tests)