### PR TITLE
fix: compact default UI density

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Realgar</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.41.6</UIVersion>
+    <UIVersion>1.41.7</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Styles/Theme.axaml
+++ b/PKHeX.Avalonia/Styles/Theme.axaml
@@ -606,7 +606,7 @@
     <Style Selector="NumericUpDown.form-field">
         <Setter Property="ShowButtonSpinner" Value="False" />
         <Setter Property="MinWidth" Value="80" />
-        <Setter Property="MinHeight" Value="28" />
+        <Setter Property="MinHeight" Value="32" />
         <Setter Property="Padding" Value="6,3" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
@@ -636,7 +636,7 @@
     </Style>
 
     <Style Selector="DataGridRow">
-        <Setter Property="MinHeight" Value="32" />
+        <Setter Property="MinHeight" Value="36" />
     </Style>
 
     <Style Selector="DataGridCell">

--- a/PKHeX.Avalonia/Styles/Theme.axaml
+++ b/PKHeX.Avalonia/Styles/Theme.axaml
@@ -307,7 +307,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
-        <Setter Property="Padding" Value="6" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="BoxShadow" Value="{DynamicResource ThemeShadowSmall}" />
     </Style>
 
@@ -316,7 +316,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="Padding" Value="6" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="BoxShadow" Value="{DynamicResource ThemeShadowMedium}" />
     </Style>
 
@@ -418,7 +418,7 @@
         <Setter Property="Foreground" Value="White" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="Padding" Value="20,10" />
+        <Setter Property="Padding" Value="16,8" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
@@ -428,14 +428,14 @@
     <Style Selector="Border.badge-success">
         <Setter Property="Background" Value="{DynamicResource ThemeSuccessBrush}" />
         <Setter Property="CornerRadius" Value="12" />
-        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Padding" Value="6,3" />
         <Setter Property="BoxShadow" Value="{DynamicResource ThemeGlowSuccess}" />
     </Style>
 
     <Style Selector="Border.badge-error">
         <Setter Property="Background" Value="{DynamicResource ThemeErrorBrush}" />
         <Setter Property="CornerRadius" Value="12" />
-        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Padding" Value="6,3" />
         <Setter Property="BoxShadow" Value="{DynamicResource ThemeGlowError}" />
     </Style>
 
@@ -446,7 +446,7 @@
         <Setter Property="Background" Value="{DynamicResource ThemeHeaderGradient}" />
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderDefaultBrush}" />
         <Setter Property="BorderThickness" Value="0,0,0,1" />
-        <Setter Property="Padding" Value="16,12" />
+        <Setter Property="Padding" Value="12,8" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -466,7 +466,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMutedBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
-        <Setter Property="Padding" Value="8" />
+        <Setter Property="Padding" Value="6" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -474,7 +474,7 @@
          ───────────────────────────────────────────────────────────────────────── -->
     <Style Selector="Border.view-container">
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBaseBrush}" />
-        <Setter Property="Padding" Value="12" />
+        <Setter Property="Padding" Value="8" />
     </Style>
 
     <!-- ─────────────────────────────────────────────────────────────────────────
@@ -606,8 +606,8 @@
     <Style Selector="NumericUpDown.form-field">
         <Setter Property="ShowButtonSpinner" Value="False" />
         <Setter Property="MinWidth" Value="80" />
-        <Setter Property="MinHeight" Value="32" />
-        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="MinHeight" Value="28" />
+        <Setter Property="Padding" Value="6,3" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
@@ -636,11 +636,11 @@
     </Style>
 
     <Style Selector="DataGridRow">
-        <Setter Property="MinHeight" Value="36" />
+        <Setter Property="MinHeight" Value="32" />
     </Style>
 
     <Style Selector="DataGridCell">
-        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="Padding" Value="6,3" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -168,7 +168,7 @@
                 Background="{DynamicResource ThemeBackgroundCardBrush}"
                 BorderBrush="{DynamicResource ThemeBorderDefaultBrush}"
                 BorderThickness="0,1,0,0"
