### PR TITLE
feat: stable self-signed macOS identity + quarantine handling (tertius pattern)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,10 +95,12 @@ jobs:
           zip -r ../${{ matrix.artifact }}.zip PKHeX.Avalonia.app
           cd ..
 
-      # Gate real Developer ID signing/notarization on repo secrets. Without
-      # them we still ship a .dmg (clearly named "-unsigned") so the artifact
-      # shape stays stable either way; see docs/packaging.md for the secrets
-      # a repo owner needs to add to turn this on.
+      # Three-tier signing priority for macOS (see docs/packaging.md):
+      #   1. Developer ID secrets present  → full sign + notarize (below, unchanged)
+      #   2. else self-signed cert secrets → stable self-signed identity (tertius
+      #      pattern) so repeat Gatekeeper prompts / TCC re-grants don't happen
+      #      across updates, artifact suffixed "-selfsigned"
+      #   3. else                          → ad-hoc/no identity, "-unsigned"
       - name: Determine macOS signing capability
         if: startsWith(matrix.rid, 'osx')
         id: mac_sign
@@ -108,7 +110,20 @@ jobs:
             echo "Signing secrets present — will produce a Developer ID signed, notarized .dmg"
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Signing secrets absent — will produce an UNSIGNED .dmg"
+            echo "Developer ID signing secrets absent — will produce an UNSIGNED .dmg"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine macOS self-sign capability
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled != 'true'
+        id: mac_selfsign
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.SELFSIGN_CERT_P12_BASE64 }}" ] && [ -n "${{ secrets.SELFSIGN_CERT_PASSWORD }}" ] && [ -n "${{ secrets.SELFSIGN_IDENTITY }}" ]; then
+            echo "Self-signed cert secrets present — will sign with a stable self-signed identity"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Self-signed cert secrets absent — will produce an UNSIGNED .dmg"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -158,6 +173,38 @@ jobs:
           xcrun stapler staple publish/PKHeX.Avalonia.app
           rm -f "$RUNNER_TEMP/notarize.zip" "$RUNNER_TEMP/notary_key.p8"
 
+      # Tertius pattern: sign with a stable self-signed identity (not
+      # notarized — no Apple Developer ID needed) so the codesign designated
+      # requirement stays identical release over release. macOS then treats
+      # updates as the same app: keychain items and TCC (Accessibility, Full
+      # Disk Access, etc.) grants persist across `brew upgrade` / manual
+      # re-download instead of re-prompting every time. See docs/packaging.md.
+      - name: Import self-signed certificate
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled != 'true' && steps.mac_selfsign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          P12_BASE64: ${{ secrets.SELFSIGN_CERT_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.SELFSIGN_CERT_PASSWORD }}
+        run: |
+          printf '%s' "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/selfsign.p12"
+          export KEYCHAIN="$RUNNER_TEMP/pkhex-avalonia-ci.keychain-db"
+          chmod +x Scripts/import-cert.sh
+          Scripts/import-cert.sh "$RUNNER_TEMP/selfsign.p12"
+          rm -f "$RUNNER_TEMP/selfsign.p12"
+          echo "SELFSIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
+      - name: Codesign with self-signed identity
+        if: startsWith(matrix.rid, 'osx') && steps.mac_sign.outputs.enabled != 'true' && steps.mac_selfsign.outputs.enabled == 'true'
+        shell: bash
+        env:
+          SELFSIGN_IDENTITY: ${{ secrets.SELFSIGN_IDENTITY }}
+        run: |
+          security unlock-keychain -p "pkhex-avalonia-build" "$SELFSIGN_KEYCHAIN" 2>/dev/null || true
+          # --deep re-signs every nested Mach-O (frameworks, native libs, the
+          # main executable) with the same identity, not just the top level.
+          codesign --force --deep --sign "$SELFSIGN_IDENTITY" --keychain "$SELFSIGN_KEYCHAIN" publish/PKHeX.Avalonia.app
+          codesign --verify --deep --strict --verbose=2 publish/PKHeX.Avalonia.app
+
       - name: Build DMG
         if: startsWith(matrix.rid, 'osx')
         shell: bash
