### PR TITLE
feat: expose PID with re-roll button in Pokémon editor (#164)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.41.3</UIVersion>
+    <UIVersion>1.41.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -590,7 +590,13 @@
                                     <UniformGrid Columns="2">
                                         <StackPanel Margin="0,0,4,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Pid}" FontWeight="SemiBold" Margin="0,0,0,4" />
-                                            <TextBox Text="{Binding Pid}" FontFamily="Consolas" Height="32" VerticalContentAlignment="Center" />
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBox Grid.Column="0" Text="{Binding Pid}" FontFamily="Consolas" Height="32" VerticalContentAlignment="Center" Margin="0,0,4,0" />
+                                                <Button Grid.Column="1" Command="{Binding RerollPidCommand}" Content="🎲" Width="34" Height="32"
+                                                        FontSize="12" Padding="0"
+                                                        ToolTip.Tip="{loc:Loc PokemonEditor_RerollPidTooltip}"
+                                                        AutomationProperties.Name="Re-roll PID" />
+                                            </Grid>
                                         </StackPanel>
                                         <StackPanel Margin="4,0,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Ec}" FontWeight="SemiBold" Margin="0,0,0,4" />

--- a/PKHeX.Presentation/Localization/Strings/de.json
+++ b/PKHeX.Presentation/Localization/Strings/de.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "Der Download hat die Überprüfung nicht bestanden und wurde verworfen.",
   "Update_Error_NeedsAdmin": "Die Aktualisierung dieser Installation erfordert Administratorrechte. Die Download-Seite wird stattdessen geöffnet.",
   "Update_Error_SwapFailed": "Das Update konnte nicht angewendet werden. Ihre aktuelle Version ist unverändert.",
-  "Update_Error_Generic": "Das Update konnte nicht abgeschlossen werden: {0}"
+  "Update_Error_Generic": "Das Update konnte nicht abgeschlossen werden: {0}",
+  "PokemonEditor_RerollPidTooltip": "PID neu würfeln"
 }

--- a/PKHeX.Presentation/Localization/Strings/en.json
+++ b/PKHeX.Presentation/Localization/Strings/en.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "The download failed verification and was discarded.",
   "Update_Error_NeedsAdmin": "Updating this install needs administrator rights. Opening the download page instead.",
   "Update_Error_SwapFailed": "The update could not be applied. Your current version is unchanged.",
-  "Update_Error_Generic": "The update could not be completed: {0}"
+  "Update_Error_Generic": "The update could not be completed: {0}",
+  "PokemonEditor_RerollPidTooltip": "Re-roll PID"
 }

--- a/PKHeX.Presentation/Localization/Strings/es.json
+++ b/PKHeX.Presentation/Localization/Strings/es.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "La descarga no superó la verificación y fue descartada.",
   "Update_Error_NeedsAdmin": "Actualizar esta instalación requiere permisos de administrador. Se abrirá la página de descarga en su lugar.",
   "Update_Error_SwapFailed": "No se pudo aplicar la actualización. Su versión actual no ha cambiado.",
-  "Update_Error_Generic": "No se pudo completar la actualización: {0}"
+  "Update_Error_Generic": "No se pudo completar la actualización: {0}",
+  "PokemonEditor_RerollPidTooltip": "Volver a generar PID"
 }

--- a/PKHeX.Presentation/Localization/Strings/fr.json
+++ b/PKHeX.Presentation/Localization/Strings/fr.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "Le téléchargement a échoué à la vérification et a été supprimé.",
   "Update_Error_NeedsAdmin": "La mise à jour de cette installation nécessite des droits d'administrateur. Ouverture de la page de téléchargement à la place.",
   "Update_Error_SwapFailed": "La mise à jour n'a pas pu être appliquée. Votre version actuelle est inchangée.",
-  "Update_Error_Generic": "La mise à jour n'a pas pu être terminée : {0}"
+  "Update_Error_Generic": "La mise à jour n'a pas pu être terminée : {0}",
+  "PokemonEditor_RerollPidTooltip": "Re-générer le PID"
 }

--- a/PKHeX.Presentation/Localization/Strings/it.json
+++ b/PKHeX.Presentation/Localization/Strings/it.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "Il download non ha superato la verifica ed è stato eliminato.",
   "Update_Error_NeedsAdmin": "L'aggiornamento di questa installazione richiede diritti di amministratore. Verrà aperta invece la pagina di download.",
   "Update_Error_SwapFailed": "Impossibile applicare l'aggiornamento. La versione attuale non è cambiata.",
