### PR TITLE
fix: restore box slot click hit-testing after drag-drop rework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.40.0</UIVersion>
+    <UIVersion>1.40.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Styles/Theme.axaml
+++ b/PKHeX.Avalonia/Styles/Theme.axaml
@@ -346,11 +346,15 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate x:DataType="models:SlotData">
-                <!-- Hit-test-transparent: Avalonia's drag/drop target resolution requires
-                     DragDrop.AllowDrop on the exact innermost hit-test-visible element. AllowDrop
-                     is set on the Button itself (see BoxViewer.axaml), so the template's visuals
-                     must not intercept hit-testing, letting the Button's own bounds win instead. -->
-                <Panel IsHitTestVisible="False">
+                <!-- Root MUST stay hit-test-visible with a non-null fill (Transparent counts) so a
+                     pointer press/release anywhere in the slot resolves to this Button and its Click
+                     fires. A templated Button has no independent hittable surface: if the template
+                     root is IsHitTestVisible="False" the Button's entire visual subtree is excluded
+                     from hit-testing and every click (and drop) dies. Drop targeting still works —
+                     Avalonia walks UP from the hit element to the nearest DragDrop.AllowDrop, which
+                     is this Button (see BoxViewer.axaml); the sprite content Panel is kept
+                     IsHitTestVisible="False" only so hits resolve here rather than to the Image. -->
+                <Panel Background="Transparent">
                     <Border Name="PART_Border"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"

--- a/PKHeX.Avalonia/Views/PartyViewer.axaml
+++ b/PKHeX.Avalonia/Views/PartyViewer.axaml
@@ -79,18 +79,21 @@
                                         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
                                         <Setter Property="BorderThickness" Value="1" />
                                         <Setter Property="CornerRadius" Value="8" />