@@ -167,6 +214,8 @@ jobs:
           ln -s /Applications "$DMG_STAGING/Applications"
           if [ "${{ steps.mac_sign.outputs.enabled }}" = "true" ]; then
             DMG_NAME="${{ matrix.artifact }}.dmg"
+          elif [ "${{ steps.mac_selfsign.outputs.enabled }}" = "true" ]; then
+            DMG_NAME="${{ matrix.artifact }}-selfsigned.dmg"
           else
             DMG_NAME="${{ matrix.artifact }}-unsigned.dmg"
           fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.39.0</UIVersion>
+    <UIVersion>1.39.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ Get the latest build for your platform from the [Releases](https://github.com/re
 | macOS Apple Silicon | `PKHeX-Avalonia-osx-arm64.zip`, or `PKHeX-Avalonia-osx-arm64.dmg` |
 | macOS Intel | `PKHeX-Avalonia-osx-x64.zip`, or `PKHeX-Avalonia-osx-x64.dmg` |
 
-**Unsigned builds:** installer/dmg artifacts are only code-signed and notarized once signing
-secrets are configured (see [`docs/packaging.md`](docs/packaging.md)). Filenames ending in
-`-unsigned` will trigger an OS warning on first launch — on Windows, click **More info** → **Run
-anyway**; on macOS, right-click → **Open**, or run:
+**Unsigned builds:** installer/dmg artifacts are only fully code-signed and notarized once signing
+secrets are configured; macOS `.dmg`s may instead carry a stable self-signed identity
+(`-selfsigned`, avoids repeat Gatekeeper prompts on updates but still needs a one-time approval —
+see [`docs/packaging.md`](docs/packaging.md)). Filenames ending in `-unsigned` will trigger an OS
+warning on first launch — on Windows, click **More info** → **Run anyway**; on macOS, right-click →
+**Open**, or run:
 ```bash
-xattr -d com.apple.quarantine ~/Downloads/PKHeX.Avalonia.app
+xattr -dr com.apple.quarantine ~/Downloads/PKHeX.Avalonia.app
 ```
+Homebrew installs strip this automatically via the cask's postflight step.
 
 Package-manager installs (Homebrew cask, winget) are templated under `packaging/`, pending signed
 builds — see [`docs/packaging.md`](docs/packaging.md).

--- a/Scripts/import-cert.sh
+++ b/Scripts/import-cert.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Import a signing .p12 into a DEDICATED keychain set up for non-interactive
+# codesign. Idempotent. Used both locally and in CI (same flow ⇒ same identity
+# ⇒ same designated requirement). Tertius pattern.
+#
+# Usage:  P12_PASSWORD=... Scripts/import-cert.sh <path-to.p12>
+# Env:    P12_PASSWORD (required)
+#         KEYCHAIN          (default pkhex-avalonia-signing.keychain-db)
+#         KEYCHAIN_PASSWORD (default pkhex-avalonia-build)
+#
+set -euo pipefail
+
+P12="${1:?usage: import-cert.sh <path-to.p12>}"
+: "${P12_PASSWORD:?set P12_PASSWORD}"
+KC="${KEYCHAIN:-pkhex-avalonia-signing.keychain-db}"
+KCPASS="${KEYCHAIN_PASSWORD:-pkhex-avalonia-build}"
+
+security create-keychain -p "$KCPASS" "$KC" 2>/dev/null || true
+security set-keychain-settings "$KC"                 # no auto-lock timeout
+security unlock-keychain -p "$KCPASS" "$KC"
+security import "$P12" -k "$KC" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+# Allow codesign to use the key without a GUI prompt.
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" "$KC" >/dev/null 2>&1 || true
+# Add to the user search list, preserving existing keychains.
+security list-keychains -d user -s "$KC" $(security list-keychains -d user | sed 's/[\"" ]//g')
+
+echo "Imported identity into keychain: $KC"

--- a/Scripts/make-signing-cert.sh
+++ b/Scripts/make-signing-cert.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Generate a self-signed CODE SIGNING identity as a .p12 (tertius pattern).
+#
+# This .p12 is THE signing identity. Reusing the same one for every release
+# keeps the codesign designated requirement stable, so macOS treats upgrades
+# as the same app — keychain items and any TCC (Accessibility, Full Disk
+# Access, etc.) grants persist across updates instead of re-prompting the
+# user every time. Store it as a GitHub Actions secret for CI.
+#
+# Usage:   P12_PASSWORD=... Scripts/make-signing-cert.sh [output-dir]
+# Env:     P12_PASSWORD (required)   CERT_CN (default "PKHeX-Avalonia Self-Signed")
+#
+set -euo pipefail
+
+OUTDIR="${1:-./secrets}"
+CN="${CERT_CN:-PKHeX-Avalonia Self-Signed}"
+: "${P12_PASSWORD:?set P12_PASSWORD}"
+
+mkdir -p "$OUTDIR"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/ext.cnf" <<EOF
+[req]
+distinguished_name = dn
+prompt = no
+x509_extensions = v3
+[dn]
+CN = $CN
+[v3]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+subjectKeyIdentifier = hash
+EOF
+
+# EC key + self-signed cert with the codeSigning EKU.
+openssl ecparam -name prime256v1 -genkey -noout -out "$WORK/key.pem"
+openssl req -new -x509 -key "$WORK/key.pem" -out "$WORK/cert.pem" -days 3650 -config "$WORK/ext.cnf"
+
+# Package as .p12. System openssl is LibreSSL — do NOT pass -legacy.
+openssl pkcs12 -export \
+  -inkey "$WORK/key.pem" -in "$WORK/cert.pem" \
+  -out "$OUTDIR/signing.p12" -name "$CN" \
+  -passout pass:"$P12_PASSWORD"
+
+echo "Wrote $OUTDIR/signing.p12  (CN: $CN)"
+echo "For CI:   base64 -i $OUTDIR/signing.p12 | pbcopy   → store as SELFSIGN_CERT_P12_BASE64"

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -51,6 +51,84 @@ Gatekeeper will still complain.
 
 The existing ad-hoc-signed `.zip` artifacts are untouched by this change.
 
+## macOS: stable self-signed identity (the "tertius" pattern)
+
+Real Developer ID signing needs a paid Apple Developer account. Without one,
+`release.yml` falls back to a second tier before giving up and shipping
+unsigned: a **stable self-signed identity**.
+
+**Why a stable identity matters.** Gatekeeper's "this app is from an
+unidentified developer" prompt, and macOS's re-prompting for TCC permissions
+(Accessibility, Full Disk Access, etc.) and keychain access, are keyed off
+the app's *codesign designated requirement* — effectively a hash derived
+from the signing certificate. An ad-hoc signature (`codesign --sign -`) has
+no stable identity: every build gets a new one, so macOS treats every
+update as a brand-new, never-before-seen app. That means every single
+release re-triggers Gatekeeper's "are you sure?" dialog and drops any TCC
+grants the user already approved.
+
+If instead every release is signed with the **same** self-signed
+certificate, the designated requirement stays identical release over
+release. macOS then recognizes an update as *the same app* upgrading in
+place — TCC grants and keychain items persist across `brew upgrade` or a
+manual re-download and reinstall, and Gatekeeper only has an opinion about
+the app once, not on every update.
+
+This does **not** replace notarization — a self-signed cert isn't trusted by
+Apple, so first launch of a freshly downloaded artifact still shows the
+Gatekeeper "unidentified developer" prompt once. What it fixes is the
+*repeat* prompting on every subsequent update, and it works entirely without
+an Apple Developer Program membership.
+
+**Generating the certificate (one-time, by the repo owner):**
+
+```bash
+P12_PASSWORD='choose-a-password' Scripts/make-signing-cert.sh ./secrets
+base64 -i ./secrets/signing.p12 | pbcopy   # paste into SELFSIGN_CERT_P12_BASE64
+```
+
+This produces a 10-year self-signed EC certificate with the `codeSigning`
+extended key usage, packaged as `signing.p12`. Keep this file (and the
+password) somewhere durable outside the repo — regenerating it produces a
+*different* identity, which resets the stability this whole pattern exists
+for.
+
+**The three secrets to add** (repo Settings → Secrets and variables →
+Actions), used only when the Developer ID secrets above are absent:
+
+| Secret | Contents |
+|---|---|
+| `SELFSIGN_CERT_P12_BASE64` | Base64 of the `.p12` produced above |
+| `SELFSIGN_CERT_PASSWORD` | The `P12_PASSWORD` used to generate it |
+| `SELFSIGN_IDENTITY` | The certificate's CN, default `PKHeX-Avalonia Self-Signed` (override via `CERT_CN` when running the script) |
+
+When present, `release.yml` imports the cert into a dedicated CI keychain
+(`Scripts/import-cert.sh`, same idempotent import-and-unlock-partition-list
+flow used for local testing) and re-signs every Mach-O in
+`PKHeX.Avalonia.app` with that identity before building the `.dmg`. The
+artifact is named `PKHeX-Avalonia-osx-<arch>-selfsigned.dmg` so it's
+distinguishable from a Developer ID build and from a fully unsigned one.
+
+**Homebrew users get the whole problem solved for them.** The cask template
+(`packaging/homebrew/pkhex-avalonia.rb`) runs a `postflight` block that
+strips the quarantine extended attribute Homebrew's downloader adds
+(`xattr -dr com.apple.quarantine`), so `brew install --cask pkhex-avalonia`
+never shows a Gatekeeper prompt at all, on first install or any later
+upgrade.
+
+**Manual `.dmg`/`.zip` downloads** still see the one-time "unidentified
+developer" prompt on first launch (self-signed, not notarized). Either
+right-click → **Open** once, or clear the quarantine bit yourself:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/PKHeX-Avalonia.app
+```
+
+After that one time, updating in place (replacing the same `/Applications`
+copy) keeps the same designated requirement release to release, so this
+manual step should not be needed again as long as the self-signed cert
+itself isn't regenerated.
+
 ## Windows: installer & code signing
 
 `release.yml`'s Windows leg installs Inno Setup via `choco install
@@ -135,11 +213,12 @@ review is far more likely to reject them.
 ## Summary: what's automatic vs. gated vs. manual
 
 - **Fully automatic, every release:** zip artifacts (all platforms),
-  AppImage, `.dmg` (signed or unsigned), Windows installer (signed or
-  unsigned), GitHub Release creation and asset upload.
+  AppImage, `.dmg` (signed, self-signed, or unsigned), Windows installer
+  (signed or unsigned), GitHub Release creation and asset upload.
 - **Gated on secrets (automatic once configured):** Developer ID codesigning
-  + notarization/stapling for macOS, code signing for the Windows installer
-  and exe.
+  + notarization/stapling for macOS (tier 1), stable self-signed identity
+  for macOS (tier 2, the "tertius" pattern — no Apple Developer account
+  needed), code signing for the Windows installer and exe.
 - **Manual, one-time-per-version, by design (cannot be automated without
   publishing into third-party repos on the maintainer's behalf):**
   submitting the Homebrew cask and winget manifest PRs. Flathub packaging is

--- a/packaging/homebrew/pkhex-avalonia.rb
+++ b/packaging/homebrew/pkhex-avalonia.rb
@@ -23,6 +23,16 @@ cask "pkhex-avalonia" do
 
   app "PKHeX.Avalonia.app"
 
+  # Strip the quarantine bit Homebrew's own download adds so Gatekeeper
+  # doesn't prompt on first launch. Safe regardless of which signing tier
+  # produced the .dmg (Developer ID notarized, stable self-signed identity,
+  # or unsigned) — see the "tertius pattern" section in docs/packaging.md.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/PKHeX.Avalonia.app"],
+                   sudo: false
+  end
+
   zap trash: [
     "~/Library/Application Support/PKHeX.Avalonia",
     "~/Library/Preferences/io.pkhex.avalonia.plist",


### PR DESCRIPTION
## Summary

Ports the "tertius" macOS signing pattern (from teams-phonemanager) into PKHeX-Avalonia so users who update the app on macOS aren't re-prompted by Gatekeeper every time, without needing a paid Apple Developer ID.

**Mechanic:**
1. Every release's Mach-O binaries get signed with the **same self-signed identity**, so the codesign designated requirement stays stable across updates — keychain items and TCC grants (Accessibility, Full Disk Access, etc.) persist instead of resetting on every release.
2. The Homebrew cask postflight strips `com.apple.quarantine` outright, so `brew install --cask` never shows a Gatekeeper prompt at all.
3. Manual `.dmg`/`.zip` downloads still see Gatekeeper's "unidentified developer" prompt **once**, since the identity is self-signed, not notarized — documented with the one-time `xattr -dr com.apple.quarantine` workaround.

## Three-tier signing priority (`release.yml`, macOS legs)

| Tier | Trigger | Output | Notes |
|---|---|---|---|
| 1. Developer ID | `MACOS_CERT_P12` + `MACOS_SIGN_IDENTITY` + `APPLE_NOTARY_KEY` present | `PKHeX-Avalonia-osx-<arch>.dmg` | Unchanged — full sign + notarize + staple |
| 2. Self-signed (new) | `SELFSIGN_CERT_P12_BASE64` + `SELFSIGN_CERT_PASSWORD` + `SELFSIGN_IDENTITY` present | `PKHeX-Avalonia-osx-<arch>-selfsigned.dmg` | Stable identity, not notarized |
| 3. Unsigned | neither | `PKHeX-Avalonia-osx-<arch>-unsigned.dmg` | Unchanged |

## What the repo owner needs to do to turn tier 2 on

1. Run once, locally: `P12_PASSWORD='...' Scripts/make-signing-cert.sh ./secrets` — produces a 10-year self-signed EC cert (CN `PKHeX-Avalonia Self-Signed` by default) with the `codeSigning` EKU.
2. `base64 -i ./secrets/signing.p12 | pbcopy` and add as repo secret `SELFSIGN_CERT_P12_BASE64`.
3. Add `SELFSIGN_CERT_PASSWORD` (the password used above) and `SELFSIGN_IDENTITY` (the cert's CN) as secrets.
4. Keep the `.p12` + password somewhere durable outside the repo — regenerating the cert produces a *different* identity, which resets the whole stability guarantee.

CI imports the cert via `Scripts/import-cert.sh` (idempotent dedicated-keychain import, same pattern used locally) and re-signs `PKHeX.Avalonia.app`'s Mach-O binaries (`codesign --force --deep`) before `.dmg` creation.

## Files changed

- `Scripts/make-signing-cert.sh`, `Scripts/import-cert.sh` — new, adapted from teams-phonemanager
- `.github/workflows/release.yml` — adds the tier-2 self-sign gate/import/codesign steps and 3-way `.dmg` naming; Developer ID and unsigned paths untouched
- `packaging/homebrew/pkhex-avalonia.rb` — adds `postflight` quarantine-strip block
- `docs/packaging.md` — new "macOS: stable self-signed identity (the tertius pattern)" section: why it works, how to generate the cert, the 3 secrets, its limits, the manual `xattr` command
- `README.md` — one-line update to the download note reflecting the new tier
- `Directory.Build.props` — `UIVersion` 1.39.0 → 1.39.1 (release-infra change → patch)

## Suggested follow-up (not implemented here)

A future in-app self-updater that downloads and swaps `PKHeX.Avalonia.app` itself (rather than the user re-downloading a `.dmg`/`.zip` through the browser) would sidestep quarantine entirely — `HttpClient` downloads don't set the `com.apple.quarantine` xattr the way Finder/Safari downloads do. Natural phase 2 once this lands.

## Test plan

- [x] `dotnet build PKHeX.sln -c Release` — succeeds, 0 warnings/errors (unrelated to this change, sanity check only)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly
- [x] `bash -n` on both new scripts — syntax OK (shellcheck not available locally; scripts closely mirror the proven teams-phonemanager originals)
- [ ] Real signing flow needs to be exercised in CI once the repo owner adds the three `SELFSIGN_*` secrets (cannot be verified without them)