### PR TITLE
chore: upgrade GitHub Actions to latest versions (Node 24 runtime)

### DIFF
--- a/.github/workflows/check-upstream-sync.yml
+++ b/.github/workflows/check-upstream-sync.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Get last synced SHA
         id: get-last-sha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'ga'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}
           path: '**/TestResults/*.trx'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       should_release: ${{ steps.check_tag.outputs.should_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -66,10 +66,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           dotnet-quality: 'ga'
@@ -350,7 +350,7 @@ jobs:
         run: Rename-Item PKHeX-Avalonia-Setup.exe PKHeX-Avalonia-Setup-unsigned.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |
@@ -367,7 +367,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create tag
         env:
@@ -378,7 +378,7 @@ jobs:
             -f sha="${{ github.sha }}"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -386,7 +386,7 @@ jobs:
         run: find artifacts -type f
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: v${{ needs.check-version.outputs.version }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.43.0</UIVersion>
+    <UIVersion>1.43.1</UIVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

All 11 `uses:` directives across our 3 workflow files used deprecated Node 20 runtime versions. This upgrades every action to its latest major version running on Node 24.

## Changes

| Action | Old | New | Occurrences |
|--------|-----|-----|-------------|
| `actions/checkout` | `@v4` | `@v7` | 5 |
| `actions/setup-dotnet` | `@v4` | `@v6` | 2 |
| `actions/upload-artifact` | `@v4` | `@v7` | 2 |
| `actions/download-artifact` | `@v4` | `@v8` | 1 |
| `softprops/action-gh-release` | `@v2` | `@v3` | 1 |

## Files

- `.github/workflows/check-upstream-sync.yml` — 1 upgrade
- `.github/workflows/ci.yml` — 3 upgrades
- `.github/workflows/release.yml` — 7 upgrades

UIVersion bumped 1.43.0 → 1.43.1 (patch).

No breaking changes: all actions preserve the same inputs/outputs across these major versions. The only runtime change is Node 20 → Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)