### PR TITLE
fix: protect Batch Editor state transitions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.46.0</UIVersion>
+    <UIVersion>1.46.1</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/BatchEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/BatchEditorViewModel.cs
@@ -16,7 +16,9 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
     private readonly List<UndoRedoService.BatchToken> _batchTokens = [];
     private readonly IUiDispatcher? _uiDispatcher;
     private CancellationTokenSource? _previewCancellation;
+    private CancellationTokenSource? _runCancellation;
     private long _previewVersion;
+    private long _stateVersion;
     private bool _disposed;
 
     public event Action? BatchEditCompleted;
@@ -165,23 +167,28 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
 
         IsRunning = true;
         CancelPreview();
+        var runCancellation = new CancellationTokenSource();
+        _runCancellation = runCancellation;
+        var cancellationToken = runCancellation.Token;
         var text = Instructions;
         var editBoxes = EditBoxes;
         var editParty = EditParty;
+        var stateVersion = Volatile.Read(ref _stateVersion);
+        var historyVersion = _undoRedo.ChangeCount;
         try
         {
-            var plan = await Task.Run(() => BuildPlan(text, editBoxes, editParty));
+            var plan = await Task.Run(
+                () => BuildPlan(text, editBoxes, editParty, cancellationToken),
+                cancellationToken);
             if (plan is null || plan.Changes.Count == 0)
             {
-                RefreshPreview();
+                RefreshIfActive();
                 return;
             }
 
-            if (!string.Equals(text, Instructions, StringComparison.Ordinal)
-                || editBoxes != EditBoxes
-                || editParty != EditParty)
+            if (!CanCommitRun(text, editBoxes, editParty, stateVersion, historyVersion, cancellationToken))
             {
-                RefreshPreview();
+                RefreshIfActive();
                 return;
             }
 
@@ -198,7 +205,7 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
 
             if (token is null)
             {
-                RefreshPreview();
+                RefreshIfActive();
                 return;
             }
 
@@ -206,12 +213,21 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
             BatchEditCompleted?.Invoke();
             RefreshPreview();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The save or editor state changed while the background plan was being built.
+        }
+        catch (Exception ex) when (!_disposed)
         {
             Results = $"Error: {ex.Message}";
         }
         finally
         {
+            if (ReferenceEquals(_runCancellation, runCancellation))
+            {
+                _runCancellation = null;
+                runCancellation.Dispose();
+            }
             IsRunning = false;
             ResetBatchCommand.NotifyCanExecuteChanged();
         }
@@ -277,9 +293,24 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
 
     private void OnUndoRedoStateChanged(object? sender, EventArgs e) => PostToUi(() =>
     {
+        Interlocked.Increment(ref _stateVersion);
+        CancelRun();
         ResetBatchCommand.NotifyCanExecuteChanged();
+        NotifyTargetCommands();
         RefreshPreview();
     });