-                                        <!-- Local template (replacing Fluent's default) whose Border/ContentPresenter
-                                             are hit-test-transparent, so DragDrop hit-testing resolves to the Button
-                                             itself (which carries DragDrop.AllowDrop) instead of being swallowed by
-                                             the template's own Border. -->
+                                        <!-- Local template (replacing Fluent's default). PART_Border MUST stay
+                                             hit-test-visible with a non-null Background so a pointer press/release
+                                             resolves to this Button and its Click fires; a templated Button has no
+                                             hittable surface of its own, so an IsHitTestVisible="False" root excludes
+                                             the whole subtree from hit-testing and kills clicks (and drops). Drop
+                                             targeting still works: Avalonia walks UP from the hit element to the
+                                             nearest DragDrop.AllowDrop (this Button). The card content Panel below is
+                                             kept IsHitTestVisible="False" only so hits resolve here, not to the sprite. -->
                                         <Setter Property="Template">
                                             <ControlTemplate>
                                                 <Border Name="PART_Border"
                                                         Background="{TemplateBinding Background}"
                                                         BorderBrush="{TemplateBinding BorderBrush}"
                                                         BorderThickness="{TemplateBinding BorderThickness}"
-                                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                                        IsHitTestVisible="False">
+                                                        CornerRadius="{TemplateBinding CornerRadius}">
                                                     <ContentPresenter Name="PART_ContentPresenter"
                                                                       Content="{TemplateBinding Content}"
                                                                       ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/Tests/PKHeX.Avalonia.Tests/SlotClickHitTestTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SlotClickHitTestTests.cs
@@ -1,0 +1,102 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Moq;
+using PKHeX.Avalonia.Services;
+using PKHeX.Avalonia.Views;
+using PKHeX.Core;
+using PKHeX.Presentation.Models;
+using PKHeX.Presentation.ViewModels;
+using Xunit.Abstractions;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Behavioral (headless, real layout + real hit-testing) regression guard for the box/party slot
+/// click that PR #169 broke. The slot Button's ControlTemplate (Theme.axaml Button.slot for boxes,
+/// the local template in PartyViewer.axaml for party) must have a hit-test-visible root carrying a
+/// non-null Background so a pointer press/release inside the slot resolves to the Button and its
+/// Click fires. PR #169 set the template root <c>IsHitTestVisible="False"</c>, which excluded the
+/// Button's entire visual subtree from hit-testing, killing every slot click (and, since drop
+/// resolution walks up from the hit element, drops too).
+///
+/// These tests simulate a real mouse press/release at the slot's on-screen center via
+/// Avalonia.Headless input and assert the ViewModel selection actually moves — which only happens
+/// if the click routed through hit-testing to the Button. With the defect present the click lands
+/// on the non-hittable subtree, the Button never fires, and the assertion fails.
+/// </summary>
+public class SlotClickHitTestTests(ITestOutputHelper output)
+{
+    private static Mock<ISpriteRenderer> SpriteMock() => new();
+
+    [AvaloniaFact]
+    public void BoxViewer_ClickingFilledSlot_RoutesToButton_AndSelectsSlot()
+    {
+        const int targetSlot = 3; // not the default-selected slot 0, so a real change is observable
+
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 25 }, targetSlot); // Pikachu in box 0, slot 3
+        var vm = new BoxViewerViewModel(sav, SpriteMock().Object);
+        var view = new BoxViewer { DataContext = vm };
+
+        var window = new Window { Content = view, Width = 720, Height = 640 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, vm.SelectedIndex); // baseline
+
+        var button = view.GetVisualDescendants()
+            .OfType<Button>()
+            .First(b => b.Tag is SlotData sd && sd.Slot == targetSlot);
+
+        ClickCenter(window, button);
+
+        Assert.True(button.Bounds.Width > 0 && button.Bounds.Height > 0,
+            "Slot button was not laid out; the test setup, not the fix, is at fault.");
+        Assert.Equal(targetSlot, vm.SelectedIndex);
+        Assert.True(vm.Slots[targetSlot].IsSelected, "Clicked slot should be selected.");
+        output.WriteLine($"BoxViewer: click at slot {targetSlot} center routed to Button, SelectedIndex={vm.SelectedIndex} ✓");
+    }
+
+    [AvaloniaFact]
+    public void PartyViewer_ClickingSlot_RoutesToButton_AndSelectsSlot()
+    {
+        const int targetSlot = 2;
+
+        var sav = new SAV6XY();
+        var vm = new PartyViewerViewModel(sav, SpriteMock().Object);
+        var view = new PartyViewer { DataContext = vm };
+
+        var window = new Window { Content = view, Width = 520, Height = 640 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(0, vm.SelectedIndex);
+
+        var button = view.GetVisualDescendants()
+            .OfType<Button>()
+            .First(b => b.Tag is PartySlotData sd && sd.Slot == targetSlot);
+
+        ClickCenter(window, button);
+
+        Assert.True(button.Bounds.Width > 0 && button.Bounds.Height > 0,
+            "Slot button was not laid out; the test setup, not the fix, is at fault.");
+        Assert.Equal(targetSlot, vm.SelectedIndex);
+        Assert.True(vm.Slots[targetSlot].IsSelected, "Clicked slot should be selected.");
+        output.WriteLine($"PartyViewer: click at slot {targetSlot} center routed to Button, SelectedIndex={vm.SelectedIndex} ✓");
+    }
+
+    private static void ClickCenter(Window window, Control target)
+    {
+        var center = target.TranslatePoint(
+            new Point(target.Bounds.Width / 2, target.Bounds.Height / 2), window);
+        Assert.NotNull(center);
+        window.MouseDown(center.Value, MouseButton.Left);
+        window.MouseUp(center.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/SlotDragDropWiringTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SlotDragDropWiringTests.cs
@@ -12,8 +12,8 @@ namespace PKHeX.Avalonia.Tests;
 ///    swallow the hit before it reaches the AllowDrop Button.
 ///  - PokemonEditor's AllowDrop lives on the inner Border (not the root UserControl).
 ///  - DragDrop.DragOver handlers are wired for drop-cursor feedback.
-/// This is a static-source check, not a rendered/headless behavioral test — full drag/drop
-/// verification happens by hand in a published .app (see PR description).
+/// This is a static-source check; the behavioral counterpart (real layout + hit-testing that a slot
+/// click routes to the Button) lives in <see cref="SlotClickHitTestTests"/>.
 /// </summary>
 public class SlotDragDropWiringTests(ITestOutputHelper output)
 {
@@ -41,16 +41,24 @@ public class SlotDragDropWiringTests(ITestOutputHelper output)
         Assert.Contains("DragDrop.Drop=\"OnSlotDrop\"", xml);
         Assert.Contains("DragDrop.DragOver=\"OnSlotDragOver\"", xml);
 
-        // The local Button template's Border root must be hit-test-transparent (Fluent's default
-        // Button template has its own opaque Border that would otherwise swallow the hit before
-        // it reaches the Button element that actually carries AllowDrop).
+        // The local Button template's PART_Border root must stay hit-test-VISIBLE (it carries the
+        // Button's Background), otherwise the Button's whole visual subtree is excluded from
+        // hit-testing and clicks/drops die. Regression guard for PR #169, which had set it
+        // IsHitTestVisible="False". Drop targeting still resolves because Avalonia walks up from the
+        // hit element to the Button's DragDrop.AllowDrop.
         Assert.Contains("<Border Name=\"PART_Border\"", xml);
-        Assert.Contains("IsHitTestVisible=\"False\"", xml);
-        output.WriteLine("PartyViewer.axaml: slot Button carries AllowDrop/Drop/DragOver, local template root is hit-test-transparent ✓");
+        var partBorderIndex = xml.IndexOf("<Border Name=\"PART_Border\"", StringComparison.Ordinal);
+        var partBorderTag = xml[partBorderIndex..xml.IndexOf('>', partBorderIndex)];
+        Assert.DoesNotContain("IsHitTestVisible=\"False\"", partBorderTag);
+
+        // The card content Panel (sprite + overlays) stays hit-test-transparent so hits resolve to
+        // the Button, not the Image.
+        Assert.Contains("<Panel IsHitTestVisible=\"False\">", xml);
+        output.WriteLine("PartyViewer.axaml: slot Button carries AllowDrop/Drop/DragOver, PART_Border root is hit-testable, content Panel is hit-test-transparent ✓");
     }
 
     [Fact]
-    public void BoxViewer_SlotTemplate_InThemeAxaml_HasTransparentRoot()
+    public void BoxViewer_SlotTemplate_InThemeAxaml_HasHitTestableRoot()
     {
         var repoRoot = FindRepoRoot();
         var themePath = Path.Combine(repoRoot, "PKHeX.Avalonia", "Styles", "Theme.axaml");
@@ -59,9 +67,14 @@ public class SlotDragDropWiringTests(ITestOutputHelper output)
         var styleIndex = xml.IndexOf("Selector=\"Button.slot\"", StringComparison.Ordinal);
         Assert.True(styleIndex >= 0, "Expected a Button.slot style in Theme.axaml.");
 
-        var templateSlice = xml[styleIndex..Math.Min(xml.Length, styleIndex + 1500)];
-        Assert.Contains("<Panel IsHitTestVisible=\"False\">", templateSlice);
-        output.WriteLine("Theme.axaml: Button.slot template root Panel is hit-test-transparent ✓");
+        var templateSlice = xml[styleIndex..Math.Min(xml.Length, styleIndex + 2000)];
+        // The template root Panel must stay hit-test-VISIBLE with a non-null fill (Transparent
+        // counts). A templated Button has no hittable surface of its own, so a non-hittable root
+        // excludes the entire subtree from hit-testing and kills every slot click (and drop).
+        // Regression guard for PR #169, which had set the root <Panel IsHitTestVisible="False">.
+        Assert.Contains("<Panel Background=\"Transparent\">", templateSlice);
+        Assert.DoesNotContain("<Panel IsHitTestVisible=\"False\">", templateSlice);
+        output.WriteLine("Theme.axaml: Button.slot template root Panel is hit-testable (Transparent fill) ✓");
     }
 
     [Fact]


### PR DESCRIPTION
Hotfix for a regression introduced by PR #169: box and party slot clicks stopped working ("I can't click anything inside the box").

## Root cause
PR #169's drag-drop rework set the slot Button's ControlTemplate root `IsHitTestVisible="False"` (Theme.axaml `Button.slot` for box slots; the local Button template in PartyViewer.axaml for party slots), on the theory it would let "the Button's own bounds win" for DragDrop target resolution. But a templated Button has no independent hittable surface — it is hit-tested through its template. Marking the template root non-hittable excluded the Button's entire visual subtree from hit-testing, so pointer presses inside a slot never reached the Button: every slot click (and, since drop resolution walks up from the hit element, every drop) died.

## Fix
The template root stays hit-test-visible with a non-null fill: Theme.axaml `Button.slot` root Panel → `Background="Transparent"`; PartyViewer local template → removed `IsHitTestVisible="False"` from `PART_Border` (it already carries the Button's Background). The sprite/overlay content Panels keep `IsHitTestVisible="False"` so hits resolve to the Button, preserving PR #169's drop design (AllowDrop on the Button; drop resolution walks up to it). PokemonEditor unaffected — its AllowDrop Border already has a real Background.

## Verification (headless — real Avalonia layout + hit-testing, no screen automation)
- New `SlotClickHitTestTests` host the real BoxViewer/PartyViewer with the real Theme.axaml styles and simulate a real mouse press/release at a slot's on-screen center through the actual input pipeline, asserting ViewModel selection moves. **They fail on pre-fix code (SelectedIndex stays 0) and pass after the fix** — confirmed repro and regression guard.
- Rewrote the two `SlotDragDropWiringTests` structural checks that had codified the buggy non-hittable root to assert hit-testability instead.
- Full build: 0 warnings. Full suite: all green (Core 449, Architecture 5, Avalonia 2163).

UIVersion 1.40.0 → 1.40.1 (fix → patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)