### PR TITLE
fix: gate backup manager actions on selection and surface empty state (#256)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.48.2</UIVersion>
+    <UIVersion>1.48.3</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/BackupManager.axaml
+++ b/PKHeX.Avalonia/Views/BackupManager.axaml
@@ -24,15 +24,27 @@
             </DockPanel>
         </Border>
 
-        <DataGrid ItemsSource="{Binding Backups}" SelectedItem="{Binding SelectedBackup}"
-                  CanUserSortColumns="True" IsReadOnly="True" CanUserResizeColumns="True"
-                  GridLinesVisibility="All" BorderThickness="1"
-                  BorderBrush="{DynamicResource ThemeBorderBrush}">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="{loc:Loc BackupManager_TimestampHeader}" Binding="{Binding Timestamp}" Width="180"/>
-                <DataGridTextColumn Header="{loc:Loc BackupManager_SizeHeader}" Binding="{Binding Size}" Width="100"/>
-                <DataGridTextColumn Header="{loc:Loc BackupManager_FileHeader}" Binding="{Binding FileName}" Width="*"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Panel>
+            <DataGrid ItemsSource="{Binding Backups}" SelectedItem="{Binding SelectedBackup}"
+                      CanUserSortColumns="True" IsReadOnly="True" CanUserResizeColumns="True"
+                      GridLinesVisibility="All" BorderThickness="1"
+                      BorderBrush="{DynamicResource ThemeBorderBrush}"
+                      IsVisible="{Binding !IsEmpty}">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="{loc:Loc BackupManager_TimestampHeader}" Binding="{Binding Timestamp}" Width="180"/>
+                    <DataGridTextColumn Header="{loc:Loc BackupManager_SizeHeader}" Binding="{Binding Size}" Width="100"/>
+                    <DataGridTextColumn Header="{loc:Loc BackupManager_FileHeader}" Binding="{Binding FileName}" Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+
+            <TextBlock Text="{loc:Loc BackupManager_NoBackupsYet}"
+                       IsVisible="{Binding IsEmpty}"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       Foreground="{DynamicResource ThemeTextMutedBrush}"
+                       TextWrapping="Wrap"
+                       MaxWidth="360"
+                       TextAlignment="Center" />
+        </Panel>
     </DockPanel>
 </UserControl>

--- a/PKHeX.Presentation/Localization/Strings/de.json
+++ b/PKHeX.Presentation/Localization/Strings/de.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "Das Backup wurde wiederhergestellt und neu geladen.",
   "BackupManager_DeleteBackupTitle": "Backup löschen",
   "BackupManager_DeleteConfirm": "Das Backup vom {0} löschen? Dies kann nicht rückgängig gemacht werden.",
+  "BackupManager_NoBackupsYet": "Noch keine Backups vorhanden. Bei jedem Speichern wird automatisch ein Backup erstellt.",
   "BlockEditor_ExportErrorTitle": "Exportfehler",
   "BlockEditor_ImportErrorTitle": "Importfehler",
   "BlockEditor_SizeMismatch": "Blockgröße stimmt nicht überein. Erwartet {0} Bytes, erhalten {1} Bytes.",

--- a/PKHeX.Presentation/Localization/Strings/en.json
+++ b/PKHeX.Presentation/Localization/Strings/en.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "The backup has been restored and reloaded.",
   "BackupManager_DeleteBackupTitle": "Delete Backup",
   "BackupManager_DeleteConfirm": "Delete the backup from {0}? This cannot be undone.",
+  "BackupManager_NoBackupsYet": "No backups yet. A backup is created automatically each time you save.",
   "BlockEditor_ExportErrorTitle": "Export Error",
   "BlockEditor_ImportErrorTitle": "Import Error",
   "BlockEditor_SizeMismatch": "Block size mismatch. Expected {0} bytes, got {1} bytes.",

--- a/PKHeX.Presentation/Localization/Strings/es.json
+++ b/PKHeX.Presentation/Localization/Strings/es.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "La copia de seguridad ha sido restaurada y recargada.",
   "BackupManager_DeleteBackupTitle": "Eliminar copia de seguridad",
   "BackupManager_DeleteConfirm": "¿Eliminar la copia de seguridad de {0}? Esto no se puede deshacer.",
+  "BackupManager_NoBackupsYet": "Aún no hay copias de seguridad. Se crea una copia de seguridad automáticamente cada vez que guardas.",
   "BlockEditor_ExportErrorTitle": "Error de exportación",
   "BlockEditor_ImportErrorTitle": "Error de importación",
   "BlockEditor_SizeMismatch": "El tamaño del bloque no coincide. Se esperaban {0} bytes, se obtuvieron {1} bytes.",

--- a/PKHeX.Presentation/Localization/Strings/fr.json
+++ b/PKHeX.Presentation/Localization/Strings/fr.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "La sauvegarde a été restaurée et rechargée.",
   "BackupManager_DeleteBackupTitle": "Supprimer la sauvegarde",
   "BackupManager_DeleteConfirm": "Supprimer la sauvegarde du {0} ? Cette action est irréversible.",
+  "BackupManager_NoBackupsYet": "Aucune sauvegarde pour l'instant. Une sauvegarde est créée automatiquement à chaque enregistrement.",
   "BlockEditor_ExportErrorTitle": "Erreur d'exportation",
   "BlockEditor_ImportErrorTitle": "Erreur d'importation",
   "BlockEditor_SizeMismatch": "Taille de bloc incompatible. Attendu {0} octets, reçu {1} octets.",

--- a/PKHeX.Presentation/Localization/Strings/it.json
+++ b/PKHeX.Presentation/Localization/Strings/it.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "Il backup è stato ripristinato e ricaricato.",
   "BackupManager_DeleteBackupTitle": "Elimina Backup",
   "BackupManager_DeleteConfirm": "Eliminare il backup del {0}? Questa azione non può essere annullata.",
+  "BackupManager_NoBackupsYet": "Ancora nessun backup. Viene creato automaticamente un backup ogni volta che salvi.",
   "BlockEditor_ExportErrorTitle": "Errore di esportazione",
   "BlockEditor_ImportErrorTitle": "Errore di importazione",
   "BlockEditor_SizeMismatch": "Le dimensioni del blocco non corrispondono. Attesi {0} byte, ricevuti {1} byte.",

--- a/PKHeX.Presentation/Localization/Strings/ja.json
+++ b/PKHeX.Presentation/Localization/Strings/ja.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "バックアップが復元され、再読み込みされました。",
   "BackupManager_DeleteBackupTitle": "バックアップの削除",
   "BackupManager_DeleteConfirm": "{0} のバックアップを削除しますか? この操作は元に戻せません。",
+  "BackupManager_NoBackupsYet": "バックアップはまだありません。保存するたびに自動的にバックアップが作成されます。",
   "BlockEditor_ExportErrorTitle": "エクスポートエラー",
   "BlockEditor_ImportErrorTitle": "インポートエラー",
   "BlockEditor_SizeMismatch": "ブロックサイズが一致しません。期待値は {0} バイトですが、{1} バイトでした。",

--- a/PKHeX.Presentation/Localization/Strings/ko.json
+++ b/PKHeX.Presentation/Localization/Strings/ko.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "백업이 복원되어 다시 불러왔습니다.",
   "BackupManager_DeleteBackupTitle": "백업 삭제",
   "BackupManager_DeleteConfirm": "{0}의 백업을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  "BackupManager_NoBackupsYet": "아직 백업이 없습니다. 저장할 때마다 자동으로 백업이 생성됩니다.",
   "BlockEditor_ExportErrorTitle": "내보내기 오류",
   "BlockEditor_ImportErrorTitle": "가져오기 오류",
   "BlockEditor_SizeMismatch": "블록 크기가 일치하지 않습니다. 예상 {0}바이트, 실제 {1}바이트.",

--- a/PKHeX.Presentation/Localization/Strings/zh-Hans.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hans.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "备份已还原并重新加载。",
   "BackupManager_DeleteBackupTitle": "删除备份",
   "BackupManager_DeleteConfirm": "删除来自 {0} 的备份？此操作无法撤销。",
+  "BackupManager_NoBackupsYet": "暂无备份。每次保存时都会自动创建备份。",
   "BlockEditor_ExportErrorTitle": "导出错误",
   "BlockEditor_ImportErrorTitle": "导入错误",
   "BlockEditor_SizeMismatch": "数据块大小不匹配。期望 {0} 字节，实际 {1} 字节。",

--- a/PKHeX.Presentation/Localization/Strings/zh-Hant.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hant.json
@@ -272,6 +272,7 @@
   "BackupManager_RestoreCompleteMessage": "備份已還原並重新載入。",
   "BackupManager_DeleteBackupTitle": "刪除備份",
   "BackupManager_DeleteConfirm": "要刪除來自 {0} 的備份嗎？此動作無法復原。",
+  "BackupManager_NoBackupsYet": "尚無備份。每次儲存時都會自動建立備份。",
   "BlockEditor_ExportErrorTitle": "匯出錯誤",
   "BlockEditor_ImportErrorTitle": "匯入錯誤",
   "BlockEditor_SizeMismatch": "區塊大小不符。預期 {0} 位元組，實際為 {1} 位元組。",

--- a/PKHeX.Presentation/ViewModels/BackupManagerViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/BackupManagerViewModel.cs
@@ -24,10 +24,18 @@ public partial class BackupManagerViewModel : ViewModelBase
     private ObservableCollection<BackupEntryRow> _backups = [];
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RestoreSelectedCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DeleteSelectedCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RevealSelectedCommand))]
     private BackupEntryRow? _selectedBackup;
 
     [ObservableProperty]
     private string _statusText = string.Empty;