+
+    /// <summary>Refreshes preview and command state after a direct save-slot mutation.</summary>
+    public void RefreshExternalState()
+    {
+        if (_disposed)
+            return;
+
+        Interlocked.Increment(ref _stateVersion);
+        CancelRun();
+        NotifyTargetCommands();
+        RefreshPreview();
+    }
 
     private void RefreshPreview()
     {
@@ -348,6 +379,37 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
 
     private void CancelPreview() => _previewCancellation?.Cancel();
 
+    private void CancelRun() => _runCancellation?.Cancel();
+
+    private void RefreshIfActive()
+    {
+        if (!_disposed)
+            RefreshPreview();
+    }
+
+    private void NotifyTargetCommands()
+    {
+        SetMaxIVsCommand.NotifyCanExecuteChanged();
+        SetMaxEVsCommand.NotifyCanExecuteChanged();
+        SetShinyCommand.NotifyCanExecuteChanged();
+        HealAllCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanCommitRun(
+        string text,
+        bool editBoxes,
+        bool editParty,
+        long stateVersion,
+        int historyVersion,
+        CancellationToken cancellationToken)
+        => !_disposed
+            && !cancellationToken.IsCancellationRequested
+            && stateVersion == Volatile.Read(ref _stateVersion)
+            && historyVersion == _undoRedo.ChangeCount
+            && string.Equals(text, Instructions, StringComparison.Ordinal)
+            && editBoxes == EditBoxes
+            && editParty == EditParty;
+
     private void PostToUi(Action action)
     {
         if (_uiDispatcher is null || _uiDispatcher.CheckAccess())
@@ -359,7 +421,11 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
     private int GetWritableTargetCount() => GetTargetSlots(EditBoxes, EditParty)
         .Count(entry => entry.Pokemon.Species != 0 && entry.Slot.CanWriteTo(_sav));
 
-    private BatchEditPlan? BuildPlan(string text, bool editBoxes, bool editParty)
+    private BatchEditPlan? BuildPlan(
+        string text,
+        bool editBoxes,
+        bool editParty,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(text))
             return null;
@@ -390,6 +456,7 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
         var changes = new List<PlannedChange>();
         foreach (var target in GetTargetSlots(editBoxes, editParty))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (target.Pokemon.Species == 0 || !target.Slot.CanWriteTo(_sav))
                 continue;
 
@@ -455,7 +522,9 @@ public partial class BatchEditorViewModel : ViewModelBase, IDisposable
 
         _disposed = true;
         Interlocked.Increment(ref _previewVersion);
+        Interlocked.Increment(ref _stateVersion);
         CancelPreview();
+        CancelRun();
         _previewCancellation?.Dispose();
         _undoRedo.StateChanged -= OnUndoRedoStateChanged;
     }

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.SlotOperations.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.SlotOperations.cs
@@ -61,6 +61,7 @@ public partial class MainWindowViewModel
 
         BoxViewer?.RefreshCurrentBox();
         PartyViewer?.RefreshParty();
+        BatchEditor?.RefreshExternalState();
     }
 
     private void OnBoxViewSlot(int box, int slot)
@@ -81,6 +82,7 @@ public partial class MainWindowViewModel
         }
         CurrentSave.SetBoxSlotAtIndex(pk, box, slot);
         BoxViewer?.RefreshCurrentBox();
+        BatchEditor?.RefreshExternalState();
     }
 
     private void OnBoxDeleteSlot(int box, int slot)
@@ -89,6 +91,7 @@ public partial class MainWindowViewModel
         if (CurrentSave.GetBoxSlotAtIndex(box, slot).Species == 0) return;
         CurrentSave.SetBoxSlotAtIndex(CurrentSave.BlankPKM, box, slot);
         BoxViewer?.RefreshCurrentBox();
+        BatchEditor?.RefreshExternalState();
     }
 
     private void OnPartyViewSlot(int slot)
@@ -109,6 +112,7 @@ public partial class MainWindowViewModel
         }
         CurrentSave.SetPartySlotAtIndex(pk, slot);
         PartyViewer.RefreshParty();
+        BatchEditor?.RefreshExternalState();
     }
 
     /// <summary>

--- a/Tests/PKHeX.Avalonia.Tests/BatchEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/BatchEditorTests.cs
@@ -337,6 +337,27 @@ public class BatchEditorTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task BatchEditor_RefreshExternalState_UpdatesPreviewAndQuickActions()
+    {
+        var sav = new SAV6XY();
+        sav.SetBoxSlotAtIndex(new PK6 { Species = 1, CurrentLevel = 5 }, 0, 0);
+        var vm = new BatchEditorViewModel(sav, DialogMock().Object)
+        {
+            Instructions = "=Species=1" + Environment.NewLine + ".CurrentLevel=50",
+        };
+        await WaitForAsync(() => vm.AffectedCount == 1);
+
+        var commandNotifications = 0;
+        vm.SetShinyCommand.CanExecuteChanged += (_, _) => commandNotifications++;
+        sav.SetBoxSlotAtIndex(sav.BlankPKM, 0, 0);
+        vm.RefreshExternalState();
+
+        await WaitForAsync(() => vm.AffectedCount == 0);
+        Assert.True(commandNotifications > 0);
+        Assert.False(vm.SetShinyCommand.CanExecute(null));
+    }
+
+    [Fact]
     public void BatchEditor_InstructionBuilderCommands_RequireAProperty()
     {
         var sav = new SAV6XY();


### PR DESCRIPTION
## Summary

- cancel and revalidate background Batch Editor plans before applying them when the save or history changes;
- refresh quick-action command state after shared undo/redo and direct box/party slot mutations;
- add a regression test for external save-state refresh and bump `UIVersion` to 1.46.1.

## Verification

- `dotnet build PKHeX.sln -c Release`: 0 warnings, 0 errors
- `dotnet test PKHeX.sln -c Release --no-restore`: Core 449 passed / 1 existing skip, Architecture 5 passed, Avalonia 2,505 passed