-                Padding="12,6">
+                Padding="8,4">
             <Grid ColumnDefinitions="*,Auto">
                 <TextBlock Grid.Column="0"
                            Text="{Binding StatusText}"
@@ -216,7 +216,7 @@
 
             <!-- Save Loaded State: WinForms-style layout -->
             <!-- Left: PKMEditor (persistent side panel) | Right: SAVEditor (tabs with Box/Party/Trainer/etc) -->
-            <Grid IsVisible="{Binding HasSave}" ColumnDefinitions="560,*">
+            <Grid IsVisible="{Binding HasSave}" ColumnDefinitions="520,*">
 
             <!-- Left Panel: PKM Editor (700px) -->
             <Border Grid.Column="0"

--- a/PKHeX.Avalonia/Views/MainWindow.axaml
+++ b/PKHeX.Avalonia/Views/MainWindow.axaml
@@ -218,7 +218,7 @@
             <!-- Left: PKMEditor (persistent side panel) | Right: SAVEditor (tabs with Box/Party/Trainer/etc) -->
             <Grid IsVisible="{Binding HasSave}" ColumnDefinitions="520,*">
 
-            <!-- Left Panel: PKM Editor (700px) -->
+            <!-- Left Panel: PKM Editor (520px) -->
             <Border Grid.Column="0"
                     Background="{DynamicResource ThemeBackgroundBaseBrush}"
                     BorderThickness="0,0,1,0"

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -122,7 +122,7 @@
                                     <!-- Main Tab -->
                                     <TabItem Header="{loc:Loc PokemonEditor_TabMain}">
                                         <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                                            <StackPanel Spacing="16" Margin="8,8,8,80">
+                                            <StackPanel Spacing="12" Margin="6,6,6,64">
 
                                 <!-- Core Info Card -->
                             <Border Classes="section-card"
@@ -145,7 +145,7 @@
                                     </StackPanel>
 
                                     <!-- Form -->
-                                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,12,0,0" IsVisible="{Binding HasForms}">
+                                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,8,0,0" IsVisible="{Binding HasForms}">
                                         <TextBlock Text="{loc:Loc PokemonEditor_Form}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                         <ComboBox ItemsSource="{Binding FormList}"
                                                   SelectedValue="{Binding Form}" SelectedValueBinding="{Binding Value}"
@@ -153,7 +153,7 @@
                                     </StackPanel>
 
                                     <!-- Gender -->
-                                    <StackPanel Grid.Row="2" Grid.Column="2" Margin="0,12,0,0">
+                                    <StackPanel Grid.Row="2" Grid.Column="2" Margin="0,8,0,0">
                                         <TextBlock Text="{loc:Loc PokemonEditor_Gender}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                         <ComboBox ItemsSource="{Binding GenderList}"
                                                   SelectedValue="{Binding Gender}" SelectedValueBinding="{Binding Value}"
@@ -213,7 +213,7 @@
                                                   DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" />
 
                                         <!-- Stat Alignment (gen8+) -->
-                                        <StackPanel IsVisible="{Binding ShowStatAlignment}" Margin="0,12,0,0">
+                                        <StackPanel IsVisible="{Binding ShowStatAlignment}" Margin="0,8,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_StatAlignment}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <ComboBox ItemsSource="{Binding NatureList}"
                                                       SelectedValue="{Binding StatAlignment}" SelectedValueBinding="{Binding Value}"
@@ -223,7 +223,7 @@
                                     </StackPanel>
 
                                     <!-- Ability -->
-                                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,12,0,0">
+                                    <StackPanel Grid.Row="2" Grid.Column="0" Margin="0,8,0,0">
                                         <TextBlock Text="{loc:Loc PokemonEditor_Ability}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                         <ComboBox ItemsSource="{Binding AbilityList}"
                                                   SelectedValue="{Binding Ability}" SelectedValueBinding="{Binding Value}"
@@ -231,7 +231,7 @@
                                     </StackPanel>
                                     
                                     <!-- Language -->
