### PR TITLE
fix: Gen V nature not persisting when overwriting (#168)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.41.1</UIVersion>
+    <UIVersion>1.41.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -480,8 +480,8 @@ public partial class PokemonEditorViewModel : ViewModelBase
         _pk.Form = (byte)Form;
         _pk.Nickname = Nickname;
         _pk.Stat_Level = (byte)Level;
-        _pk.Nature = (Nature)Nature;
         _pk.StatAlignment = (Nature)StatAlignment;
+        _pk.Nature = (Nature)Nature;
         _pk.Ability = Ability;
         _pk.HeldItem = HeldItem;
         _pk.Ball = (byte)Ball;


### PR DESCRIPTION
## Summary

Fixes Gen V nature changes not persisting when overwriting a Pokémon.

### Root Cause

In `PreparePKM()`, the order of operations was:
```csharp
_pk.Nature = (Nature)Nature;           // ✅ Sets Nature to user's choice
_pk.StatAlignment = (Nature)StatAlignment;  // ❌ Overwrites it back to old value!
```

For Gen V (and all formats < Gen 8), the base `PKM.StatAlignment` setter is simply an alias:
```csharp
public virtual Nature StatAlignment { get => Nature; set => Nature = value; }
```

Since the `StatAlignment` UI control is hidden for Gen V+ (`ShowStatAlignment => _pk.Format >= 8`), the ViewModel's `StatAlignment` property retains its **original load value**, and writing it second overwrites the user's nature selection.

### Fix

Swap the order: set `StatAlignment` first, `Nature` second. This way the user's explicit nature choice is the final value written.

### Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2420 passed, 0 failed
- ✅ Fix is in consumer layer (PKHeX.Presentation), Core untouched

Fixes #168