### PR TITLE
chore: add CLAUDE.md and commit .claude automation tooling

### DIFF
--- a/.claude/agents/architecture-boundary-reviewer.md
+++ b/.claude/agents/architecture-boundary-reviewer.md
@@ -1,0 +1,37 @@
+---
+name: architecture-boundary-reviewer
+description: Reviews a diff or PR in PKHeX-Avalonia for Clean Architecture layering violations — PKHeX.Core purity and cross-project reference direction. Use after implementing a feature or fix that touches more than one of the five projects (PKHeX.Core, PKHeX.Application, PKHeX.Infrastructure, PKHeX.Presentation, PKHeX.Avalonia), or before opening a PR that adds a new class/service/dependency.
+model: sonnet
+---
+
+You are a Clean Architecture boundary reviewer for PKHeX-Avalonia, a 5-project .NET solution. Your only job is checking that a diff respects the project's layering — you are not a general code reviewer, and you do not comment on style, naming, or business logic correctness.
+
+## The layering (verified from the .csproj files — treat as ground truth)
+
+```
+PKHeX.Core            → references nothing (vendored, upstream-mirrored)
+PKHeX.Application      → references PKHeX.Core only
+PKHeX.Infrastructure   → references PKHeX.Application, PKHeX.Core
+PKHeX.Presentation     → references PKHeX.Application, PKHeX.Core   (NOT Infrastructure)
+PKHeX.Avalonia (host)  → references all four (composition root)
+```
+
+If any `.csproj` diff changes these reference lists, that IS the finding — don't just check `.cs` files.
+
+## What to check, in order
+
+1. **PKHeX.Core purity.** Any diff touching `PKHeX.Core/**` is a violation UNLESS the branch matches `chore/sync-pkhex-core-*` (the upstream-sync workflow). `PKHeX.Core` must stay a byte-for-byte mirror of upstream `kwsch/PKHeX` — a fix that "just needs one line changed in Core" always belongs in a consumer layer instead.
+
+2. **Reference direction.** Flag any new `using PKHeX.X` where the current project isn't allowed to reference `X` per the diagram above. The two violations that actually happen in practice:
+   - `PKHeX.Presentation` code (a ViewModel) referencing `PKHeX.Infrastructure` or `PKHeX.Avalonia` types directly. Presentation should depend on `PKHeX.Application` abstractions, not concrete Infrastructure services, and must never reference Avalonia/View types (that's what `ViewLocator` in the host project is for).
+   - `PKHeX.Application` referencing anything outside `PKHeX.Core` — Application defines abstractions/use cases and must stay Avalonia- and Infrastructure-agnostic.
+
+3. **New or extended cross-cutting service.** If the diff adds a new interface + implementation pair, or adds members to an existing cross-project interface (e.g. a new method on `IWindowService`), confirm the interface lives in `PKHeX.Application/Abstractions` and the implementation lives in `PKHeX.Infrastructure` or the `PKHeX.Avalonia` host (matching the existing pattern) — not both in the same project, and not the interface in Infrastructure. This rule only applies to interfaces crossing a project boundary — an interface defined and implemented entirely within one project (e.g. a `PKHeX.Presentation`-internal navigator interface) is out of scope for this check.
+
+4. **ViewModel doing View work, or vice versa.** A `PKHeX.Presentation/ViewModels/*.cs` file should not reference Avalonia Controls/Views. A `PKHeX.Avalonia/Views/*.axaml.cs` code-behind should contain essentially nothing beyond `InitializeComponent()` — business logic there is a layering violation in spirit even if it compiles (View code-behind isn't unit-testable the way a ViewModel is).
+
+## Output format
+
+For each finding: file path, line if applicable, which rule it breaks, and the one-line fix (usually "move X to project Y" or "revert the Core edit and port the fix into Z instead"). If you find nothing, say so plainly — do not invent stylistic nitpicks to pad the review.
+
+Do not review anything outside architecture/layering. Correctness bugs, missing tests, naming, and UI/UX concerns are out of scope — leave those to other reviewers.

--- a/.claude/agents/xaml-mvvm-reviewer.md
+++ b/.claude/agents/xaml-mvvm-reviewer.md
@@ -1,0 +1,35 @@
+---
+name: xaml-mvvm-reviewer
+description: Reviews Avalonia .axaml views and their paired ViewModels in PKHeX-Avalonia for MVVM correctness — binding paths, compiled-binding setup, command wiring, and code-behind discipline. Use after adding or editing a View/ViewModel pair, before manually testing it in the running app.
+model: sonnet
+---
+
+You are an Avalonia MVVM reviewer for PKHeX-Avalonia. You review `.axaml` + `.axaml.cs` + the paired `PKHeX.Presentation/ViewModels/*.cs` file together as one unit — a binding bug is invisible in either file alone.
+
+## What this codebase's correct pattern looks like (verified from existing editors, e.g. `Misc4Editor`)
+
+- ViewModel: `partial class FooViewModel : ViewModelBase` (which is `ObservableObject`), fields via `[ObservableProperty]`, actions via `[RelayCommand]` (CommunityToolkit.Mvvm source generators) — never hand-written `INotifyPropertyChanged` boilerplate.
+- View: `x:DataType="vm:FooViewModel"` on the root element for compiled bindings, with the matching `xmlns:vm="clr-namespace:PKHeX.Presentation.ViewModels;assembly=PKHeX.Presentation"`.
+- Code-behind (`.axaml.cs`): constructor body is `InitializeComponent();` and nothing else. Any logic here is a smell — it belongs in the ViewModel.
+- New View/ViewModel pairs must be registered in `PKHeX.Avalonia/ViewLocator.cs`'s `Map` dictionary, or the dialog silently fails to resolve at runtime with no compile error.
+- Dialog commands on `MainWindowViewModel` follow `[RelayCommand(CanExecute = nameof(HasSave))]` + a `CurrentSave is not SAV<N> sav` type-guard, then `await _windowService.ShowDialogAsync(new FooViewModel(sav), "Title")`.
+
+## What to check
+
+1. **Binding path correctness.** Every `{Binding X}` in the `.axaml` must correspond to a public property or `[RelayCommand]`-generated command on the `x:DataType` ViewModel. With compiled bindings (the default here — `x:DataType` present on ~all views), a typo'd path is a **build-time error**, so if it compiles, paths are syntactically valid — but still check for the *wrong* property (e.g. bound to a property that never changes, or a stale name after a rename).
+
+2. **Missing `x:DataType`.** If a new View lacks `x:DataType`, bindings fall back to reflection (no compile-time safety, worse perf) — flag it and point to any sibling `.axaml` as the pattern to match.
+
+3. **`[ObservableProperty]` change notification.** If a property's setter needs to affect another computed property or command's `CanExecute`, confirm `[NotifyPropertyChangedFor(nameof(Other))]` / `[NotifyCanExecuteChangedFor(nameof(OtherCommand))]` is present — a common bug class here is a UI element that doesn't refresh because the dependency wasn't declared.
+
+4. **Command `CanExecute` wiring.** Every `[RelayCommand]` that shouldn't always be enabled needs a `CanExecute` — check it references a real, currently-true-or-false-returning member, not something that's always true.
+
+5. **Code-behind discipline.** Anything beyond `InitializeComponent()` in `.axaml.cs` — event handlers, data manipulation, direct Control access — is a violation. Note it even if functionally correct.
+
+6. **ViewLocator registration.** For a brand-new ViewModel type that is a dialog/view root, confirm a matching entry exists in `PKHeX.Avalonia/ViewLocator.cs`. This is the single most common "works in theory, throws at runtime" gap. Nested/composed sub-ViewModels (e.g. a filter or seek-state object owned by a parent ViewModel and bound via `{Binding Filter.X}`) are not view roots and don't need a `ViewLocator` entry — don't flag their absence.
+
+7. **Disposal/leak risk.** If the ViewModel subscribes to events, holds a reference to the save file, or starts anything long-lived, check there's a corresponding cleanup path (dialog close, `IDisposable`, or explicit unsubscribe) — Avalonia doesn't garbage-collect subscriptions for you. `WeakReferenceMessenger.Default.Register` (the established pattern in this codebase, e.g. for `LanguageChangedMessage`) counts as an acceptable cleanup-free pattern since it holds only a weak reference — don't flag it as a leak on that basis alone; still flag a strong-reference event subscription (`+=`) with no matching `-=`.
+
+## Output format
+
+For each finding: file path, line if applicable, what's wrong, and the concrete fix (e.g. "add `[NotifyCanExecuteChangedFor(nameof(SaveCommand))]` to `_isValid`"). If the View/ViewModel pair is clean, say so — don't manufacture nitpicks. Stay out of Clean Architecture layering concerns (that's `architecture-boundary-reviewer`'s job) and out of domain/business-logic correctness (that's for a general code reviewer).

--- a/.claude/hooks/block-core-edit.sh
+++ b/.claude/hooks/block-core-edit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse hook (Edit|Write|MultiEdit): PKHeX.Core must stay a 1:1 mirror of
+# upstream kwsch/PKHeX. Block edits to it except on a sync branch created by
+# the sync-upstream-core skill.
+f=$(jq -r '.tool_input.file_path // empty')
+
+case "$f" in
+  */PKHeX.Core/*|PKHeX.Core/*)
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    case "$branch" in
+      chore/sync-pkhex-core-*)
+        echo '{}'
+        ;;
+      *)
+        jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"PKHeX.Core must stay a byte-for-byte mirror of upstream kwsch/PKHeX — port the fix into PKHeX.Application/Infrastructure/Presentation/Avalonia instead. (Allowed on a chore/sync-pkhex-core-* branch during an upstream sync — see the sync-upstream-core skill.)"}}'
+        ;;
+    esac
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac

--- a/.claude/hooks/block-main-writes.sh
+++ b/.claude/hooks/block-main-writes.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# PreToolUse hook (Bash): block git commit/push while checked out on main.
+# Project convention is to always work in a branch and land changes via PR.
+cmd=$(jq -r '.tool_input.command // empty')
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+if [[ "$branch" == "main" ]] && echo "$cmd" | grep -qE '(^|&&|;|\|)[[:space:]]*git[[:space:]]+(commit|push)\b'; then
+  jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"Direct commits/pushes to main are blocked — create a feature branch and open a PR instead (project convention: no direct pushes to main)."}}'
+else
+  echo '{}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-core-edit.sh\"",
+            "statusMessage": "Checking PKHeX.Core boundary..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-main-writes.sh\"",
+            "statusMessage": "Checking branch..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/new-generation-editor/SKILL.md
+++ b/.claude/skills/new-generation-editor/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: new-generation-editor
+description: Use when adding a new generation-specific save-data editor (a "Misc Editor"-style dialog scoped to one SAV<N> type, e.g. coins/BP/flags/records) to PKHeX-Avalonia — scaffolds the View, ViewModel, ViewLocator entry, open-command, and menu wiring across the Clean Architecture layers.
+---
+
+# New Generation Editor
+
+## Overview
+
+PKHeX-Avalonia's generation-specific editors (`Misc3Editor`, `Misc4Editor`, `Misc7Editor`, `PokeathlonEditor`, etc.) all follow one wiring pattern across the Clean Architecture split. Missing any one of the 5 steps below leaves a dead command or an unreachable dialog — this happened for several existing `OpenMisc*Command`s, which have a ViewModel/View/ViewLocator entry but **no menu item**, so they're unreachable from the UI. Don't repeat that gap.
+
+## When to Use
+
+- Adding a dialog that edits fields specific to one generation/game family (e.g. "Gen 10 Ribbons", "Misc (Gen 10)").
+- NOT for fields that already have a cross-gen editor (Pokédex, Trainer Card, Box tools) — extend those instead.
+
+## The 5 Steps
+
+1. **ViewModel** — `PKHeX.Presentation/ViewModels/Misc<N>EditorViewModel.cs`
+   - `partial class`, inherits `ViewModelBase`, constructor takes the concrete save type (`SAV<N>`, not the base `SaveFile`).
+   - Read/write fields directly through `PKHeX.Core` APIs on that save object — no repository/service indirection needed for simple field editors.
+   - Use `[ObservableProperty]` for bound fields and `[RelayCommand]` for actions (CommunityToolkit.Mvvm source generators).
+   - Reference: [Misc4EditorViewModel.cs](../../../PKHeX.Presentation/ViewModels/Misc4EditorViewModel.cs)
+
+2. **View** — `PKHeX.Avalonia/Views/Misc<N>Editor.axaml` + `.axaml.cs`
+   - Code-behind is just `InitializeComponent()` in the constructor — no logic in code-behind.
+   - Reference: [Misc4Editor.axaml.cs](../../../PKHeX.Avalonia/Views/Misc4Editor.axaml.cs)
+
+3. **ViewLocator entry** — `PKHeX.Avalonia/ViewLocator.cs`
+   - Add `[typeof(Misc<N>EditorViewModel)] = () => new Misc<N>Editor(),` to the `Map` dictionary (alphabetical by key).
+   - This is the *only* place Views and ViewModels are coupled — Presentation never references Avalonia.
+
+4. **Open command** — `PKHeX.Presentation/ViewModels/MainWindowViewModel.EditorDialogs.cs`
+   ```csharp
+   [RelayCommand(CanExecute = nameof(HasSave))]
+   private async Task OpenMisc<N>Async()
+   {
+       if (CurrentSave is not SAV<N> sav) return;
+       await _windowService.ShowDialogAsync(
+           new Misc<N>EditorViewModel(sav),
+           "Misc Editor (Gen <N>)");
+   }
+   ```
+   The generation type-check (`CurrentSave is not SAV<N> sav`) is the guard — it's what makes the command safely bindable everywhere while only doing something for the right save type.
+
+5. **Menu entry** — `PKHeX.Avalonia/Views/MainWindow.axaml`, inside the relevant `<MenuItem Header="Gen <N>">` block:
+   ```xml
+   <MenuItem Header="Misc (Gen <N>)" Command="{Binding OpenMisc<N>Command}" />
+   ```
+   If a `Gen <N>` top-level menu doesn't exist yet (brand-new generation), add it as a sibling of the existing `<MenuItem Header="Gen <N-1>">` block, in generation order — match the indentation of its immediate neighbors, not the block above it (existing gen blocks are inconsistently indented; don't propagate that or "fix" it as a drive-by).
+
+   **Do not skip this step even though some existing `OpenMisc*Command`s lack it** — those are a known gap, not the pattern to follow.
+
+## Verifying
+
+- Build: `dotnet build PKHeX.sln -c Release`
+- Launch the app, load a save of the target generation, open the new menu item, confirm the dialog appears and fields round-trip (edit → save → reload).
+- Add a test alongside the existing `Misc<N>EditorTests.cs` files in `Tests/PKHeX.Avalonia.Tests/` if the editor has non-trivial field logic (bit-packed flags, checksums, etc.).
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| ViewModel constructor takes `SaveFile` instead of `SAV<N>` | Use the concrete type — the whole point is generation-specific fields only that type exposes |
+| Forgot the ViewLocator entry | Dialog throws/no-ops at runtime with no compile error — Presentation and Avalonia aren't statically linked here |
+| Forgot the menu entry (step 5) | Command exists and compiles but is unreachable from the UI — grep `Command="{Binding Open<Name>Command}"` across `.axaml` to confirm it's wired |
+| Logic in the View's code-behind | Keep code-behind to `InitializeComponent()`; put logic in the ViewModel |
+| Editing `PKHeX.Core` to add a helper for the new editor | Don't — `PKHeX.Core` must stay 1:1 with upstream. Put helpers in `PKHeX.Application`/`PKHeX.Presentation` instead |

--- a/.claude/skills/pr-checklist/SKILL.md
+++ b/.claude/skills/pr-checklist/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pr-checklist
+description: Use before opening a pull request in PKHeX-Avalonia, or when asked to check a branch/diff is PR-ready — verifies UIVersion was bumped correctly, no PKHeX.Core edits snuck in, and upstream UI changes have frontend-parity coverage.
+---
+
+# PR Checklist
+
+## Overview
+
+Three checks this repo needs on every PR that a clean `dotnet build` won't catch. Run all three before `gh pr create`.
+
+## The 3 Checks
+
+### 1. UIVersion bumped, by change type
+
+```bash
+git diff main...HEAD -- Directory.Build.props
+```
+
+- Any user-facing change (fix, feature, chore, dep bump) → `<UIVersion>` in `Directory.Build.props` must have moved.
+- The bump size follows SemVer **by change type**, not a flat +1:
+  - **MAJOR** — breaking changes
+  - **MINOR** — new editors/tools/capabilities
+  - **PATCH** — fixes, refactors, chores, dep bumps, routine `PKHeX.Core` syncs
+- The top-level `<Version>` (date-stamped, e.g. `26.05.05`) tracks upstream `PKHeX.Core` — do NOT bump that one; only `<UIVersion>`.
+- No diff to `Directory.Build.props` at all on a user-facing PR = missing bump, fix before opening.
+
+### 2. No PKHeX.Core edits (unless this is a sync PR)
+
+```bash
+git diff main...HEAD --stat -- PKHeX.Core/
+```
+
+- Expected output: empty.
+- `PKHeX.Core` must stay a byte-for-byte mirror of upstream `kwsch/PKHeX`. Any consumer-side fix belongs in `PKHeX.Application`/`PKHeX.Infrastructure`/`PKHeX.Presentation`/`PKHeX.Avalonia` instead.
+- Exception: PRs from the `sync-upstream-core` skill on a `chore/sync-pkhex-core-*` branch — those are expected to touch `PKHeX.Core`.
+
+### 3. Frontend-parity coverage (sync PRs only)
+
+Only applies when this PR is an upstream `PKHeX.Core` sync (branch `chore/sync-pkhex-core-*`):
+
+- Confirm the sync's Frontend Parity Review step ran — check the PR body/commit for a note on upstream's non-Core (WinForms UI) changes and whether they need Avalonia equivalents.
+- Any genuine gap should already be a tracked `frontend-parity`-labeled issue, not silently dropped.
+- See the `sync-upstream-core` skill for the full review process — this check only confirms it happened, it doesn't replace it.
+
+## Quick Reference
+
+| Check | Command | Pass condition |
+|---|---|---|
+| UIVersion bumped | `git diff main...HEAD -- Directory.Build.props` | `<UIVersion>` changed, by correct SemVer type |
+| No Core edits | `git diff main...HEAD --stat -- PKHeX.Core/` | Empty (unless sync PR) |
+| Frontend parity | Check PR body / `frontend-parity` issues | Reviewed if this is a sync PR |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| Bumping `<Version>` instead of `<UIVersion>` | `<Version>` mirrors upstream's date stamp — never hand-edit it outside a sync |
+| Flat +1 patch bump for a new feature | New editors/tools/capabilities are MINOR, not PATCH |
+| Editing `PKHeX.Core` to fix a compile error after an upstream change | Port the fix into the consuming layer instead — see the `sync-upstream-core` skill's "Core principle" |
+| Opening a sync PR without a Frontend Parity Review note | Re-run step 5 of `sync-upstream-core` before opening |

--- a/.claude/skills/sync-upstream-core/SKILL.md
+++ b/.claude/skills/sync-upstream-core/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: sync-upstream-core
+description: Use when a "PKHeX.Core Sync Required" issue is open (the daily auto-generated sync-labeled issue) and PKHeX.Core must be brought 1:1 with upstream kwsch/PKHeX, propagated to the Avalonia layer, version-bumped, and shipped as a merged PR. Keywords - PKHeX.Core sync, upstream sync, kwsch/PKHeX, last-synced-sha, UIVersion bump.
+---
+
+# Sync Upstream PKHeX.Core
+
+## Overview
+
+Brings the vendored `PKHeX.Core/` to **byte-for-byte parity** with upstream
+[kwsch/PKHeX](https://github.com/kwsch/PKHeX) at the SHA named in a `sync` issue,
+fixes any Avalonia-layer call sites the upstream change touched, **reviews upstream's
+non-Core (WinForms UI / sprite) changes for Avalonia frontend-parity gaps**, bumps the
+version, opens a PR, and **auto-merges once CI is green**.
+
+**Core principle:** `PKHeX.Core` is a 1:1 mirror of upstream. We never edit it to make
+things compile — upstream API changes are absorbed by editing **consumers only**.
+
+**Second principle:** a clean build proves nothing *broke* — it does **not** prove the
+Avalonia frontend gained the user-facing changes upstream made to its (WinForms) UI.
+Upstream is a WinForms app; this fork reimplements that UI in Avalonia, so a new upstream
+editor/field/sprite compiles fine here while being entirely absent from the app. Every sync
+therefore includes a **Frontend Parity Review** (step 5) that classifies upstream's non-Core
+changes and opens `frontend-parity` tracking issues for genuine gaps — without ever blocking
+the Core auto-merge.
+
+## When to Use
+
+- An open issue labeled `sync` titled `PKHeX.Core Sync Required ...` (auto-generated daily at 08:00 UTC).
+- User says "sync issue 87", "run the upstream sync", "adopt the latest PKHeX.Core".
+
+**Not for:** feature issues, bug reports, or anything without the `sync` label. This skill assumes the sync-issue shape.
+
+## Invocation
+
+Pass the issue number, or find it:
+
+```bash
+N="${1:-$(gh issue list --label sync --state open --json number --jq '.[0].number')}"
+```
+
+## Hard Rules (read before every run)
+
+1. **Never edit `PKHeX.Core/`** except by mirroring upstream. A build error is fixed in `PKHeX.Application` / `PKHeX.Presentation` / `PKHeX.Infrastructure` / `PKHeX.Avalonia` / `Tests` — never in Core. If a "fix" seems to need a Core edit, you've misdiagnosed.
+2. **No direct pushes to `main`.** Everything goes through the sync branch + PR.
+3. **Auto-merge is gated.** Merge only when ALL pass: `diff`=0, `dotnet build` clean, `dotnet test` green, **and CI green**. Any failure → stop, report, leave PR open.
+4. **Preserve fork-only fields** in `Directory.Build.props`: `Company/Authors/Copyright = Realgar` and `<UIVersion>`. Only the `<Version>` *value* mirrors upstream.
+5. **Use the full 40-char SHA** in `last-synced-sha.txt` (the daily checker compares it exactly).
+6. **Build-green ≠ feature-parity.** A passing build only means no consumer *broke*. Upstream UI/feature changes the Avalonia frontend should adopt are surfaced by the **Frontend Parity Review** (step 5) and tracked as separate `frontend-parity` issues — they never block the Core sync's auto-merge.
+
+## Workflow
+
+Track these as a TodoWrite checklist and stop at the first failed gate. (The Frontend Parity
+Review in step 5 is **not** a gate — it records findings and opens follow-up issues, never blocks.)
+
+### 1 — Preflight & parse
+
+```bash
+git switch main && git pull --ff-only
+git status --porcelain            # MUST be empty, else stop
+gh issue view "$N" --json title,labels,body   # MUST have the `sync` label, else stop
+# Authoritative latest SHA (don't trust body parsing):
+LATEST_SHA=$(gh api 'repos/kwsch/PKHeX/commits?path=PKHeX.Core&per_page=1' --jq '.[0].sha')
+SHORT="${LATEST_SHA:0:7}"
+```
+
+Read the issue body for the human-readable **commit list** and the **changed-files** summary — you'll reuse them in the PR.
+
+### 2 — Branch
+
+```bash
+git switch -c "chore/sync-pkhex-core-$SHORT"
+```
+
+### 3 — Mirror Core 1:1 and verify
+
+```bash
+rm -rf /tmp/pkhex-upstream && mkdir /tmp/pkhex-upstream && cd /tmp/pkhex-upstream
+git init -q && git remote add origin https://github.com/kwsch/PKHeX.git
+git sparse-checkout init --cone && git sparse-checkout set PKHeX.Core
+git fetch -q --depth 1 origin "$LATEST_SHA" && git checkout -q FETCH_HEAD
+cd - >/dev/null
+
+rsync -a --delete --exclude bin --exclude obj /tmp/pkhex-upstream/PKHeX.Core/ PKHeX.Core/
+diff -rq -x bin -x obj PKHeX.Core /tmp/pkhex-upstream/PKHeX.Core   # MUST print nothing
+```
+
+`diff` non-empty → the mirror failed; fix before continuing. (`rsync --delete` also removes
+files upstream deleted and adds new ones — note any in the PR.)
+
+### 4 — Build & propagate to the Avalonia layer
+
+```bash
+dotnet build PKHeX.sln -c Release
+```
+
+If it fails, the upstream commits renamed/changed a public API (e.g. `StatNature` → `StatAlignment`).
+Find and fix the call sites **outside Core**:
+
+```bash
+grep -rn "OldSymbol" PKHeX.Application PKHeX.Presentation PKHeX.Infrastructure PKHeX.Avalonia Tests
+```
+
+Re-build until **0 warnings, 0 errors**. Record what changed (or "None") for the PR's
+"Avalonia-layer changes (build)" section. This step only covers *build breakage* — whether the
+frontend should **gain** new user-facing behavior is the separate Frontend Parity Review (step 5).
+
+### 5 — Frontend Parity Review (not a gate)
+
+The clean build in step 4 only proves nothing *broke*. It does **not** prove the Avalonia frontend
+gained the user-facing changes upstream made to its **WinForms UI**. Review the non-Core changes in
+this sync's range and classify them — this is the step that catches "upstream added an editor / field /
+sprite set we now need in Avalonia too."
+
+```bash
+OLD_SHA=$(cat .github/upstream-sync/last-synced-sha.txt)   # still the PREVIOUS sha at this point (step 6 overwrites it)
+# Per-commit enumeration of non-Core touches. NOTE: the compare API's .files list is capped at 300
+# (and commits at 250) — unreliable for big ranges; iterate per commit, whose file list is complete:
+for sha in $(gh api "repos/kwsch/PKHeX/compare/$OLD_SHA...$LATEST_SHA" --jq '.commits[].sha'); do
+  n=$(gh api "repos/kwsch/PKHeX/commits/$sha" --jq '[.files[].filename|select(startswith("PKHeX.Core/")|not)]|length')
+  [ "$n" -gt 0 ] && echo "$sha  ${n} non-Core  $(gh api repos/kwsch/PKHeX/commits/$sha --jq '.commit.message|split("\n")[0]')"
+done
+```
+
+Look at `PKHeX.WinForms/**` (UI) and `PKHeX.Drawing.*` (sprite/asset additions). New **public** Core
+APIs that surface user-facing data also count (they usually imply a new field/control). The strongest
+gap signal is a **new UI file added upstream** — fetch it with a history-bearing clone:
+
+```bash
+# A blobless clone gives full history + path filtering without downloading every blob:
+git clone --filter=blob:none --no-checkout https://github.com/kwsch/PKHeX.git /tmp/pkhex-hist 2>/dev/null
+git -C /tmp/pkhex-hist log --diff-filter=A --name-only --format='' "$OLD_SHA..$LATEST_SHA" \
+    -- 'PKHeX.WinForms/**/*.cs' | grep -v '\.Designer\.cs$' | sort -u   # new forms/controls/editors
+```
+
+Classify each non-Core-touching commit, then cross-check `GAP` candidates against the existing
+Avalonia surface (`PKHeX.Avalonia/Views/*.axaml`, `PKHeX.Presentation/ViewModels/*`, `ViewLocator.cs`,
+`MainWindowViewModel.*.cs`):
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| Core-only | no non-Core files | none |
+| WinForms-internal | Designer regen, refactor, layout reflow, localization-only, bulk asset re-encode | none |
+| different-impl | a WinForms widget Avalonia builds differently (e.g. GDI `ExperienceBar` ↔ `NumericUpDown`) | note, none |
+| already-covered | Avalonia already has the equivalent | note where |
+| **GAP** | upstream added/changed user-facing behavior Avalonia lacks | track (below) |
+
+For each **GAP**: do **not** block the sync. Keep the sync PR pure (Core + version). Open a tracking
+issue labeled `frontend-parity` (create the label once with `gh label create frontend-parity`):
+
+```bash
+gh issue create --label frontend-parity \
+  --title "frontend-parity: <feature> (<upstream short sha>)" \
+  --body "Upstream <sha> added <what>. Core API: <type/SaveBlock>. Avalonia: suggest <XView>+<XViewModel>, wire in MainWindowViewModel.EditorDialogs.cs (gated <SAV type>), register in ViewLocator.cs."
+```
+
+Record the full classification in the PR body's **Frontend parity review** section (it replaces the
+old thin "Avalonia-layer changes: None" line). If the range has zero non-Core commits, say so explicitly.
+
+> Daily syncs are ~1–6 commits, so the per-commit loop is plenty. The blobless clone matters only for
+> large backfill windows where the compare-API caps bite.
+
+### 6 — Version housekeeping (`Directory.Build.props` + SHA file)
+
+```bash
+printf '%s\n' "$LATEST_SHA" > .github/upstream-sync/last-synced-sha.txt
+
+# UIVersion: +1 patch
+CUR=$(grep -oE '<UIVersion>[^<]+' Directory.Build.props | sed 's/<UIVersion>//')
+NEW=$(echo "$CUR" | awk -F. '{printf "%d.%d.%d",$1,$2,$3+1}')
+
+# <Version>: mirror upstream's value at this SHA (usually unchanged)
+UPVER=$(curl -s "https://raw.githubusercontent.com/kwsch/PKHeX/$LATEST_SHA/Directory.Build.props" \
+        | grep -oE '<Version>[^<]+' | sed 's/<Version>//')
+```
+
+Then **edit `Directory.Build.props`**: set `<UIVersion>` to `$NEW`; set `<Version>` to `$UPVER`
+**only if it differs** from the current value. Leave `Company/Authors/Copyright` untouched.
+
+### 7 — Verify (all three are gates)
+
+```bash
+dotnet build PKHeX.sln -c Release    # 0 warnings, 0 errors
+dotnet test  PKHeX.sln -c Release    # all pass
+diff -rq -x bin -x obj PKHeX.Core /tmp/pkhex-upstream/PKHeX.Core   # nothing => 1:1
+```
+
+### 8 — Commit, push, PR
+
+Commit in the established style (one sync commit; add a second `chore: align <Version>` commit
+only if `<Version>` changed):
+
+```bash
+git add -A
+git commit -m "sync: upstream PKHeX.Core to $SHORT and bump to $NEW" -m "<body: ported commits, consumer changes, housekeeping, Closes #$N>"
+git push -u origin "chore/sync-pkhex-core-$SHORT"
+```
+
+Fill `pr-template.md` (same directory) and open the PR — the body **must** contain `Closes #$N`:
+
+```bash
+gh pr create --title "sync: upstream PKHeX.Core to $SHORT + bump $NEW" --body-file /tmp/pr-body.md
+PR=$(gh pr view --json number --jq .number)
+```
+
+### 9 — Watch CI (non-blocking) → auto-merge
+
+**Do NOT foreground-wait** — the 3-OS matrix takes minutes and will blow the Bash timeout.
+Launch the watch as a **background** Bash command (`run_in_background: true`); the harness
+re-invokes you when it exits:
+
+```bash
+gh pr checks "$PR" --watch --fail-fast    # run_in_background: true
+```
+
+On completion:
+- **exit 0 (all green)** → merge and clean up:
+  ```bash
+  gh pr merge "$PR" --merge --delete-branch    # merge commit, matches history; Closes #N auto-closes the issue
+  git switch main && git pull --ff-only
+  ```
+- **non-zero (red/pending-fail)** → fetch the failing job log, **stop, report, leave PR open**:
+  ```bash
+  gh run view --log-failed -R realgarit/PKHeX-Avalonia "$(gh run list --branch "chore/sync-pkhex-core-$SHORT" --limit 1 --json databaseId --jq '.[0].databaseId')"
+  ```
+
+If `gh pr checks` errors with "no checks reported yet" right after PR creation, relaunch the
+same background watch after a short wait — checks take a moment to register.
+
+## Quick Reference
+
+| Thing | Value |
+|---|---|
+| Upstream | `kwsch/PKHeX`, folder `PKHeX.Core` |
+| Branch | `chore/sync-pkhex-core-<short7>` |
+| Version file | `Directory.Build.props` → `<UIVersion>` (+1 patch), `<Version>` (mirror upstream) |
+| SHA file | `.github/upstream-sync/last-synced-sha.txt` (full 40-char SHA) |
+| Build/test | `dotnet build/test PKHeX.sln -c Release` |
+| Merge | `gh pr merge <PR> --merge --delete-branch` |
+
+## Common Mistakes
+
+- **Editing `PKHeX.Core` to fix a build error** — fix the consumer call site instead; Core stays 1:1.
+- **Foreground-waiting on CI** — blocks for minutes and times out; use a background watch.
+- **Merging on red** — auto-merge is gated on green CI only.
+- **Squashing** — use `--merge`; the repo uses merge commits.
+- **Bumping `<Version>` blindly** — only when upstream's `<Version>` actually changed.
+- **Short SHA in `last-synced-sha.txt`** — must be the full 40-char SHA or the daily checker re-fires.
+- **Overwriting `Company/Authors/Copyright`** — those are fork-only; mirror just the `<Version>` value.
+- **Assuming a clean build means the frontend is current** — it only means nothing *broke*. New upstream WinForms editors/fields/sprites compile fine while being absent from the Avalonia app; run the Frontend Parity Review (step 5) every sync.
+- **Blocking the sync on a frontend gap** — the Core sync auto-merges on green CI; parity gaps become separate `frontend-parity` issues, never a merge blocker.

--- a/.claude/skills/sync-upstream-core/pr-template.md
+++ b/.claude/skills/sync-upstream-core/pr-template.md
@@ -1,0 +1,35 @@
+<!--
+PR body template for the sync-upstream-core skill.
+Fill every <PLACEHOLDER>, drop the "<Version>" line and the second commit if <Version> didn't change,
+write the filled result to /tmp/pr-body.md, then: gh pr create --body-file /tmp/pr-body.md
+-->
+## Summary
+
+Syncs `PKHeX.Core` 1:1 with upstream [kwsch/PKHeX](https://github.com/kwsch/PKHeX) from `<OLD_SHORT>` → [`<NEW_SHORT>`](https://github.com/kwsch/PKHeX/commit/<NEW_SHA>). Resolves #<ISSUE>.
+
+**<N> `PKHeX.Core` files** copied byte-identical from upstream (verified: `diff -rq` against the upstream tree = 0 differences).
+
+### Upstream commits ported
+<!-- one bullet per commit, newest first -->
+- [`<short>`](https://github.com/kwsch/PKHeX/commit/<sha>) — <message>
+
+### Avalonia-layer changes (build — consumers only, Core stays 1:1)
+<!-- "None — no consumer API changed." OR the list below -->
+- `<path/to/ConsumerFile.cs>` — <what changed, e.g. `pk.StatNature` → `pk.StatAlignment`>
+
+### Frontend parity review (step 5 — non-Core UI/sprite changes)
+<!-- Classify the non-Core commits in this range. "No non-Core commits in range." if empty. -->
+- Reviewed `<N>` non-Core commit(s): `<X>` WinForms-internal/cosmetic, `<Y>` different-impl, `<Z>` already-covered.
+- **Gaps tracked:** <none, OR `frontend-parity` issue links #__ , #__>
+
+### Housekeeping
+- `last-synced-sha.txt` → `<NEW_SHORT>`
+- `UIVersion` `<OLD_UI>` → `<NEW_UI>`
+- `<Version>` `<OLD_VER>` → `<NEW_VER>`  <!-- drop this line if unchanged -->
+
+## Verification
+- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
+- ✅ `dotnet test PKHeX.sln -c Release` — **<X> passed**, <Y> skipped, 0 failed
+- ✅ `PKHeX.Core` byte-identical to upstream `<NEW_SHORT>`
+
+Closes #<ISSUE>

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,9 @@ local.properties
 *.sln.docstates
 *.vs
 .vscode/
-.claude/
+.claude/worktrees/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Build results
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# PKHeX-Avalonia
+
+A native Avalonia (11.x) port of [PKHeX](https://github.com/kwsch/PKHeX), the Pokémon save editor —
+cross-platform (Windows/macOS/Linux) instead of WinForms-only.
+
+Development is AI-assisted (Claude Code), and this is now publicly disclosed. The `.claude/` directory
+in this repo is real, in-use automation (hooks, skills, subagents) — not decoration. Treat it as part
+of the project's tooling.
+
+## Hard Rules
+
+1. **`PKHeX.Core/` is a byte-for-byte upstream mirror** of kwsch/PKHeX. Never edit it manually to make
+   something compile — port the fix into the consumer layers (`PKHeX.Application`, `PKHeX.Infrastructure`,
+   `PKHeX.Presentation`, `PKHeX.Avalonia`) instead. The only exception is the `chore/sync-pkhex-core-*`
+   branch produced by the `sync-upstream-core` skill, which replaces `PKHeX.Core/` wholesale from upstream.
+2. **`PKHeX.AutoMod/` is vendored** (the Auto Legality Mod legalization engine from santacrab2/PKHeX-Plugins).
+   See `PKHeX.AutoMod/VENDORED.md` for the re-sync procedure — no `.cs` source edits under `AutoMod/` or
+   `Enhancements/`; if a Core sync breaks compilation, fix it there and log the change in that file.
+3. **No direct pushes to `main`.** Every change is a branch + PR. Enforced by `.claude/hooks/block-main-writes.sh`.
+4. **Bump `UIVersion`** in `Directory.Build.props` on every PR: `feat` → minor, `fix`/`chore`/`deps`/`refactor`
+   → patch, breaking → major.
+
+## Architecture
+
+Five-project Clean Architecture split (verified against the `.csproj` files):
+
+```
+PKHeX.Core            no project references (vendored, upstream mirror)
+PKHeX.Application      -> Core                                  (ports/abstractions, no UI deps)
+PKHeX.Infrastructure   -> Application, Core, AutoMod             (implementations)
+PKHeX.Presentation     -> Application, Core                      (Avalonia-free ViewModels)
+PKHeX.Avalonia         -> Core, Application, Infrastructure, Presentation   (host/composition root)
+PKHeX.AutoMod          -> Core                                   (vendored ALM engine)
+```
+
+Presentation depends on Application + Core only — it does **not** reference Infrastructure, so
+ViewModels stay free of both Avalonia and implementation details. Avalonia is the only project that
+references all four and is where DI wiring and Views live. This is enforced by
+`Tests/PKHeX.Architecture.Tests/LayerDependencyTests.cs` (NetArchTest-based).
+
+Two patterns to know:
+- **`ViewLocator`** (`PKHeX.Avalonia/ViewLocator.cs`) — the single place that maps a dialog ViewModel
+  type to its View, via a compile-checked dictionary. It lives in the host so Presentation never
+  references Views.
+- **`IWindowService.ShowTool`** (`PKHeX.Application/Abstractions/IWindowService.cs`) — opens a modeless
+  auxiliary tool window for panels that shouldn't crowd the main editor (e.g. batch search, box report).
+
+## Build / Test
+
+```
+dotnet build PKHeX.sln -c Release
+dotnet test PKHeX.sln -c Release
+```
+
+A clean build is expected to produce **0 warnings**. Test projects live under `Tests/`:
+`PKHeX.Core.Tests`, `PKHeX.Avalonia.Tests`, `PKHeX.Architecture.Tests`.
+
+## Guardrail Tests (fail a PR if ignored)
+
+- **`Tests/PKHeX.Avalonia.Tests/AccessibilityAuditTests.cs`** — regex-scans every `.axaml` view for
+  icon-only interactive controls (`Button`/`ToggleButton`/`RepeatButton` with no visible text) and
+  requires `AutomationProperties.Name`. Justified exceptions go in `accessibility-allowlist.txt` next
+  to the test.
+- **`Tests/PKHeX.Avalonia.Tests/LocalizationAuditTests.cs`** — regex-scans `.axaml` views and
+  ViewModels for hardcoded user-facing English string literals instead of `{loc:Loc Key}` /
+  `LocalizedStrings`. New/migrated files are enforced by default; the not-yet-migrated backlog is
+  listed in `localization-allowlist.txt`.
+- **`Tests/PKHeX.Architecture.Tests/LayerDependencyTests.cs`** — enforces the project reference
+  direction above (e.g. Application must not depend on Avalonia/Infrastructure/Presentation).
+
+## Localization
+
+Resource files live in `PKHeX.Presentation/Localization/Strings/` (`LocalizedStrings.cs` / `LocExtension.cs`
+drive lookup) with one JSON file per language: **9 languages** — `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`,
+`zh-Hans`, `zh-Hant`. Any new user-facing string needs a key added to **all 9** files, not just `en.json`.
+
+## Theming
+
+Theming is driven by `IThemeService` (`PKHeX.Application/Abstractions/IThemeService.cs`, `AppTheme` enum)
+and implemented in `PKHeX.Avalonia/Services/ThemeService.cs` using Avalonia's `ThemeVariant`/
+`ThemeDictionaries` APIs (`PKHeX.Avalonia/Styles/Theme.axaml`), including tracking the OS light/dark
+preference for the `System` option. Covered by `Tests/PKHeX.Avalonia.Tests/ThemeTests.cs`.
+
+## Upstream Sync Automation
+
+A daily workflow checks kwsch/PKHeX against `.github/upstream-sync/last-synced-sha.txt` and opens a
+`PKHeX.Core Sync Required` issue (labeled `sync`) when upstream has moved. The full sync process —
+mirroring Core 1:1, fixing consumer call sites, an Avalonia frontend-parity review of upstream's
+WinForms UI changes, version bump, PR, and auto-merge once CI is green — is encoded in
+`.claude/skills/sync-upstream-core/SKILL.md`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.39.1</UIVersion>
+    <UIVersion>1.39.2</UIVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Development on this fork has been publicly disclosed as AI-assisted (Claude Code). This PR commits the local `.claude/` automation tooling that already drives the day-to-day workflow, and adds a root `CLAUDE.md` documenting project conventions for AI-assisted development.

### Now included in `.claude/`
- `agents/architecture-boundary-reviewer.md` — reviews diffs for Clean Architecture layering violations
- `agents/xaml-mvvm-reviewer.md` — reviews Avalonia View/ViewModel pairs for MVVM correctness
- `hooks/block-core-edit.sh` — blocks manual edits to `PKHeX.Core/` outside the sync branch
- `hooks/block-main-writes.sh` — blocks direct writes/pushes to `main`
- `settings.json` — hook wiring and tool permissions
- `skills/new-generation-editor/SKILL.md` — scaffolds a new generation-specific save editor
- `skills/pr-checklist/SKILL.md` — pre-PR checklist (UIVersion bump, no stray Core edits, frontend parity)
- `skills/sync-upstream-core/SKILL.md` + `pr-template.md` — end-to-end PKHeX.Core upstream sync workflow

### Excluded (local/runtime/user-specific, stay gitignored)
- `.claude/worktrees/` — sibling git worktree trees, not portable content
- `.claude/settings.local.json` — user-specific overrides (doesn't currently exist, kept ignored for the future)
- `.claude/scheduled_tasks.lock` — runtime lock file with a live sessionId/pid, never safe to commit

`.gitignore` was updated to replace the single blanket `.claude/` ignore with these three targeted rules so the rest of `.claude/` is now tracked.

### Root `CLAUDE.md`
Summarizes: the hard rules (Core is a 1:1 upstream mirror, AutoMod is vendored, no direct pushes to main, UIVersion bump convention), the 5-project Clean Architecture layering (verified against the `.csproj` files), the `ViewLocator` and `IWindowService.ShowTool` patterns, build/test commands, the three guardrail test suites (accessibility, localization, architecture layering) and where they live, localization conventions (9 languages, add-key-to-all-files rule), theming (`IThemeService`/`ThemeService`), and the upstream sync automation.

Also bumps `UIVersion` 1.39.1 → 1.39.2 (chore/patch) per repo convention.

## Test plan
- [x] `dotnet build PKHeX.sln -c Release` — succeeds, 0 warnings, 0 errors
- [x] Secret scan (`grep -iE 'token|api[_-]?key|password|realgar@|/Users/realgar'`) over the staged diff — no matches
- [x] Hook scripts retain the executable bit (`100755`) after being committed