-                                    <StackPanel Grid.Row="2" Grid.Column="2" Margin="0,12,0,0">
+                                    <StackPanel Grid.Row="2" Grid.Column="2" Margin="0,8,0,0">
                                         <TextBlock Text="{loc:Loc PokemonEditor_Language}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                         <ComboBox ItemsSource="{Binding LanguageList}"
                                                   SelectedValue="{Binding Language}" SelectedValueBinding="{Binding Value}"
@@ -242,7 +242,7 @@
 
                             <!-- Misc Card -->
                             <Border Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto">
                                     <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Text="{loc:Loc PokemonEditor_Equipment}" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
 
@@ -271,9 +271,9 @@
                 <!-- Stats Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabStats}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="16">
+                        <StackPanel Spacing="12" Margin="6,6,6,64">
                         <Border Classes="section-card"
-                                CornerRadius="4" Padding="12">
+                                CornerRadius="4" Padding="8">
                             <Grid ColumnDefinitions="40,*,*,*,*" RowDefinitions="Auto,4,Auto,Auto,Auto,Auto,Auto,Auto">
                                 <!-- Headers -->
                                 <TextBlock Grid.Row="0" Grid.Column="0" Text="{loc:Loc PokemonEditor_ColStat}" FontWeight="Bold" Opacity="0.6" HorizontalAlignment="Left" />
@@ -401,7 +401,7 @@
                 <!-- Moves Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabMoves}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="16">
+                        <StackPanel Spacing="12" Margin="6,6,6,64">
                             <!-- Current Moves Section -->
                             <StackPanel Spacing="8">
                                 <DockPanel Margin="0,0,0,4">
@@ -414,7 +414,7 @@
                                 
                                 <StackPanel Spacing="4">
                                     <!-- Move 1 -->
-                                    <Border Classes="section-card" Padding="12">
+                                    <Border Classes="section-card" Padding="8">
                                         <Grid RowDefinitions="Auto,12,Auto">
                                             <controls:FilterableComboBox Grid.Row="0" ItemsSource="{Binding MoveList}"
                                                       SelectedValue="{Binding Move1}" HorizontalAlignment="Stretch"
@@ -433,7 +433,7 @@
                                     </Border>
 
                                     <!-- Move 2 -->
-                                    <Border Classes="section-card" Padding="12">
+                                    <Border Classes="section-card" Padding="8">
                                         <Grid RowDefinitions="Auto,12,Auto">
                                             <controls:FilterableComboBox Grid.Row="0" ItemsSource="{Binding MoveList}"
                                                       SelectedValue="{Binding Move2}" HorizontalAlignment="Stretch"
@@ -452,7 +452,7 @@
                                     </Border>
 
                                     <!-- Move 3 -->
-                                    <Border Classes="section-card" Padding="12">
+                                    <Border Classes="section-card" Padding="8">
                                         <Grid RowDefinitions="Auto,12,Auto">
                                             <controls:FilterableComboBox Grid.Row="0" ItemsSource="{Binding MoveList}"
                                                       SelectedValue="{Binding Move3}" HorizontalAlignment="Stretch"
@@ -471,7 +471,7 @@
                                     </Border>
 
                                     <!-- Move 4 -->
-                                    <Border Classes="section-card" Padding="12">
+                                    <Border Classes="section-card" Padding="8">
                                         <Grid RowDefinitions="Auto,12,Auto">
                                             <controls:FilterableComboBox Grid.Row="0" ItemsSource="{Binding MoveList}"
                                                       SelectedValue="{Binding Move4}" HorizontalAlignment="Stretch"
@@ -543,10 +543,10 @@
                 <!-- OT/Misc Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabOtMisc}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="16">
+                        <StackPanel Spacing="12" Margin="6,6,6,64">
                             <!-- Original Trainer Card -->
                             <Border Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto,Auto">
                                     <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Text="{loc:Loc PokemonEditor_OriginalTrainer}" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
                                     
@@ -562,7 +562,7 @@
                                                   DisplayMemberBinding="{Binding Text}" HorizontalAlignment="Stretch" />
                                     </StackPanel>
 
