### PR TITLE
fix: compact Gen4 key-item pouch after Poke Radar removal

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.43.1</UIVersion>
+    <UIVersion>1.43.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/Misc4EditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/Misc4EditorViewModel.cs
@@ -275,6 +275,12 @@ public partial class Misc4EditorViewModel : ViewModelBase
             {
                 item.Index = 0;
                 item.Count = 0;
+
+                // The Gen 4 bag pouch is a null-terminated array: leaving a zeroed slot in the
+                // middle would strand any items after it behind the hole, making them invisible
+                // in-game. Compact so all remaining non-empty entries stay contiguous from the
+                // start, preserving their relative order.
+                pouch.ClearCount0();
             }
         }
 

--- a/Tests/PKHeX.Avalonia.Tests/Misc4PokeRadarTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/Misc4PokeRadarTests.cs
@@ -1,3 +1,4 @@
+using PKHeX.Avalonia.Tests.Fixtures;
 using PKHeX.Presentation.ViewModels;
 using PKHeX.Core;
 using Xunit;
@@ -109,5 +110,140 @@ public class Misc4PokeRadarTests
         // Assert
         Assert.False(vm.IsPokeRadarVisible);
         Assert.False(vm.PokeRadar);
+    }
+
+    // =========================================================================
+    // Regression: OFF path must not leave a null hole in the null-terminated
+    // Gen4 bag pouch when the radar sits mid-list (items follow it).
+    // =========================================================================
+
+    [Fact]
+    public void Misc4_PokeRadar_Pt_ToggleOff_MidList_CompactsPouch_NoNullHole()
+    {
+        // Arrange: place the radar in the middle of a run of key items, with items after it.
+        // Zeroing the radar's slot in place (without compacting) leaves those trailing items
+        // stranded behind a null hole, making them invisible in-game.
+        var sav = new SAV4Pt();
+        var bag = sav.Inventory;
+        var pouch = (InventoryPouch4)bag.Pouches.First(p => p.Type is InventoryType.KeyItems);
+
+        ushort[] beforeRadar = [428, 433];
+        ushort[] afterRadar = [434, 435, 438];
+        int slot = 0;
+        foreach (var idx in beforeRadar)
+        {
+            pouch.Items[slot].Index = idx;
+            pouch.Items[slot].Count = 1;
+            slot++;
+        }
+        pouch.Items[slot].Index = PokeRadarItem;
+        pouch.Items[slot].Count = 1;
+        slot++;
+        foreach (var idx in afterRadar)
+        {
+            pouch.Items[slot].Index = idx;
+            pouch.Items[slot].Count = 1;
+            slot++;
+        }
+        bag.CopyTo(sav);
+
+        var vm = new Misc4EditorViewModel(sav);
+        Assert.True(vm.PokeRadar);
+
+        // Act
+        vm.PokeRadar = false;
+        vm.SaveCommand.Execute(null);
+
+        // Assert: no empty slot precedes a filled one (no null hole in the null-terminated pouch).
+        var result = KeyItemsPouch(sav);
+        bool seenEmpty = false;
+        for (int i = 0; i < result.Items.Length; i++)
+        {
+            var isEmpty = result.Items[i].Count == 0;
+            if (seenEmpty)
+                Assert.True(isEmpty, $"Slot {i} is filled (Index={result.Items[i].Index}) after an earlier empty slot - null hole present");
+            seenEmpty |= isEmpty;
+        }
+
+        // Assert: radar removed, all other items retained (order preserved).
+        Assert.False(result.HasItem(PokeRadarItem));
+        var expectedOrder = beforeRadar.Concat(afterRadar).ToArray();
+        var actualOrder = result.Items.Where(it => it.Count > 0).Select(it => (ushort)it.Index).ToArray();
+        Assert.Equal(expectedOrder, actualOrder);
+    }
+
+    // =========================================================================
+    // Regression: byte-level round trip against a real save. Toggling the radar
+    // must only touch the key-item pouch bytes and the general-block checksum
+    // footer - nothing else in the file may change.
+    // =========================================================================
+
+    [Fact]
+    public void Misc4_PokeRadar_Pt_RealSave_ToggleOn_WriteRoundTrip_OnlyTouchesPouchAndChecksum()
+    {
+        // Arrange
+        var saveDir = SaveFileFixture.FindSaveFilesPath();
+        Assert.NotNull(saveDir);
+        var raw = File.ReadAllBytes(Path.Combine(saveDir!, "gen4_platinum.sav"));
+
+        var sav = Assert.IsType<SAV4Pt>(SaveUtil.GetSaveFile(raw));
+
+        var bag = sav.Inventory;
+        var pouch = (InventoryPouch4)bag.Pouches.First(p => p.Type is InventoryType.KeyItems);
+
+        // This fixture already carries the radar mid-list (slot 16 of 40). Establish a "radar
+        // absent" baseline directly through the Core pouch API - rather than via the VM's OFF
+        // path exercised by the compaction test above - so this byte-scoping check is independent
+        // of that fix and purely exercises the (always-correct) ON path against real save bytes.
+        pouch.Items.FirstOrDefault(it => it.Index == PokeRadarItem)?.Clear();
+        bag.CopyTo(sav);
+        var baseline = sav.Write().ToArray();
+
+        var vm = new Misc4EditorViewModel(sav);
+        Assert.False(vm.PokeRadar);
+
+        // Act
+        vm.PokeRadar = true;
+        vm.SaveCommand.Execute(null);
+        var after = sav.Write().ToArray();
+
+        // Assert: only the key-item pouch region and the general-block checksum footer changed.
+        Assert.Equal(baseline.Length, after.Length);
+
+        // The active General block for this specific fixture (SAV4's double-buffered block
+        // selection picks whichever of the two 0x40000 partitions holds the newer save
+        // generation - a runtime fact not derivable from any public API) lives in the second
+        // partition. Absolute pouch offset = partition base (0x40000) + PlayerBag4Pt's internal
+        // BaseOffset (0x630) + KeyItems pouch offset (0x294) = 0x0408C4. Verified empirically
+        // against this fixture file.
+        const int pouchOffset = 0x0408C4;
+        var pouchLength = pouch.Items.Length * 4; // InventoryPouch4: 4 bytes/item (u16 index, u16 count)
+        const int generalBlockPartitionOffset = 0x40000;
+        var checksumOffset = generalBlockPartitionOffset + SAV4Pt.GeneralSize - 2; // last 2 bytes of General = CRC16
+
+        var unexpectedOffsets = new List<int>();
+        for (int i = 0; i < baseline.Length; i++)
+        {
+            if (baseline[i] == after[i]) continue;
+            var inPouch = i >= pouchOffset && i < pouchOffset + pouchLength;
+            var inChecksum = i >= checksumOffset && i < checksumOffset + 2;
+            if (!inPouch && !inChecksum)
+                unexpectedOffsets.Add(i);
+        }
+        Assert.True(unexpectedOffsets.Count == 0,
+            $"Unexpected byte changes outside the pouch/checksum regions at: {string.Join(", ", unexpectedOffsets.Take(20).Select(o => $"0x{o:X}"))}");
+
+        var pouchChanged = false;
+        for (int i = pouchOffset; i < pouchOffset + pouchLength; i++)
+        {
+            if (baseline[i] != after[i]) { pouchChanged = true; break; }
+        }
+        Assert.True(pouchChanged, "Expected the key-item pouch region to change when toggling the radar on");
+
+        // Assert: the written bytes reload as a valid SAV4Pt with the radar present.
+        var reloaded = Assert.IsType<SAV4Pt>(SaveUtil.GetSaveFile(after));
+        Assert.True(reloaded.ChecksumsValid);
+        var reloadedPouch = reloaded.Inventory.Pouches.First(p => p.Type is InventoryType.KeyItems);
+        Assert.True(reloadedPouch.HasItem(PokeRadarItem));
     }
 }


### PR DESCRIPTION
## Context
A Reddit user reported that ticking the Poké Radar checkbox on a Platinum save "corrupted" their save. Byte-level investigation on a real Platinum save proved the ON path is safe: it changes exactly 4 inventory bytes + 2 checksum bytes, nothing else in the 512 KB file (no Safari Zone / location / event data). The SD-card-read-only symptom is hardware, not something a save editor can cause.

The investigation did surface a real bug in the **OFF** path: removing the radar zeroed its slot in place, leaving a null hole in the null-terminated Gen 4 bag array — key items after the hole (e.g. Super Rod, Member Card, Oak's Letter, Azure Flute on the test save) become invisible in-game.

## Fix
- `SavePokeRadar()` now calls `pouch.ClearCount0()` after removal, compacting non-empty entries to the front (Presentation layer only, no Core edit).
- New test: toggle OFF mid-list → no empty slot precedes a filled one, all items retained.
- New byte-level regression test on `Tests/savefiles/gen4_platinum.sav`: toggle ON only touches the key-item pouch region and general-block checksum; save reloads as valid SAV4Pt.
- UIVersion 1.43.1 → 1.43.2.

Build: 0 warnings. Tests: 2938 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)