+
+    /// <summary>True once a save file is open and its backup list has been fetched but is empty
+    /// (as opposed to backups being disabled entirely because no save is open yet).</summary>
+    [ObservableProperty]
+    private bool _isEmpty;
 
     /// <summary>Raised after a successful restore so the host can refresh any other open editors/tools.</summary>
     public event Action? Restored;
@@ -49,6 +57,7 @@ public partial class BackupManagerViewModel : ViewModelBase
         {
             Backups = [];
             StatusText = LocalizedStrings.Instance["BackupManager_SaveFirst"];
+            IsEmpty = false;
             return;
         }
 
@@ -59,9 +68,12 @@ public partial class BackupManagerViewModel : ViewModelBase
         StatusText = result.Warnings.Count == 0
             ? LocalizedStrings.Instance.Format("BackupManager_BackupCount", Backups.Count)
             : LocalizedStrings.Instance.Format("BackupManager_BackupCountWithWarnings", Backups.Count, result.Warnings.Count, string.Join("; ", result.Warnings));
+        IsEmpty = Backups.Count == 0;
     }
 
-    [RelayCommand]
+    private bool CanActOnSelection => SelectedBackup is not null;
+
+    [RelayCommand(CanExecute = nameof(CanActOnSelection))]
     private async Task RestoreSelectedAsync()
     {
         if (SelectedBackup is null)
@@ -150,7 +162,7 @@ public partial class BackupManagerViewModel : ViewModelBase
         await _dialogService.ShowInformationAsync(LocalizedStrings.Instance["BackupManager_RestoreCompleteTitle"], LocalizedStrings.Instance["BackupManager_RestoreCompleteMessage"]);
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanActOnSelection))]
     private async Task DeleteSelectedAsync()
     {
         if (SelectedBackup is null)
@@ -166,7 +178,7 @@ public partial class BackupManagerViewModel : ViewModelBase
         Refresh();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanActOnSelection))]
     private void RevealSelected()
     {
         if (SelectedBackup is null)

--- a/Tests/PKHeX.Avalonia.Tests/BackupManagerViewModelTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/BackupManagerViewModelTests.cs
@@ -11,6 +11,11 @@ namespace PKHeX.Avalonia.Tests;
 /// Covers the Backup Manager restore/delete flows required by issue #135: restoring asks for
 /// confirmation, itself creates a pre-restore backup of the current file, and reloads the save;
 /// a corrupt backup is rejected gracefully instead of corrupting the working file.
+///
+/// Also covers issue #256: the Reveal/Delete/Restore commands must be selection-gated via
+/// <c>CanExecute</c> (so the bound buttons disable themselves) instead of silently doing nothing
+/// when clicked with no selection, and the empty-backup-list state must be distinguishable from
+/// the no-save-file-open state.
 /// </summary>
 public sealed class BackupManagerViewModelTests : IDisposable
 {
@@ -157,5 +162,88 @@ public sealed class BackupManagerViewModelTests : IDisposable
         await vm.DeleteSelectedCommand.ExecuteAsync(null);
 
         Assert.True(File.Exists(row.FilePath));
+    }
+
+    [Fact]
+    public void SelectionGatedCommands_ReportCanExecuteFalse_WhenNoBackupSelected()
+    {
+        var vm = new BackupManagerViewModel(_backupService, _saveFileService.Object, _dialogService.Object, _settings);
+
+        Assert.Null(vm.SelectedBackup);
+        Assert.False(vm.RestoreSelectedCommand.CanExecute(null));
+        Assert.False(vm.DeleteSelectedCommand.CanExecute(null));
+        Assert.False(vm.RevealSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SelectionGatedCommands_EnableAndRaiseCanExecuteChanged_WhenBackupSelected()
+    {
+        var row = CreateOneBackup();
+        var vm = new BackupManagerViewModel(_backupService, _saveFileService.Object, _dialogService.Object, _settings);
+
+        var restoreRaised = false;
+        var deleteRaised = false;
+        var revealRaised = false;
+        vm.RestoreSelectedCommand.CanExecuteChanged += (_, _) => restoreRaised = true;
+        vm.DeleteSelectedCommand.CanExecuteChanged += (_, _) => deleteRaised = true;
+        vm.RevealSelectedCommand.CanExecuteChanged += (_, _) => revealRaised = true;
+
+        vm.SelectedBackup = row;
+
+        // This is the notification that actually flips the bound buttons from disabled to enabled.
+        Assert.True(restoreRaised);
+        Assert.True(deleteRaised);
+        Assert.True(revealRaised);
+        Assert.True(vm.RestoreSelectedCommand.CanExecute(null));
+        Assert.True(vm.DeleteSelectedCommand.CanExecute(null));
+        Assert.True(vm.RevealSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SelectionGatedCommands_DisableAndRaiseCanExecuteChanged_WhenSelectionCleared()
+    {
+        var row = CreateOneBackup();
+        var vm = new BackupManagerViewModel(_backupService, _saveFileService.Object, _dialogService.Object, _settings)
+        {
+            SelectedBackup = row,
+        };
+        Assert.True(vm.RestoreSelectedCommand.CanExecute(null));
+
+        var restoreRaised = false;
+        var deleteRaised = false;
+        var revealRaised = false;
+        vm.RestoreSelectedCommand.CanExecuteChanged += (_, _) => restoreRaised = true;
+        vm.DeleteSelectedCommand.CanExecuteChanged += (_, _) => deleteRaised = true;
+        vm.RevealSelectedCommand.CanExecuteChanged += (_, _) => revealRaised = true;
+
+        vm.SelectedBackup = null;
+
+        Assert.True(restoreRaised);
+        Assert.True(deleteRaised);
+        Assert.True(revealRaised);
+        Assert.False(vm.RestoreSelectedCommand.CanExecute(null));
+        Assert.False(vm.DeleteSelectedCommand.CanExecute(null));
+        Assert.False(vm.RevealSelectedCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void IsEmpty_TrueWhenSaveOpenWithNoBackups_FalseOnceABackupExists()
+    {
+        var vm = new BackupManagerViewModel(_backupService, _saveFileService.Object, _dialogService.Object, _settings);
+        Assert.True(vm.IsEmpty);
+
+        CreateOneBackup();
+        vm.Refresh();
+
+        Assert.False(vm.IsEmpty);
+    }
+
+    [Fact]
+    public void IsEmpty_FalseWhenNoSaveFileOpen()
+    {
+        _saveFileService.SetupGet(s => s.CurrentPath).Returns((string?)null);
+        var vm = new BackupManagerViewModel(_backupService, _saveFileService.Object, _dialogService.Object, _settings);
+
+        Assert.False(vm.IsEmpty);
     }
 }


### PR DESCRIPTION
## Summary

Backup Manager's Reveal / Delete / Restore buttons stayed enabled with no row selected in the list, and clicking them with nothing selected silently did nothing (the guard was only an internal `if (SelectedBackup is null) return;` inside each command body).

- `RestoreSelectedCommand`, `DeleteSelectedCommand`, and `RevealSelectedCommand` in `BackupManagerViewModel` are now gated by a shared `CanActOnSelection => SelectedBackup is not null` guard via `[RelayCommand(CanExecute = ...)]`, with `[NotifyCanExecuteChangedFor(...)]` on `SelectedBackup` so the guard re-evaluates the moment a row is selected or cleared.
- Avalonia `Button` controls bound to an `ICommand` already disable themselves based on `CanExecute`, so no `IsEnabled` bindings were added in the `.axaml` — the command guard is the whole fix.
- Added a new `IsEmpty` observable property, kept in sync in `Refresh()`, that is true only once a save file is open and its backup list is empty (as opposed to backups being disabled entirely because no save is open yet, which keeps its existing `BackupManager_SaveFirst` guidance). `BackupManager.axaml` now shows a new, distinct empty-state message (`BackupManager_NoBackupsYet`) in that case, following the existing `IsVisible="{Binding IsEmpty}"` / `IsVisible="{Binding !IsEmpty}"` pattern used elsewhere (e.g. `MysteryGiftEditor.axaml`).
- Added the new `BackupManager_NoBackupsYet` key with real translations across all 9 locales (`de, en, es, fr, it, ja, ko, zh-Hans, zh-Hant`).
- Bumped `UIVersion` 1.48.2 -> 1.48.3 (patch, per repo policy for a `fix`).

## Tests added (`Tests/PKHeX.Avalonia.Tests/BackupManagerViewModelTests.cs`)

- `SelectionGatedCommands_ReportCanExecuteFalse_WhenNoBackupSelected`
- `SelectionGatedCommands_EnableAndRaiseCanExecuteChanged_WhenBackupSelected`
- `SelectionGatedCommands_DisableAndRaiseCanExecuteChanged_WhenSelectionCleared`
- `IsEmpty_TrueWhenSaveOpenWithNoBackups_FalseOnceABackupExists`
- `IsEmpty_FalseWhenNoSaveFileOpen`

All 6 pre-existing tests in that file continue to pass unchanged.

## Test plan

- [x] `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release` — all tests passing (2575 total, 1 pre-existing unrelated skip)
- [x] `AccessibilityAuditTests` and `LocalizationAuditTests` pass unchanged

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)