### PR TITLE
docs: README + documentation overhaul, repo tidy-up

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.37.0</UIVersion>
+    <UIVersion>1.37.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
+<div align="center">
+
 # PKHeX Avalonia
 
 ![License](https://img.shields.io/badge/License-GPLv3-blue.svg)
 ![CI](https://github.com/realgarit/PKHeX-Avalonia/actions/workflows/ci.yml/badge.svg)
 ![Release](https://img.shields.io/github/v/release/realgarit/PKHeX-Avalonia?label=Latest%20Release)
+![Latest tag](https://img.shields.io/github/v/tag/realgarit/PKHeX-Avalonia?label=Latest%20Tag)
+![Downloads](https://img.shields.io/github/downloads/realgarit/PKHeX-Avalonia/total?label=Downloads)
 
-PKHeX Avalonia is a cross-platform port of [PKHeX](https://github.com/kwsch/PKHeX). It's the classic Pokémon save editor, built with Avalonia so it runs on **Windows**, **macOS**, and **Linux**.
+PKHeX Avalonia is a cross-platform port of [PKHeX](https://github.com/kwsch/PKHeX), the classic
+Pokémon save editor, built with Avalonia so it runs on **Windows**, **macOS**, and **Linux**.
 
+</div>
 
 ## Download
 
@@ -18,7 +24,8 @@ Get the latest build for your platform from the [Releases](https://github.com/re
 | macOS Apple Silicon | `PKHeX-Avalonia-osx-arm64.zip`, or `PKHeX-Avalonia-osx-arm64.dmg` |
 | macOS Intel | `PKHeX-Avalonia-osx-x64.zip`, or `PKHeX-Avalonia-osx-x64.dmg` |
 
-Every build is self-contained, so you don't need to install .NET.
+Every build is self-contained, so you don't need to install .NET. `.dmg` and the Windows installer
+are additive alongside the existing `.zip`/`.AppImage` artifacts.
 
 **Signing note:** the installer/dmg builds are code-signed and (on macOS)
 notarized only once the repo owner has configured signing secrets — see
@@ -36,6 +43,9 @@ Package-manager installs (Homebrew cask, winget) are templated under
 `packaging/` and documented in `docs/packaging.md`, pending signed release
 builds to submit.
 
+The app checks GitHub Releases for updates on startup and shows a changelog after upgrading — see
+[`docs/features.md`](docs/features.md#in-app-update-checker).
+
 
 ## Project Structure
 
@@ -45,13 +55,18 @@ The code is split into layers so the UI stays separate from the PKHeX logic:
 |---------|--------------|------|
 | **PKHeX.Core** | Save, entity, and legality logic. Kept 1:1 with [upstream PKHeX](https://github.com/kwsch/PKHeX). We don't change it directly. | None |
 | **PKHeX.Application** | Use-cases and service interfaces on top of Core. | Core |
-| **PKHeX.Infrastructure** | File access and other OS bits. | Application, Core |
-| **PKHeX.Presentation** | View-models. No UI framework here. | Application, Core |
-| **PKHeX.Avalonia** | The Avalonia UI: views, styles, and the desktop app. | all of the above |
+| **PKHeX.Infrastructure** | File access, settings, backups, update checks, LiveHeX networking, and other OS bits. | Application, Core |
+| **PKHeX.Presentation** | View-models and localization. No UI framework here. | Application, Core |
+| **PKHeX.Avalonia** | The Avalonia UI: views, styles, themes, and the desktop app. | all of the above |
+| **PKHeX.AutoMod** | Vendored Auto-Legality Mod legalization engine. | Core |
 
-Tests live under `Tests/`: `PKHeX.Core.Tests`, `PKHeX.Avalonia.Tests`, and `PKHeX.Architecture.Tests` (which checks the layers above stay separate).
+Tests live under `Tests/`: `PKHeX.Core.Tests`, `PKHeX.Avalonia.Tests`, and `PKHeX.Architecture.Tests`
+(which checks the layers above stay separate). Full layer map, dependency rules, and vendoring
+policy: [`docs/development.md`](docs/development.md).
 
 ## Features
+
+### Save editing
 
 * Edit saves from Gen 1 to Gen 9, plus Let's Go, Legends: Arceus, BDSP, and Legends: Z-A.
 * Edit any Pokémon: stats, moves, ribbons, memories, and more.
@@ -61,7 +76,40 @@ Tests live under `Tests/`: `PKHeX.Core.Tests`, `PKHeX.Avalonia.Tests`, and `PKHe
 * Search your boxes with the PKM, Mystery Gift, and Encounter databases.
 * Edit many Pokémon at once with the batch editor.
 * Game specific editors under Tools, like Pokédex, Hall of Fame, and Secret Base.
-* Drag and drop with the OS: drag a box/party slot out to Finder/Explorer to get an entity file, drop entity files onto a slot (or several onto a box to fill it), and drop a save file anywhere on the window to open it.
+
+### App experience
+
+* **Themes:** Dark, Light, High Contrast, and Follow System, switchable at runtime — no restart.
+* **Localization:** the app shell is translated into 9 languages (English, Japanese, Korean,
+  French, Italian, German, Spanish, Simplified Chinese, Traditional Chinese), switchable live from
+  the Options menu. [Contribute a translation.](CONTRIBUTING.md)
+* **OS drag-and-drop:** drag a box/party slot out to Finder/Explorer to get an entity file, drop
+  entity files onto a slot (or several onto a box to fill it), and drop a save file anywhere on the
+  window to open it. [Details below.](#os-drag-and-drop-notes)
+* **Accessibility:** keyboard-navigable box/party grids, accessible names on icon-only controls,
+  and visible focus in every theme. See [`docs/accessibility.md`](docs/accessibility.md).
+* **In-app update checker:** checks GitHub Releases on startup and shows a changelog after
+  upgrading.
+* **Save backup manager & diff:** automatic timestamped backups of every save you open or write,
+  with a restore UI and a slot-by-slot diff between two saves (Tools → Backup Manager).
+* **Whole-save legality audit:** a tool window that runs the legality checker over every Pokémon in
+  the save at once (Tools → Data → Legality Audit).
+* **Platform-standard config/data directories,** with automatic one-time migration from the old
+  next-to-executable location.
+
+### Beyond WinForms parity
+
+Tools that go past what the original WinForms PKHeX offers — full guide in
+[`docs/features.md`](docs/features.md):
+
+* **Auto-Legality Mod:** paste a Pokémon Showdown set and get back a legal, ready-to-inject
+  Pokémon, using the same legalization engine as the original Auto Legality Mod plugin
+  (Tools → Showdown → Import Set, `Ctrl+T`).
+* **Living Dex generator:** fills an entire Pokédex's worth of boxes with legal Pokémon using that
+  same engine (Tools → Generate Living Dex).
+* **LiveHeX:** read and write Pokémon directly on a running Nintendo Switch over Wi-Fi via
+  [sys-botbase](https://github.com/olliz0r/sys-botbase) — no save export/import round-trip needed
+  (Tools → LiveHeX). Requires a hackable/CFW console running sys-botbase.
 
 ### OS drag-and-drop notes
 
@@ -104,6 +152,20 @@ dotnet test PKHeX.sln
 dotnet publish PKHeX.Avalonia -c Release -r osx-arm64 --self-contained -p:PublishSingleFile=true
 ```
 
+See [`docs/development.md`](docs/development.md) for the full layer map, the PKHeX.Core 1:1 sync
+policy, and the test suite overview.
+
+## Documentation
+
+* [`docs/features.md`](docs/features.md) — guide to Auto-Legality Mod, Living Dex, LiveHeX, backup
+  manager, legality audit, themes, localization, and more.
+* [`docs/development.md`](docs/development.md) — build/test/run, Clean Architecture layer map,
+  PKHeX.Core sync policy, UIVersion convention, test suite overview.
+* [`docs/accessibility.md`](docs/accessibility.md) — keyboard shortcuts and screen-reader notes.
+* [`docs/packaging.md`](docs/packaging.md) — how release installers/packages are built and signed.
+* [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to contribute a UI translation.
+* [`docs/README.md`](docs/README.md) — full documentation index.
+
 ## Screenshots
 
 Pokémon editor and box view. The full editor next to the sprite box grid.
@@ -119,6 +181,8 @@ Save editors. Gen 1 to 9 plus game specific tools under Tools, then Save Editors
 This fork is built on the work of the [PKHeX team](https://github.com/kwsch/PKHeX).
 
 * **Logic & Research:** [PKHeX](https://github.com/kwsch/PKHeX)
+* **Auto-Legality Mod:** [PKHeX-Plugins](https://github.com/santacrab2/PKHeX-Plugins) by architdate, santacrab2, and contributors (see [`PKHeX.AutoMod/VENDORED.md`](PKHeX.AutoMod/VENDORED.md))
+* **LiveHeX protocol:** [sys-botbase](https://github.com/olliz0r/sys-botbase) by olliz0r
 * **QR Codes:** [QRCoder](https://github.com/codebude/QRCoder) (MIT)
 * **Sprites:** [pokesprite](https://github.com/msikma/pokesprite) (MIT)
 * **Arceus Sprites:** National Pokédex Icon Dex project and contributors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation index
+
+- **[features.md](features.md)** — guide to the tools beyond a straight WinForms port: Auto-Legality
+  Mod (Showdown → legal), Living Dex generator, whole-save legality audit, LiveHeX (live console
+  editing), save backup manager & diff, theme system, localization, update checker, drag-and-drop,
+  and platform config directories.
+- **[development.md](development.md)** — build/test/run, the Clean Architecture layer map and
+  dependency rules, the PKHeX.Core 1:1 mirror policy and sync automation, PKHeX.AutoMod vendoring,
+  the UIVersion SemVer convention, and the test suite overview.
+- **[accessibility.md](accessibility.md)** — keyboard shortcuts and screen-reader notes.
+- **[packaging.md](packaging.md)** — how release installers/packages are built, signed, and
+  distributed per platform.
+- **[../CONTRIBUTING.md](../CONTRIBUTING.md)** — how to contribute a UI translation (the main
+  community contribution path today).
+
+See the [main README](../README.md) for an overview, downloads, and screenshots.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,135 @@
+# Development guide
+
+## Build, run, test
+
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
+
+```bash
+# Run the app
+dotnet run --project PKHeX.Avalonia
+
+# Build
+dotnet build PKHeX.sln -c Release
+
+# Test (full suite)
+dotnet test PKHeX.sln -c Release
+
+# Publish a self-contained build (example: macOS ARM)
+dotnet publish PKHeX.Avalonia -c Release -r osx-arm64 --self-contained -p:PublishSingleFile=true
+```
+
+CI (`.github/workflows/ci.yml`) builds and tests on Windows, macOS, and Linux for every push and
+pull request. `release.yml` builds installers/packages on a version bump — see
+[packaging.md](packaging.md).
+
+## Clean Architecture layer map
+
+The code is split into five projects so the UI never touches PKHeX's core logic directly, and so
+dependencies only ever point one way:
+
+```
+PKHeX.Avalonia  ──depends on──▶  PKHeX.Presentation, PKHeX.Application, PKHeX.Infrastructure, PKHeX.Core
+PKHeX.Infrastructure ──depends on──▶  PKHeX.Application, PKHeX.Core
+PKHeX.Presentation ──depends on──▶  PKHeX.Application, PKHeX.Core
+PKHeX.Application ──depends on──▶  PKHeX.Core
+PKHeX.Core ──depends on──▶  (nothing in this repo)
+```
+
+| Project | What it does |
+|---|---|
+| **PKHeX.Core** | Save, entity, and legality logic. Kept **1:1** with [upstream PKHeX](https://github.com/kwsch/PKHeX) — never edited directly (see below). |
+| **PKHeX.Application** | Use-cases and service interfaces (ports) on top of Core. No UI framework, no file/network I/O. |
+| **PKHeX.Infrastructure** | Implements the Application-layer ports: file access, settings storage, backups, update checks, LiveHeX networking, and the vendored Auto-Legality engine's integration. |
+| **PKHeX.Presentation** | ViewModels and localization plumbing. No Avalonia/UI-framework references. |
+| **PKHeX.Avalonia** | The Avalonia desktop app: views (`.axaml`), styles/themes, converters, and composition root. |
+| **PKHeX.AutoMod** | Vendored Auto-Legality Mod legalization engine (separate from the Core mirror — see below). |
+
+`Tests/PKHeX.Architecture.Tests` enforces the dependency direction above — it fails the build if a
+lower layer references a higher one (e.g. `PKHeX.Application` referencing `PKHeX.Avalonia`).
+
+Rule of thumb when adding a feature: define the capability as an interface in
+`PKHeX.Application/Abstractions`, implement it in `PKHeX.Infrastructure`, drive it from a
+`PKHeX.Presentation` ViewModel, and wire the view in `PKHeX.Avalonia`.
+
+## PKHeX.Core: 1:1 mirror policy
+
+`PKHeX.Core` is never modified directly in this repo — it's kept byte-for-byte identical to
+[kwsch/PKHeX](https://github.com/kwsch/PKHeX)'s `PKHeX.Core` folder. Any fix or behavior change
+needed for the Avalonia UI is ported into `PKHeX.Application`/`PKHeX.Infrastructure`/
+`PKHeX.Presentation` instead — never patched into Core.
+
+Sync automation:
+
+- `.github/workflows/check-upstream-sync.yml` runs daily, compares
+  `.github/upstream-sync/last-synced-sha.txt` against the latest upstream commit touching
+  `PKHeX.Core`, and opens a **"PKHeX.Core Sync Required"** issue (with the new commits and a diff
+  link) when out of date. It can also be triggered manually from the Actions tab. See
+  [`.github/upstream-sync/README.md`](../.github/upstream-sync/README.md) for how the workflow and
+  the SHA file fit together.
+- Syncing from that issue mirrors the upstream `PKHeX.Core` folder byte-for-byte, ports any
+  resulting API changes into the Avalonia layers (never into Core itself), updates
+  `last-synced-sha.txt` to the new commit, bumps `UIVersion`, and ships the result as a normal PR.
+
+## PKHeX.AutoMod: vendored, not mirrored
+
+Unlike `PKHeX.Core`, `PKHeX.AutoMod` (the Auto-Legality Mod legalization engine) is vendored from a
+different upstream — [santacrab2/PKHeX-Plugins](https://github.com/santacrab2/PKHeX-Plugins) — and
+is **not** under the 1:1 mirror rule; it's a separate vendored sync target with its own re-sync
+procedure. Source is copied verbatim (no `.cs` edits) with only the `.csproj` adapted to build
+against this repo's `PKHeX.Core` via project reference instead of a NuGet pin. Full details,
+including the re-sync steps and what was deliberately *not* vendored (the WinForms plugin UI, and
+the USB/3DS-capable `PKHeX.Core.Injection` project — see LiveHeX below), are in
+[`PKHeX.AutoMod/VENDORED.md`](../PKHeX.AutoMod/VENDORED.md).
+
+LiveHeX's console connectivity (`PKHeX.Infrastructure/LiveHex/`) is **not** vendored from that same
+upstream — it's a clean-room re-implementation of the small, public sys-botbase protocol. The
+rationale (USB dependency out of scope, dead 3DS code, compile-time coupling that would break the
+byte-for-byte rule) is documented in
+[`PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md`](../PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md).
+
+## UIVersion (SemVer) convention
+
+`Directory.Build.props`'s `<UIVersion>` tracks Avalonia-layer releases independently of
+`PKHeX.Core`'s own `<Version>`. Bump it on every PR, by change type:
+
+| Change type | Bump |
+|---|---|
+| `feat` (new feature) | minor |
+| `fix` / `chore` / `refactor` / dependency update | patch |
+| breaking change | major |
+
+`release.yml` triggers a release build on a push to `main` that changes `<UIVersion>`.
+
+## Localization contribution guide
+
+UI-chrome translations (menus, dialogs, settings, status text — not game data, which
+`PKHeX.Core`'s `GameInfo.Strings` already localizes) live in
+`PKHeX.Presentation/Localization/Strings/*.json`, one file per language, with `en.json` as the
+source of truth. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full guide: file format,
+placeholder/mnemonic rules, how to add a new string, and how to migrate one of the still-unlocalized
+editor dialogs off the allowlist.
+
+## Test suite overview
+
+```
+Tests/
+  PKHeX.Core.Tests/        Legality, save format, PKM, simulator, and general PKHeX.Core coverage — mirrors upstream's own test suite.
+  PKHeX.Avalonia.Tests/    ViewModel/use-case tests for the Avalonia layer, plus feature-specific suites (LiveHex/, BackupManagerViewModelTests.cs, LivingDexTests.cs, ...).
+  PKHeX.Architecture.Tests/  Enforces the Clean Architecture dependency rules described above.
+```
+
+Guardrail/audit tests worth knowing about, all under `Tests/PKHeX.Avalonia.Tests/`:
+
+- **`AccessibilityAuditTests.cs`** — scans every `.axaml` view for icon-only buttons missing an
+  `AutomationProperties.Name`.
+- **`LocalizationAuditTests.cs`** — fails the build if a view or ViewModel introduces a hardcoded
+  user-facing string instead of going through the localization resource system (dialogs not yet
+  migrated are tracked in `localization-allowlist.txt`).
+- **`LegalityAuditTests.cs`** — covers the whole-save legality audit tool.
+- **`SaveLoadAuditTests.cs`** — round-trips every bundled test save through load/save.
+
+Run the full suite with `dotnet test PKHeX.sln -c Release`, or scope to one area, e.g.:
+
+```bash
+dotnet test Tests/PKHeX.Avalonia.Tests --filter "FullyQualifiedName~Localization"
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,146 @@
+# Feature guide
+
+Short, practical guide to the tools that go beyond a straight WinForms-to-Avalonia port. For
+keyboard/screen-reader behavior see [accessibility.md](accessibility.md); for build artifacts see
+[packaging.md](packaging.md).
+
+## Auto-Legality Mod (Showdown → legal Pokémon)
+
+Paste a [Pokémon Showdown](https://pokemonshowdown.com/) export-format set and get back a legal,
+ready-to-inject `PKM` — same engine as the original Windows Auto Legality Mod plugin.
+
+- **Open it:** Tools → Showdown → Import Set (`Ctrl+T`) imports a single set into the currently
+  selected slot; Import Team imports a full team across the box. Export Set/Export Box/Export All
+  Boxes (`Ctrl+Shift+T`) go the other direction, dumping the box back out as Showdown text.
+- **Under the hood:** the legalization engine lives in `PKHeX.AutoMod` (vendored from
+  [santacrab2/PKHeX-Plugins](https://github.com/santacrab2/PKHeX-Plugins), see
+  [`PKHeX.AutoMod/VENDORED.md`](../PKHeX.AutoMod/VENDORED.md)) and picks an encounter, ball,
+  moves, EVs/IVs, and any other detail needed to satisfy `PKHeX.Core`'s legality checker.
+- **Caveats:** if no legal encounter exists for the requested species/form/game combination, the
+  import fails with an error rather than producing an illegal mon. Nicknames, OT, and language are
+  filled with sensible defaults when the Showdown text doesn't specify them.
+
+## Living Dex generator
+
+Fills an entire Pokédex's worth of boxes with legal Pokémon, one per species (and, where relevant,
+per form), using the same Auto-Legality engine as the Showdown importer.
+
+- **Open it:** Tools → Generate Living Dex.
+- **What it does:** walks the currently loaded save's Pokédex, generates a legal encounter for
+  each missing entry, and places it into open box slots. It reports which species it couldn't
+  place (no free slot, no legal encounter for that game) rather than silently skipping them.
+- **Caveats:** it needs enough free box space for the full dex; run it on a save with room to
+  spare, or clear boxes first.
+
+## Whole-save legality audit
+
+A tool window that runs the legality checker over every Pokémon in the save at once, instead of
+one slot at a time in the main editor.
+
+- **Open it:** Tools → Data → Legality Audit.
+- **What it shows:** one row per occupied slot (box + party) with its legality verdict, so you can
+  find every illegal or flagged entry in a save without clicking through each box individually.
+
+## LiveHeX (live console box editing over Wi-Fi)
+
+Reads and writes Pokémon directly on a running Nintendo Switch game over the local network,
+instead of editing an exported save file.
+
+- **Open it:** Tools → LiveHeX.
+- **Requires:** the console must be running
+  [**sys-botbase**](https://github.com/olliz0r/sys-botbase) (a homebrew sysmodule — requires a
+  hackable/CFW Switch) and be reachable over Wi-Fi; enter its IP address in the LiveHeX window to
+  connect. USB connections are out of scope for v1.
+- **Supported games:** Sword/Shield, Brilliant Diamond/Shining Pearl, Legends: Arceus, and
+  Scarlet/Violet (see the firmware-version matrix in
+  [`PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md`](../PKHeX.Infrastructure/LiveHex/NOTICE.LiveHeX.md)).
+- **Implementation note:** unlike the vendored Auto-Legality engine, LiveHeX's connectivity is a
+  **clean-room** re-implementation of the small, public sys-botbase TCP protocol
+  (`PKHeX.Infrastructure/LiveHex/`) — it does not vendor upstream's USB/3DS-capable injection
+  code. See the NOTICE file linked above for why.
+- **Caveats:** this edits the console's live memory. A bad write can corrupt your in-game save;
+  keep a backup (see the backup manager below) before making changes you're not sure about.
+
+## Save backup manager & save diff
+
+Automatic backups of every save you open or write, plus a tool to compare two saves slot-by-slot.
+
+- **Open it:** Tools → Backup Manager.
+- **What it does:** `SaveBackupService` (`PKHeX.Infrastructure/SaveBackupService.cs`) snapshots a
+  save before it's overwritten, timestamped and kept in the app's per-platform data directory (see
+  Platform config/data directories below). The Backup Manager window lists all backups for the
+  current save, lets you restore one, and opens the diff view to compare two saves and see which
+  boxes/slots changed.
+
+## Theme system
+
+Dark, Light, High Contrast, and Follow System themes, switchable at runtime with no restart.
+
+- **Change it:** Options → Settings → Appearance → Theme.
+- **Implementation:** `PKHeX.Avalonia/Services/ThemeService.cs` applies the selection via
+  Avalonia's `ThemeVariant` (High Contrast is a custom variant defined in
+  `PKHeX.Avalonia/Services/AppThemeVariants.cs`, layered on the Dark palette); resource
+  dictionaries live in `PKHeX.Avalonia/Styles/Theme.axaml`. Follow System tracks the OS light/dark
+  setting live. Your choice persists in app settings across restarts.
+
+## Localization (9 languages)
+
+The app shell — menus, dialogs, settings, status messages — is localized into English, Japanese,
+Korean, French, Italian, German, Spanish, Simplified Chinese, and Traditional Chinese (the same
+nine languages `PKHeX.Core` uses for game data).
+
+- **Change it:** Options → Language, or Settings → Appearance → Language. Switching applies
+  immediately across the whole UI, no restart required.
+- **Where strings live:** `PKHeX.Presentation/Localization/Strings/*.json`, one flat JSON file per
+  language; `en.json` is the source of truth and any missing key in another language falls back to
+  English rather than showing blank text or a raw key.
+- **Contributing a translation or fixing one:** see [CONTRIBUTING.md](../CONTRIBUTING.md), which
+  covers the file format, placeholders, menu-mnemonic conventions, and the guardrail tests.
+- **Status:** the core application shell is fully localized; a backlog of less-common editor
+  dialogs is tracked in `Tests/PKHeX.Avalonia.Tests/localization-allowlist.txt` and localized
+  incrementally.
+
+## In-app update checker
+
+Checks GitHub Releases for a newer version and shows what changed.
+
+- **Where it lives:** `PKHeX.Infrastructure/GitHubUpdateCheckService.cs` behind the
+  `IUpdateCheckService` port.
+- **Behavior:** runs automatically at startup, failing silently (no dialog, no retry) if the check
+  can't complete — for example, no network access. If you've just upgraded across a version
+  boundary, a "What's New" changelog dialog shows automatically once on the first run of the new
+  version.
+- **Downloads:** point you at the [Releases](https://github.com/realgarit/PKHeX-Avalonia/releases)
+  page for the appropriate per-platform artifact — see the Download section in the
+  [README](../README.md) and [packaging.md](packaging.md) for what's available per OS.
+
+## OS drag-and-drop
+
+- **Drag out:** drag a box/party slot to the desktop/Finder/Explorer to get a decrypted entity
+  file (e.g. `.pk9`).
+- **Drag in:** drop entity files (`.pk1`–`.pk9`, `.pb7`/`.pb8`, `.pa8`, encrypted `.ek*`, Mystery
+  Gift files) onto a slot, or several onto a box to fill it.
+- **Drag a save file** anywhere on the main window to open it, same as File → Open.
+- Full details, including the sandboxed/browser-hosted fallback behavior, are in the README's
+  Features section.
+
+## Platform config/data directories
+
+Settings, backups, and caches live in the OS-standard location instead of next to the executable:
+
+| OS | Config | Data (backups, caches) |
+|---|---|---|
+| Windows | `%APPDATA%\PKHeX-Avalonia` | `%LOCALAPPDATA%\PKHeX-Avalonia` |
+| macOS | `~/Library/Application Support/PKHeX-Avalonia` | same as config |
+| Linux | `$XDG_CONFIG_HOME/PKHeX-Avalonia` (falls back to `~/.config/PKHeX-Avalonia`) | `$XDG_DATA_HOME/PKHeX-Avalonia` (falls back to `~/.local/share/PKHeX-Avalonia`) |
+
+Resolution logic is pure and unit-tested for all three platforms regardless of host OS — see
+`PKHeX.Infrastructure/Configuration/AppPathResolver.cs`. Settings from the legacy
+next-to-executable location are migrated automatically the first time the app starts with the new
+version; nothing is lost, and the old location is left in place rather than deleted.
+
+## Accessibility
+
+Keyboard-first navigation for the box/party grids, accessible names on icon-only buttons, and
+visible focus in every theme. Full shortcut reference and screen-reader notes in
+[accessibility.md](accessibility.md).


### PR DESCRIPTION
## Summary

- Overhauled `README.md`: added a centered badges row (License, CI, Latest Release, Latest Tag, Downloads), reorganized Features into scannable sections (Save editing / App experience / Beyond WinForms parity), added a new "Beyond WinForms parity" section covering Auto-Legality Mod, Living Dex generator, and LiveHeX, added a Documentation section linking `docs/*.md`, and updated the Download section to note the new `.dmg`/installer artifacts alongside the existing unsigned-build guidance. Kept the existing macOS quarantine note, screenshots (no new ones invented — still the 4 existing files under `docs/screenshots/`), and credits, and added credit lines for the vendored Auto-Legality Mod and the LiveHeX sys-botbase protocol.
- Added `docs/README.md` as a documentation index.
- Added `docs/features.md`: how to open and use each of the newer tools (Auto-Legality Mod, Living Dex generator, whole-save legality audit, LiveHeX, save backup manager & diff, theme system, localization, update checker, drag-and-drop, platform config directories), including caveats like LiveHeX requiring sys-botbase on a hackable console.
- Added `docs/development.md`: build/test/run instructions, the Clean Architecture layer map and dependency rules, the PKHeX.Core 1:1 mirror policy and its in-repo sync workflow (`check-upstream-sync.yml` + `.github/upstream-sync/`), PKHeX.AutoMod vendoring (pointing at `PKHeX.AutoMod/VENDORED.md`), the UIVersion SemVer convention, and a test suite overview including the `AccessibilityAuditTests`/`LocalizationAuditTests` guardrails.
- Checked for repo tidy-up items: no tracked `.DS_Store` files exist, `.gitignore` already covers `.DS_Store` and `.claude/` (which covers `.claude/worktrees`), and no stray files were found at repo root. No changes needed there.
- `CONTRIBUTING.md` already covers localization contribution in depth, so `docs/README.md` links it instead of duplicating it.
- Bumped `UIVersion` 1.37.0 -> 1.37.1 (patch, docs-only change) in `Directory.Build.props`.

## Test plan

- [x] `dotnet build PKHeX.sln -c Release` — Build succeeded, 0 Warning(s), 0 Error(s)
- [x] `dotnet test PKHeX.sln -c Release --no-build` — all green: `PKHeX.Architecture.Tests` 5/5, `PKHeX.Core.Tests` 449/450 (1 pre-existing skip), `PKHeX.Avalonia.Tests` 2106/2106