### PR TITLE
fix: rename .part download to proper extension before installer launch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.42.1</UIVersion>
+    <UIVersion>1.42.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Infrastructure/GitHubUpdateInstaller.cs
+++ b/PKHeX.Infrastructure/GitHubUpdateInstaller.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography;
 using PKHeX.Application.Abstractions;
 using PKHeX.Application.Services;
@@ -66,33 +67,40 @@ public sealed class GitHubUpdateInstaller : IUpdateInstaller
         if (!_strategies.TryGetValue(location.Kind, out var strategy))
             return new UpdateInstallResult(false, false, "Update_Error_Generic");
 
-        var tempPath = Path.Combine(Path.GetTempPath(), $"{SanitizeFileName(asset.Name)}.part");
-        try
-        {
-            progress.Report(new UpdateProgress(UpdatePhase.Downloading, 0, asset.Size > 0 ? asset.Size : null));
-            await DownloadAsync(asset, tempPath, progress, ct).ConfigureAwait(false);
-
-            progress.Report(new UpdateProgress(UpdatePhase.Verifying, 0, null));
-            if (!await VerifyChecksumAsync(tempPath, asset.Sha256, ct).ConfigureAwait(false))
+            var sanitizedName = SanitizeFileName(asset.Name);
+            var tempPath = Path.Combine(Path.GetTempPath(), $"{sanitizedName}.part");
+            var finalPath = Path.Combine(Path.GetTempPath(), sanitizedName);
+            try
             {
-                TryDelete(tempPath);
-                return new UpdateInstallResult(false, false, "Update_Error_Checksum");
-            }
+                progress.Report(new UpdateProgress(UpdatePhase.Downloading, 0, asset.Size > 0 ? asset.Size : null));
+                await DownloadAsync(asset, tempPath, progress, ct).ConfigureAwait(false);
 
-            return await strategy.InstallAsync(tempPath, asset, location, progress, ct).ConfigureAwait(false);
+                progress.Report(new UpdateProgress(UpdatePhase.Verifying, 0, null));
+                if (!await VerifyChecksumAsync(tempPath, asset.Sha256, ct).ConfigureAwait(false))
+                {
+                    TryDelete(tempPath);
+                    return new UpdateInstallResult(false, false, "Update_Error_Checksum");
+                }
+
+                // Rename from .part to the proper filename so platform strategies receive the correct extension.
+                File.Move(tempPath, finalPath, overwrite: true);
+
+                return await strategy.InstallAsync(finalPath, asset, location, progress, ct).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+            catch (OperationCanceledException)
         {
-            TryDelete(tempPath);
-            throw;
+                TryDelete(tempPath);
+                TryDelete(finalPath);
+                throw;
         }
-        catch (Exception ex)
-        {
-            Trace.TraceWarning($"Update install failed: {ex.Message}");
-            TryDelete(tempPath);
-            return new UpdateInstallResult(false, false, "Update_Error_Generic");
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"Update install failed: {ex.Message}");
+                TryDelete(tempPath);
+                TryDelete(finalPath);
+                return new UpdateInstallResult(false, false, "Update_Error_Generic");
+            }
         }
-    }
 
     private async Task DownloadAsync(ReleaseAsset asset, string destinationPath, IProgress<UpdateProgress> progress, CancellationToken ct)
     {

--- a/Tests/PKHeX.Avalonia.Tests/GitHubUpdateInstallerTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/GitHubUpdateInstallerTests.cs
@@ -148,4 +148,37 @@ public class GitHubUpdateInstallerTests
         Assert.False(strategy.Invoked);
         Assert.False(File.Exists(Path.Combine(Path.GetTempPath(), $"{asset.Name}.part")));
     }
-}
+
+            [Fact]
+            public async Task Windows_installer_receives_the_correct_extension_not_part()
+            {
+                // Regression: the .part extension has no shell association on Windows, so Process.Start
+                // would show an "open with" dialog instead of launching the installer. The fix renames
+                // the temp file to the sanitized asset name before handing it to the platform strategy.
+                var payload = new byte[30_000];
+                new Random(99).NextBytes(payload);
+                var sha256 = Convert.ToHexStringLower(SHA256.HashData(payload));
+
+                var handler = new FakeHttpMessageHandler(_ =>
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(payload) };
+                    response.Content.Headers.ContentLength = payload.Length;
+                    return response;
+                });
+                var strategy = new FakeStrategy();
+                var installer = CreateInstaller(handler, strategy, InstallKind.WindowsInstaller);
+                var asset = new ReleaseAsset("MyApp-Setup.exe", "https://example.com/MyApp-Setup.exe", sha256, payload.Length);
+                var progress = new SyncProgress();
+
+                var result = await installer.DownloadAndInstallAsync(asset, progress, CancellationToken.None);
+
+                Assert.True(result.Success);
+                Assert.True(strategy.Invoked);
+                Assert.NotNull(strategy.DownloadedFilePath);
+                // The received file must have the .exe extension, not .part.
+                Assert.EndsWith(".exe", strategy.DownloadedFilePath, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain(".part", strategy.DownloadedFilePath, StringComparison.OrdinalIgnoreCase);
+                // The temp .part file must not be left behind after the rename.
+                Assert.False(File.Exists(Path.Combine(Path.GetTempPath(), $"{asset.Name}.part")));
+            }
+        }


### PR DESCRIPTION
## Problem
On Windows, the in-app updater downloads the installer as MyApp-Setup.exe.part, then passes that path to WindowsUpdateStrategy.LaunchInstaller() which calls Process.Start(UseShellExecute=true). Since .part has no shell association on Windows, the OS shows a "select an app to open this .part file" dialog instead of running the installer. Mac (hdiutil) and portable zip (ZipFile) both inspect the file format, not the extension, so they are not affected.

## Fix
After checksum verification passes, rename the temp file from {name}.part to the sanitized asset name (e.g., MyApp-Setup.exe) before handing it to the platform strategy. This preserves the .part convention during download/verification (good practice for in-progress files) while providing the correct extension for installer launch.

## Changes
- **GitHubUpdateInstaller.cs**: hoist sanitizedName, add finalPath, File.Move after verification, cleanup both paths in all catch blocks
- **GitHubUpdateInstallerTests.cs**: add Windows_installer_receives_the_correct_extension_not_part test asserting the strategy receives a .exe path, not .part
- **Directory.Build.props**: bump UIVersion 1.42.1 to 1.42.2 (fix = patch)

Fixes #170
