### PR TITLE
fix: EXP and level not kept in sync in Pokémon editor (#165)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.41.2</UIVersion>
+    <UIVersion>1.41.3</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Misc.cs
@@ -130,6 +130,7 @@ public partial class PokemonEditorViewModel
 
     // EXP & Friendship
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Level), nameof(ExpPercent))]
     private long _exp;
 
     [ObservableProperty]
@@ -146,7 +147,9 @@ public partial class PokemonEditorViewModel
     partial void OnExpChanged(long value)
     {
         if (_isLoading) return;
-        OnPropertyChanged(nameof(ExpPercent));
+        var newLevel = Experience.GetLevel((uint)value, _pk.PersonalInfo.EXPGrowth);
+        if (Level != newLevel)
+            Level = newLevel;
     }
 
     /// <summary>

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -67,7 +67,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
     private string _nickname = string.Empty;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(Title), nameof(Stat_HP), nameof(Stat_ATK), nameof(Stat_DEF), nameof(Stat_SPA), nameof(Stat_SPD), nameof(Stat_SPE))]
+    [NotifyPropertyChangedFor(nameof(Title), nameof(Stat_HP), nameof(Stat_ATK), nameof(Stat_DEF), nameof(Stat_SPA), nameof(Stat_SPD), nameof(Stat_SPE), nameof(Exp), nameof(ExpPercent))]
     private int _level;
 
     [ObservableProperty]
@@ -408,7 +408,7 @@ public partial class PokemonEditorViewModel : ViewModelBase
     }
 
     partial void OnNicknameChanged(string value) { if (!_isLoading) Validate(); }
-    partial void OnLevelChanged(int value) { if (!_isLoading) { RecalculateStats(); OnPropertyChanged(nameof(ExpPercent)); Validate(); } }
+    partial void OnLevelChanged(int value) { if (!_isLoading) { Exp = Experience.GetEXP((byte)value, _pk.PersonalInfo.EXPGrowth); RecalculateStats(); Validate(); } }
     partial void OnNatureChanged(int value) { if (!_isLoading) { RecalculateStats(); Validate(); } }
     partial void OnAbilityChanged(int value) { if (!_isLoading) Validate(); }
     partial void OnHeldItemChanged(int value) { if (!_isLoading) Validate(); }


### PR DESCRIPTION
## Summary

Fixes EXP and Level not staying in sync in the Pokémon editor. In upstream PKHeX, editing EXP updates the level and editing the level snaps EXP to the minimum for that level — this PR ports that behavior to the Avalonia layer.

### Changes

**PokemonEditorViewModel.cs** (3 lines):
- `Level` property: added `nameof(Exp)` and `nameof(ExpPercent)` to `NotifyPropertyChangedFor`
- `OnLevelChanged`: replaced manual `OnPropertyChanged(nameof(ExpPercent))` with `Exp = Experience.GetEXP((byte)value, _pk.PersonalInfo.EXPGrowth)` — setting level now snaps EXP to min for that level

**PokemonEditorViewModel.Misc.cs** (4 lines):
- `Exp` property: added `[NotifyPropertyChangedFor(nameof(Level), nameof(ExpPercent))]`
- `OnExpChanged`: now recalculates `Level` via `Experience.GetLevel()` when EXP changes (with guard against feedback loop via the existing `_isLoading` pattern)

### Design notes
- Level is treated as derived from EXP, matching upstream Core behavior (`PKM.CurrentLevel` getter computes from EXP)
- Both changes use `PKHeX.Core.Experience` utility methods directly
- The `_isLoading` flag prevents feedback loops when properties cross-notify

### Verification
- ✅ `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- ✅ `dotnet test PKHeX.sln -c Release` — 2420 passed, 0 failed

Fixes #165