-                                    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto" Margin="0,12,0,0">
+                                    <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto" Margin="0,8,0,0">
                                         <StackPanel Grid.Row="0" Grid.Column="0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Tid}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding TrainerID}" Minimum="0" Maximum="4294967295" FormatString="0" ShowButtonSpinner="False"
@@ -583,7 +583,7 @@
                             </Border>
 
                             <!-- Extra Info Card -->
-                            <Border Classes="section-card" CornerRadius="4" Padding="12">
+                            <Border Classes="section-card" CornerRadius="4" Padding="8">
                                 <StackPanel Spacing="12">
                                     <TextBlock Text="{loc:Loc PokemonEditor_EncryptionStatus}" FontWeight="Bold" Opacity="0.6" />
                                     
@@ -630,7 +630,7 @@
 
                             <!-- Form Argument -->
                             <Border IsVisible="{Binding ShowFormArgument}" Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <StackPanel>
                                     <TextBlock Text="{loc:Loc PokemonEditor_FormArgument}" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
                                     <ComboBox IsVisible="{Binding ShowFormArgumentNamed}"
@@ -648,7 +648,7 @@
 
                             <!-- Markings -->
                             <Border IsVisible="{Binding HasMarkings}" Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <StackPanel>
                                     <TextBlock Text="{loc:Loc PokemonEditor_Markings}" FontWeight="Bold" Margin="0,0,0,8" Opacity="0.6" />
                                     <UniformGrid Columns="6">
@@ -668,9 +668,9 @@
                 <!-- Contest Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabContest}" IsVisible="{Binding HasContestStats}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="16">
+                        <StackPanel Spacing="12" Margin="6,6,6,64">
                          <Border Classes="section-card"
-                                CornerRadius="4" Padding="12">
+                                CornerRadius="4" Padding="8">
                             <StackPanel Spacing="16">
                                 <TextBlock Text="{loc:Loc PokemonEditor_ContestStats}" FontWeight="Bold" FontSize="16" Opacity="0.6" />
                                 <UniformGrid Columns="2" Rows="3">
@@ -710,11 +710,11 @@
                 <!-- Memory Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabMemory}" IsVisible="{Binding HasMemories}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="16">
+                        <StackPanel Spacing="12" Margin="6,6,6,64">
                             <Button Content="{loc:Loc PokemonEditor_MemoryEditor}" Command="{Binding OpenMemoryEditorCommand}" HorizontalAlignment="Right" />
                             <!-- OT Memory -->
                             <Border Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <StackPanel Spacing="12">
                                     <TextBlock Text="{loc:Loc PokemonEditor_OtMemory}" FontWeight="Bold" Opacity="0.6" />
                                     <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto">
@@ -727,11 +727,11 @@
                                             <NumericUpDown Value="{Binding OtMemoryIntensity}" Minimum="0" Maximum="7" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>
                                         
-                                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,12,0,0">
+                                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,8,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Feeling}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding OtMemoryFeeling}" Minimum="0" Maximum="24" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>
-                                        <StackPanel Grid.Row="1" Grid.Column="2" Margin="0,12,0,0">
+                                        <StackPanel Grid.Row="1" Grid.Column="2" Margin="0,8,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Variable}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding OtMemoryVariable}" Minimum="0" Maximum="65535" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>
@@ -741,7 +741,7 @@
 
                             <!-- HT Memory -->
                             <Border Classes="section-card"
-                                    CornerRadius="4" Padding="12">
+                                    CornerRadius="4" Padding="8">
                                 <StackPanel Spacing="12">
                                     <TextBlock Text="{loc:Loc PokemonEditor_HtMemory}" FontWeight="Bold" Opacity="0.6" />
                                     <Grid ColumnDefinitions="*,16,*" RowDefinitions="Auto,Auto">
@@ -754,11 +754,11 @@
                                             <NumericUpDown Value="{Binding HtMemoryIntensity}" Minimum="0" Maximum="7" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>
 
