### PR TITLE
fix: preserve shiny sprites across artwork styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,7 @@ WinForms UI changes, version bump, PR, and auto-merge once CI is green — is en
 ## Working notes
 
 <!-- Any agent: append short dated notes here (YYYY-MM-DD — note). Prune notes when stale or once folded into the sections above. -->
+- 2026-08-21 — GitHub issue #215 reproduces a Discord report where Artwork-mode shiny Bewear and Vikavolt used normal-color artwork because `a_760s.png`/`a_738s.png` are not bundled; `SpriteLoader` now prefers the available classic shiny sprite before falling back to normal artwork. UI version is 1.45.2, with focused coverage in `SpriteStyleTests`.
 - 2026-08-21 — GitHub issue #213 reproduces a Discord report where changing a Gen 7 egg Pokémon's ability in the Avalonia editor changed the ability ID but left `AbilityNumber` stale, causing `Ability mismatch for encounter`; `PokemonEditorViewModel.ApplyAbility()` now pairs known IDs with Core `RefreshAbility`, with regression coverage for Jangmo-o → Soundproof and Beldum → Metagross hidden-to-normal edits. UI version is 1.45.1.
 - 2026-08-21 — PKHaX support on branch feat/illegal-mode-hax: Avalonia startup now uses Core StartupUtil (--HaX/-HaX or persisted ForceHaXOnLaunch) to set runtime-only AppSettings.IsHaXMode. The mode propagates through filtered species/move/item/ability sources, editable six stored battle stats, full inventory item IDs and HaX quantities, persistent title/status warnings, and suppressed legality overlays in box/party/editor views. UI version is 1.45.0; focused HaX tests pass (5), Avalonia (2,493), architecture (5), and Core (449 + 1 existing skip).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.45.1</UIVersion>
+    <UIVersion>1.45.2</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Services/SpriteLoader.cs
+++ b/PKHeX.Avalonia/Services/SpriteLoader.cs
@@ -77,11 +77,20 @@ public sealed class SpriteLoader
 
         var bitmap = LoadSprite(resourceName);
 
-        // If shiny not found, try non-shiny
+        // Some styles (notably HOME artwork) do not include shiny assets for every species.
+        // Prefer a real classic shiny sprite over showing the normal-color sprite with only
+        // the shiny overlay, which is misleading for transferred Pokémon.
         if (bitmap is null && shiny)
         {
+            if (Style != SpriteStyle.Classic)
+            {
+                var classicShinyName = GetResourceName(SpriteStyle.Classic, species, form, gender, formarg, true, context);
+                bitmap = LoadSprite(classicShinyName);
+            }
+
+            // If no shiny sprite exists in either style, try non-shiny as a last resort.
             var nonShinyName = GetResourceName(species, form, gender, formarg, false, context);
-            bitmap = LoadSprite(nonShinyName);
+            bitmap ??= LoadSprite(nonShinyName);
         }
 
         // If form not found, try base form
@@ -136,8 +145,11 @@ public sealed class SpriteLoader
     }
 
     private string GetResourceName(ushort species, byte form, byte gender, uint formarg, bool shiny, EntityContext context)
+        => GetResourceName(Style, species, form, gender, formarg, shiny, context);
+
+    private static string GetResourceName(SpriteStyle style, ushort species, byte form, byte gender, uint formarg, bool shiny, EntityContext context)
     {
-        var res = GetStyleResources(Style);
+        var res = GetStyleResources(style);
         var spriteName = GetSpriteName(species, form, gender, formarg, context);
         var useShiny = shiny && res.ShinyFolder is not null;
         var folder = useShiny ? res.ShinyFolder! : res.NormalFolder;

--- a/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/SpriteStyleTests.cs
@@ -83,6 +83,20 @@ public class SpriteStyleTests
         Assert.False(shiny!.Bytes.SequenceEqual(normal!.Bytes));
     }
 
+    [Theory]
+    [InlineData(738)] // Vikavolt
+    [InlineData(760)] // Bewear
+    public void Loader_Artwork_TransferredSpeciesShinyDoesNotFallBackToNormal(ushort species)
+    {
+        var loader = new SpriteLoader { Style = SpriteStyle.Artwork };
+        using var shiny = loader.GetSprite(species, 0, 0, 0, true, EntityContext.Gen9);
+        using var normal = loader.GetSprite(species, 0, 0, 0, false, EntityContext.Gen9);
+
+        Assert.NotNull(shiny);
+        Assert.NotNull(normal);
+        Assert.False(shiny!.Bytes.SequenceEqual(normal!.Bytes), $"Artwork shiny sprite for species {species} fell back to the normal artwork.");
+    }
+
     [Fact]
     public void Loader_Classic_MissingGen9Species_ReturnsNull()
     {


### PR DESCRIPTION
Fixes #215

Discord follow-up from BlvckFr0st reported shiny Bewear and Vikavolt rendering with normal-color artwork. The Artwork sprite set lacks shiny assets for these transferred species, so SpriteLoader previously fell back directly to normal Artwork sprites.

This prefers an available classic shiny sprite before the normal-color fallback and adds regression coverage for species 738 (Vikavolt) and 760 (Bewear). Bumps UIVersion to 1.45.2.

Verification:
- dotnet build PKHeX.sln -c Release --no-restore (0 warnings, 0 errors)
- dotnet test PKHeX.sln -c Release --no-build --no-restore (2,951 passed, 1 existing skip)
- SpriteStyleTests (21 passed)