-  "Update_Error_Generic": "Impossibile completare l'aggiornamento: {0}"
+  "Update_Error_Generic": "Impossibile completare l'aggiornamento: {0}",
+  "PokemonEditor_RerollPidTooltip": "Rigenera PID"
 }

--- a/PKHeX.Presentation/Localization/Strings/ja.json
+++ b/PKHeX.Presentation/Localization/Strings/ja.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "ダウンロードの検証に失敗したため破棄されました。",
   "Update_Error_NeedsAdmin": "このインストールを更新するには管理者権限が必要です。代わりにダウンロードページを開きます。",
   "Update_Error_SwapFailed": "アップデートを適用できませんでした。現在のバージョンは変更されていません。",
-  "Update_Error_Generic": "アップデートを完了できませんでした: {0}"
+  "Update_Error_Generic": "アップデートを完了できませんでした: {0}",
+  "PokemonEditor_RerollPidTooltip": "PIDを再生成"
 }

--- a/PKHeX.Presentation/Localization/Strings/ko.json
+++ b/PKHeX.Presentation/Localization/Strings/ko.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "다운로드가 검증에 실패하여 삭제되었습니다.",
   "Update_Error_NeedsAdmin": "이 설치를 업데이트하려면 관리자 권한이 필요합니다. 대신 다운로드 페이지를 엽니다.",
   "Update_Error_SwapFailed": "업데이트를 적용할 수 없습니다. 현재 버전은 변경되지 않았습니다.",
-  "Update_Error_Generic": "업데이트를 완료할 수 없습니다: {0}"
+  "Update_Error_Generic": "업데이트를 완료할 수 없습니다: {0}",
+  "PokemonEditor_RerollPidTooltip": "PID 재생성"
 }

--- a/PKHeX.Presentation/Localization/Strings/zh-Hans.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hans.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "下载未通过验证，已被丢弃。",
   "Update_Error_NeedsAdmin": "更新此安装需要管理员权限，将改为打开下载页面。",
   "Update_Error_SwapFailed": "无法应用更新。当前版本未更改。",
-  "Update_Error_Generic": "无法完成更新：{0}"
+  "Update_Error_Generic": "无法完成更新：{0}",
+  "PokemonEditor_RerollPidTooltip": "重新生成PID"
 }

--- a/PKHeX.Presentation/Localization/Strings/zh-Hant.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hant.json
@@ -2138,5 +2138,6 @@
   "Update_Error_Checksum": "下載未通過驗證，已被捨棄。",
   "Update_Error_NeedsAdmin": "更新此安裝需要管理員權限，將改為開啟下載頁面。",
   "Update_Error_SwapFailed": "無法套用更新。目前版本未變更。",
-  "Update_Error_Generic": "無法完成更新：{0}"
+  "Update_Error_Generic": "無法完成更新：{0}",
+  "PokemonEditor_RerollPidTooltip": "重新產生PID"
 }

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -1,4 +1,5 @@
 
+using System;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -472,6 +473,20 @@ public partial class PokemonEditorViewModel : ViewModelBase
     private void ToggleShiny()
     {
         IsShiny = !IsShiny;
+    }
+
+    [RelayCommand]
+    private void RerollPid()
+    {
+        var rnd = new Random();
+        var newPid = EntityPID.GetRandomPID(rnd, (ushort)Species, (byte)Gender, _pk.Version, (Nature)Nature, (byte)Form, _pk.PID);
+        _pk.PID = newPid;
+        _isLoading = true;
+        Pid = newPid.ToString("X8");
+        IsShiny = _pk.IsShiny;
+        _isLoading = false;
+        UpdateSprite();
+        Validate();
     }
 
     public PKM PreparePKM()


### PR DESCRIPTION
## Summary

Exposes the PID field's re-roll functionality. Adds a 🎲 button next to the PID text box that generates a new random PID.

## What Changed

- **PokemonEditorViewModel**: Added `RerollPidCommand` RelayCommand that calls `EntityPID.GetRandomPID()` — handles generation-aware PID generation (Gen3/4 links nature/gender/ability to PID; Gen6+ returns a random 32-bit value)
- **PokemonEditor.axaml**: Added 🎲 button next to PID with tooltip and `AutomationProperties.Name` for accessibility
- **Localization**: `PokemonEditor_RerollPidTooltip` key added to all 9 language files
- **Version**: Bumped `UIVersion` 1.41.3 → 1.41.4

## Testing

- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — all 2415 Avalonia tests pass (including LayoutTests and AccessibilityAuditTests)
- New button has `AutomationProperties.Name` set, so accessibility audit is satisfied
- FontSize=12 Padding=0 ensures emoji fits within button width (layout test validated)

Closes #164