-                                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,12,0,0">
+                                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,8,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Feeling}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding HtMemoryFeeling}" Minimum="0" Maximum="24" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>
-                                        <StackPanel Grid.Row="1" Grid.Column="2" Margin="0,12,0,0">
+                                        <StackPanel Grid.Row="1" Grid.Column="2" Margin="0,8,0,0">
                                             <TextBlock Text="{loc:Loc PokemonEditor_Variable}" FontWeight="SemiBold" Margin="0,0,0,4" />
                                             <NumericUpDown Value="{Binding HtMemoryVariable}" Minimum="0" Maximum="65535" FormatString="0" ShowButtonSpinner="False" />
                                         </StackPanel>

--- a/PKHeX.Avalonia/Views/PokemonEditor.axaml
+++ b/PKHeX.Avalonia/Views/PokemonEditor.axaml
@@ -344,7 +344,7 @@
                 <!-- Met Tab -->
                 <TabItem Header="{loc:Loc PokemonEditor_TabMet}">
                     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8,8,8,80" Spacing="12">
+                        <StackPanel Margin="6,6,6,64" Spacing="12">
                             <!-- Origin Game -->
                             <StackPanel>
                                 <TextBlock Text="{loc:Loc PokemonEditor_OriginGame}" FontWeight="SemiBold" Margin="0,0,0,4" />

