### PR TITLE
fix: make Showdown set text tests line-ending agnostic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.42.5</UIVersion>
+    <UIVersion>1.42.6</UIVersion>
   </PropertyGroup>
 </Project>

--- a/Tests/PKHeX.Core.Tests/Simulator/ShowdownSetTests.cs
+++ b/Tests/PKHeX.Core.Tests/Simulator/ShowdownSetTests.cs
@@ -200,7 +200,8 @@ public class ShowdownSetTests
             set2.Form.Should().Be(set.Form);
 
             var result = set2.GetText(settingsOriginal);
-            result.Should().Be(message);
+            // GetText joins with Environment.NewLine (CRLF on Windows); the expected literal is LF. Compare normalized.
+            result.ReplaceLineEndings("\n").Should().Be(message.ReplaceLineEndings("\n"));
         }
     }
 
@@ -261,7 +262,8 @@ public class ShowdownSetTests
         set2.Form.Should().Be(set.Form);
 
         var result = set2.GetText(settingsOriginal);
-        result.Should().Be(message);
+        // GetText joins with Environment.NewLine (CRLF on Windows); the expected literal is LF. Compare normalized.
+        result.ReplaceLineEndings("\n").Should().Be(message.ReplaceLineEndings("\n"));
     }
 
     [Theory]


### PR DESCRIPTION
## Root cause

`PKHeX.Core/Editing/BattleTemplate/Showdown/ShowdownSet.cs` `GetText()` joins lines with `Environment.NewLine`, which is CRLF on Windows and LF on Linux. This is correct, intentional production behavior and was **not** changed.

`Tests/PKHeX.Core.Tests/Simulator/ShowdownSetTests.cs` compared that output directly to raw string literals (e.g. `SetAllTokenExample`), which are checked out with LF, so on Windows `actual` (CRLF) != `expected` (LF). This caused `SimulatorTranslate` and `SimulatorTranslateHABCDS` to fail on Windows while passing on Linux CI.

## Fix

Normalized both sides of the comparison with `string.ReplaceLineEndings("\n")` instead of touching the intentional platform-dependent behavior in `PKHeX.Core` (which is a byte-for-byte upstream mirror and must stay 1:1).

Changed assertions:
- `Tests/PKHeX.Core.Tests/Simulator/ShowdownSetTests.cs:204` (`SimulatorTranslate`): `result.Should().Be(message)` → `result.ReplaceLineEndings("\n").Should().Be(message.ReplaceLineEndings("\n"))`
- `Tests/PKHeX.Core.Tests/Simulator/ShowdownSetTests.cs:266` (`SimulatorTranslateHABCDS`): same normalization

Scanned the rest of the file for other `GetText()`/`ToString()` comparisons against raw literals — no other instances found; other `.Should().Be(...)` calls in the file compare `Species`/`Form`/move counts, which are unaffected by line endings.

`PKHeX.Core` was **not** modified.

## Version

`UIVersion` bumped 1.42.5 → 1.42.6 (fix → patch) in `Directory.Build.props`.

## Verification

- Build: `dotnet build PKHeX.sln -c Release` → Build succeeded, 0 Warning(s), 0 Error(s)
- `dotnet test Tests/PKHeX.Core.Tests/PKHeX.Core.Tests.csproj -c Release`:
  - Before: 447 passed, 2 failed, 1 skipped
  - After: 449 passed, 0 failed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)