### PR TITLE
chore: gitignore .playwright-mcp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,9 @@ pingme.txt
 #############
 
 docs/superpowers/
+
+#############
+## Playwright MCP (browser automation artifacts)
+#############
+
+.playwright-mcp/


### PR DESCRIPTION
## Summary

Adds `.playwright-mcp/` to `.gitignore` so browser automation snapshots and console logs don't show up in git status.

Deleted the 4 existing files (2 page snapshots, 2 console logs) that were already in the working tree.

No UIVersion bump — this is a repo-config-only change with no product impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)