--- a/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
@@ -1,0 +1,50 @@
+namespace PKHeX.Avalonia.Tests;
+
+public class UiDensityTests
+{
+    [Fact]
+    public void Theme_UsesCompactControlPadding()
+    {
+        var theme = ReadSourceFile("Styles", "Theme.axaml");
+
+        Assert.Contains("<Setter Property=\"Padding\" Value=\"12,8\" />", theme);
+        Assert.Contains("<Setter Property=\"Padding\" Value=\"8\" />", theme);
+    }
+
+    [Fact]
+    public void MainWindow_UsesCompactEditorColumnWidth()
+    {
+        var mainWindow = ReadSourceFile("Views", "MainWindow.axaml");
+
+        Assert.Contains("ColumnDefinitions=\"520,*\"", mainWindow);
+    }
+
+    [Fact]
+    public void PokemonEditor_UsesCompactContentSpacingAndMargin()
+    {
+        var pokemonEditor = ReadSourceFile("Views", "PokemonEditor.axaml");
+
+        Assert.Contains("<StackPanel Spacing=\"12\" Margin=\"6,6,6,64\">", pokemonEditor);
+    }
+
+    private static string ReadSourceFile(params string[] relativePath)
+    {
+        var path = Path.Combine([FindRepoRoot(), "PKHeX.Avalonia", .. relativePath]);
+        Assert.True(File.Exists(path), $"Source file not found: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppDomain.CurrentDomain.BaseDirectory;
+        while (!Directory.Exists(Path.Combine(dir, "PKHeX.Avalonia")))
+        {
+            var parent = Directory.GetParent(dir);
+            if (parent == null)
+                throw new DirectoryNotFoundException("Could not find repository root");
+            dir = parent.FullName;
+        }
+
+        return dir;
+    }
+}

--- a/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace PKHeX.Avalonia.Tests;
 
 public class UiDensityTests
@@ -23,8 +25,16 @@ public class UiDensityTests
     public void PokemonEditor_UsesCompactContentSpacingAndMargin()
     {
         var pokemonEditor = ReadSourceFile("Views", "PokemonEditor.axaml");
+        var topLevelContentStacks = Regex.Matches(
+            pokemonEditor,
+            "<ScrollViewer HorizontalScrollBarVisibility=\"Disabled\" VerticalScrollBarVisibility=\"Auto\">\\s*<StackPanel\\b[^>]*>");
 
-        Assert.Contains("<StackPanel Spacing=\"12\" Margin=\"6,6,6,64\">", pokemonEditor);
+        Assert.Equal(7, topLevelContentStacks.Count);
+        Assert.All(topLevelContentStacks, stack =>
+        {
+            Assert.Contains("Spacing=\"12\"", stack.Value);
+            Assert.Contains("Margin=\"6,6,6,64\"", stack.Value);
+        });
     }
 
     private static string ReadSourceFile(params string[] relativePath)

--- a/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
@@ -5,20 +5,36 @@ namespace PKHeX.Avalonia.Tests;
 public class UiDensityTests
 {
     [Fact]
-    public void Theme_UsesCompactControlPadding()
+    public void Theme_UsesCompactSharedStyleValues()
     {
         var theme = ReadSourceFile("Styles", "Theme.axaml");
 
-        Assert.Contains("<Setter Property=\"Padding\" Value=\"12,8\" />", theme);
-        Assert.Contains("<Setter Property=\"Padding\" Value=\"8\" />", theme);
+        AssertStyleSetter(theme, "Border.card", "Padding", "4");
+        AssertStyleSetter(theme, "Border.card-elevated", "Padding", "4");
+        AssertStyleSetter(theme, "Button.accent-gradient", "Padding", "16,8");
+        AssertStyleSetter(theme, "Border.badge-success", "Padding", "6,3");
+        AssertStyleSetter(theme, "Border.badge-error", "Padding", "6,3");
+        AssertStyleSetter(theme, "Border.header-accent", "Padding", "12,8");
+        AssertStyleSetter(theme, "Border.section-card", "Padding", "6");
+        AssertStyleSetter(theme, "Border.view-container", "Padding", "8");
+        AssertStyleSetter(theme, "NumericUpDown.form-field", "MinHeight", "32");
+        AssertStyleSetter(theme, "NumericUpDown.form-field", "Padding", "6,3");
+        AssertStyleSetter(theme, "DataGridRow", "MinHeight", "36");
+        AssertStyleSetter(theme, "DataGridCell", "Padding", "6,3");
     }
 
     [Fact]
-    public void MainWindow_UsesCompactEditorColumnWidth()
+    public void MainWindow_UsesCompactEditorColumnAndStatusBar()
     {
         var mainWindow = ReadSourceFile("Views", "MainWindow.axaml");
+        var statusBar = Regex.Match(
+            mainWindow,
+            "<Border\\s+DockPanel.Dock=\"Bottom\"[^>]*>",
+            RegexOptions.Singleline);
 
         Assert.Contains("ColumnDefinitions=\"520,*\"", mainWindow);
+        Assert.True(statusBar.Success, "Status bar Border was not found.");
+        Assert.Contains("Padding=\"8,4\"", statusBar.Value);
     }
 
     [Fact]
@@ -35,6 +51,17 @@ public class UiDensityTests
             Assert.Contains("Spacing=\"12\"", stack.Value);
             Assert.Contains("Margin=\"6,6,6,64\"", stack.Value);
         });
+    }
+
+    private static void AssertStyleSetter(string xaml, string selector, string property, string value)
+    {
+        var style = Regex.Match(
+            xaml,
+            $"<Style\\s+Selector=\"{Regex.Escape(selector)}\">(?<body>.*?)</Style>",
+            RegexOptions.Singleline);
+
+        Assert.True(style.Success, $"Style '{selector}' was not found.");
+        Assert.Contains($"<Setter Property=\"{property}\" Value=\"{value}\" />", style.Groups["body"].Value);
     }
 
     private static string ReadSourceFile(params string[] relativePath)

--- a/docs/superpowers/plans/2026-07-17-ui-density.md
+++ b/docs/superpowers/plans/2026-07-17-ui-density.md
@@ -71,11 +71,11 @@ Update the shared style values only:
     <Setter Property="Padding" Value="8" />
 </Style>
 <Style Selector="NumericUpDown.form-field">
-    <Setter Property="MinHeight" Value="28" />
+    <Setter Property="MinHeight" Value="32" />
     <Setter Property="Padding" Value="6,3" />
 </Style>
 <Style Selector="DataGridRow">
-    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="MinHeight" Value="36" />
 </Style>
 <Style Selector="DataGridCell">
     <Setter Property="Padding" Value="6,3" />

--- a/docs/superpowers/plans/2026-07-17-ui-density.md
+++ b/docs/superpowers/plans/2026-07-17-ui-density.md
@@ -1,0 +1,131 @@
+# UI Density Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make PKHeX-Avalonia's default UI more compact on laptop displays, focused on the shared theme, main window, and Pokémon editor.
+
+**Architecture:** Keep density behavior declarative in `Theme.axaml`; no settings, service, or persistence model is introduced. A static Avalonia test owns the selected XAML resource/layout contract so future visual changes do not silently restore the oversized defaults.
+
+**Tech Stack:** Avalonia 11 XAML, .NET 10, xUnit.
+
+## Global Constraints
+
+- Do not modify `PKHeX.Core` or vendored `PKHeX.AutoMod` source.
+- No density preference or localization changes; system display scaling remains authoritative.
+- Preserve `AutomationProperties.Name` and existing minimum interactive control sizing.
+- Bump `UIVersion` from `1.41.6` to `1.41.7`.
+
+---
+
+### Task 1: Lock the density contract with a failing test
+
+**Files:**
+- Create: `Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs`
+
+**Interfaces:**
+- Consumes: source files under the repository root.
+- Produces: an xUnit static-source regression test for the compact XAML values.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UiDensityTests` with three `[Fact]` methods. Resolve the repository root from `AppDomain.CurrentDomain.BaseDirectory`, read each XAML source file, and use `Assert.Contains` to require these compact values:
+
+```csharp
+Assert.Contains("<Setter Property=\"Padding\" Value=\"12,8\" />", theme);
+Assert.Contains("<Setter Property=\"Padding\" Value=\"8\" />", theme);
+Assert.Contains("ColumnDefinitions=\"520,*\"", mainWindow);
+Assert.Contains("<StackPanel Spacing=\"12\" Margin=\"6,6,6,64\">", pokemonEditor);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release --filter FullyQualifiedName~UiDensityTests`
+
+Expected: FAIL because the current theme, main window, and Pokémon editor still contain the larger values.
+
+- [ ] **Step 3: Commit the failing-test checkpoint**
+
+```bash
+git add Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
+git commit -m "test: specify compact UI density defaults"
+```
+
+### Task 2: Compact shared theme defaults
+
+**Files:**
+- Modify: `PKHeX.Avalonia/Styles/Theme.axaml`
+
+**Interfaces:**
+- Consumes: `UiDensityTests` source assertions.
+- Produces: reduced shared padding and compact form/data-grid defaults.
+
+- [ ] **Step 1: Apply the minimal theme changes**
+
+Update the shared style values only:
+
+```xml
+<Style Selector="Border.header-accent">
+    <Setter Property="Padding" Value="12,8" />
+</Style>
+<Style Selector="Border.view-container">
+    <Setter Property="Padding" Value="8" />
+</Style>
+<Style Selector="NumericUpDown.form-field">
+    <Setter Property="MinHeight" Value="28" />
+    <Setter Property="Padding" Value="6,3" />
+</Style>
+<Style Selector="DataGridRow">
+    <Setter Property="MinHeight" Value="32" />
+</Style>
+<Style Selector="DataGridCell">
+    <Setter Property="Padding" Value="6,3" />
+</Style>
+```
+
+Also reduce `Border.card` and `Border.card-elevated` padding from `6` to `4`, `Border.section-card` from `8` to `6`, `Button.accent-gradient` padding from `20,10` to `16,8`, and badge padding from `8,4` to `6,3`.
+
+- [ ] **Step 2: Run the density test to verify it remains red for targeted views**
+
+Run: `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release --filter FullyQualifiedName~UiDensityTests`
+
+Expected: FAIL only on the main-window and Pokémon-editor assertions.
+
+### Task 3: Tighten the primary editor surfaces and release version
+
+**Files:**
+- Modify: `PKHeX.Avalonia/Views/MainWindow.axaml`
+- Modify: `PKHeX.Avalonia/Views/PokemonEditor.axaml`
+- Modify: `Directory.Build.props`
+
+**Interfaces:**
+- Consumes: compact shared theme styles from Task 2.
+- Produces: the visible daily-use layout contract tested by `UiDensityTests` and an updated UI version.
+
+- [ ] **Step 1: Apply the targeted layout changes**
+
+Make the main Pokémon-editor column `520` pixels wide and reduce the status-bar padding to `8,4`. In `PokemonEditor.axaml`, use `Spacing="12" Margin="6,6,6,64"` for each tab's top-level content stack, reduce repeated section-card `Padding="12"` to `Padding="8"`, and reduce field-group top margins from `0,12,0,0` to `0,8,0,0`. Change `UIVersion` to `1.41.7`.
+
+- [ ] **Step 2: Run the density test to verify it passes**
+
+Run: `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release --filter FullyQualifiedName~UiDensityTests`
+
+Expected: PASS, 3 tests with 0 failures.
+
+- [ ] **Step 3: Run relevant guardrails and full verification**
+
+Run:
+
+```bash
+dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release
+dotnet build PKHeX.sln -c Release
+dotnet test PKHeX.sln -c Release
+```
+
+Expected: every command succeeds with no new warnings; accessibility and localization audits remain green.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add PKHeX.Avalonia/Styles/Theme.axaml PKHeX.Avalonia/Views/MainWindow.axaml PKHeX.Avalonia/Views/PokemonEditor.axaml Directory.Build.props Tests/PKHeX.Avalonia.Tests/UiDensityTests.cs
+git commit -m "fix: compact default UI density"
+```

--- a/docs/superpowers/specs/2026-07-17-ui-density-design.md
+++ b/docs/superpowers/specs/2026-07-17-ui-density-design.md
@@ -1,0 +1,30 @@
+# UI Density Design
+
+## Goal
+
+Make the Avalonia UI feel denser by default on smaller laptop displays, addressing GitHub issue #166 without adding a user preference or changing platform display scaling.
+
+## Scope
+
+Adopt option 2: compact shared theme defaults and the primary editing experience.
+
+- Reduce shared theme padding and compact component sizing where it affects common controls.
+- Reduce explicit spacing in `MainWindow.axaml` and `PokemonEditor.axaml`, the main daily-use screens.
+- Preserve existing readable body text and all current accessibility automation names.
+- Leave specialized editor views out of scope for this issue.
+
+## Approach
+
+`Theme.axaml` remains the source of global visual defaults. Its card, header, section, and view-container spacing will be made denser, as will the shared compact numeric-input styles where needed. The main window will use a narrower Pokémon-editor column and a shorter status-bar treatment. The Pokémon editor will reduce its repeated section/card paddings, field-label gaps, and inter-section spacing while preserving control min-heights and explicit usability affordances.
+
+No density setting, persistence model, localization key, or new service is required. Avalonia continues to honor the operating system's scale factor.
+
+## Verification
+
+Add a focused resource/layout contract test that reads the three XAML files and asserts the compact default values selected for this feature. Run that test first and verify it fails before making visual changes. Then run the Avalonia test project, the full Release build, and the complete Release test suite. The existing accessibility and localization audit tests must remain green.
+
+## Constraints
+
+- Do not modify `PKHeX.Core` or vendored `PKHeX.AutoMod` source.
+- Bump `UIVersion` by one patch for this `fix` PR.
+- No direct push to `main`; changes remain on `realgar/feat/ui-density-166` for a PR.


### PR DESCRIPTION
## Summary
- compact shared theme spacing and the primary editor surfaces
- preserve existing interactive minimum heights and OS display scaling
- add selector-scoped density regression tests, including all seven Pokemon Editor content stacks

Fixes #166

## Validation
- `dotnet build PKHeX.sln -c Release` (0 warnings)
- `dotnet test PKHeX.sln -c Release` (Core 449 passed, 1 skipped; Architecture 5 passed; Avalonia 2,418 passed)