### PR TITLE
fix: render ZA Royale ticket point controls in the trainer editor (#250)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.48.3</UIVersion>
+    <UIVersion>1.48.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Avalonia/Views/TrainerEditor.axaml
+++ b/PKHeX.Avalonia/Views/TrainerEditor.axaml
@@ -177,6 +177,14 @@
                                     <TextBlock Text="{loc:Loc TrainerEditor_GimmighoulCoins}" FontSize="11" FontWeight="SemiBold" Opacity="0.7" Margin="0,0,0,4" />
                                     <NumericUpDown Value="{Binding GimmighoulCoins}" Minimum="0" FormatString="0" ShowButtonSpinner="False" />
                                 </StackPanel>
+                                <StackPanel IsVisible="{Binding HasRoyalePoints}" Width="140" Margin="0,0,16,12">
+                                    <TextBlock Text="{loc:Loc TrainerEditor_RoyalePoints}" FontSize="11" FontWeight="SemiBold" Opacity="0.7" Margin="0,0,0,4" />
+                                    <NumericUpDown Value="{Binding RoyalePoints}" Minimum="0" FormatString="0" ShowButtonSpinner="False" />
+                                </StackPanel>
+                                <StackPanel IsVisible="{Binding HasRoyalePointsInfinite}" Width="140" Margin="0,0,16,12">
+                                    <TextBlock Text="{loc:Loc TrainerEditor_RoyalePointsInfinite}" FontSize="11" FontWeight="SemiBold" Opacity="0.7" Margin="0,0,0,4" />
+                                    <NumericUpDown Value="{Binding RoyalePointsInfinite}" Minimum="0" FormatString="0" ShowButtonSpinner="False" />
+                                </StackPanel>
                              </WrapPanel>
                         </ItemsControl>
                     </StackPanel>

--- a/PKHeX.Presentation/Localization/Strings/de.json
+++ b/PKHeX.Presentation/Localization/Strings/de.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "Verdienstpunkte",
   "TrainerEditor_PokeMiles": "Pokémeilen",
   "TrainerEditor_GimmighoulCoins": "Amaury-Münzen",
+  "TrainerEditor_RoyalePoints": "Royale-Punkte",
+  "TrainerEditor_RoyalePointsInfinite": "Unendliche Royale-Punkte",
   "TrainerEditor_BattleChateau": "Kampfschloss",
   "TrainerEditor_Rank": "Rang",
   "TrainerEditor_Points": "Punkte",

--- a/PKHeX.Presentation/Localization/Strings/en.json
+++ b/PKHeX.Presentation/Localization/Strings/en.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "Merit Points",
   "TrainerEditor_PokeMiles": "Poke Miles",
   "TrainerEditor_GimmighoulCoins": "Gimmighoul Coins",
+  "TrainerEditor_RoyalePoints": "Royale Points",
+  "TrainerEditor_RoyalePointsInfinite": "Infinite Royale Points",
   "TrainerEditor_BattleChateau": "Battle Chateau",
   "TrainerEditor_Rank": "Rank",
   "TrainerEditor_Points": "Points",

--- a/PKHeX.Presentation/Localization/Strings/es.json
+++ b/PKHeX.Presentation/Localization/Strings/es.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "Puntos de Mérito",
   "TrainerEditor_PokeMiles": "Poke Millas",
   "TrainerEditor_GimmighoulCoins": "Monedas de Gimmighoul",
+  "TrainerEditor_RoyalePoints": "Puntos de Royale",
+  "TrainerEditor_RoyalePointsInfinite": "Puntos de Royale Infinita",
   "TrainerEditor_BattleChateau": "Palacio de Combate",
   "TrainerEditor_Rank": "Rango",
   "TrainerEditor_Points": "Puntos",

--- a/PKHeX.Presentation/Localization/Strings/fr.json
+++ b/PKHeX.Presentation/Localization/Strings/fr.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "Points de mérite",
   "TrainerEditor_PokeMiles": "Poké Miles",
   "TrainerEditor_GimmighoulCoins": "Jetons Radoteur",
+  "TrainerEditor_RoyalePoints": "Points de Royale",
+  "TrainerEditor_RoyalePointsInfinite": "Points de Royale Infinie",
   "TrainerEditor_BattleChateau": "Château Combat",
   "TrainerEditor_Rank": "Rang",
   "TrainerEditor_Points": "Points",

--- a/PKHeX.Presentation/Localization/Strings/it.json
+++ b/PKHeX.Presentation/Localization/Strings/it.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "Punti Merito",
   "TrainerEditor_PokeMiles": "Poke Miglia",
   "TrainerEditor_GimmighoulCoins": "Monete Gimmighoul",
+  "TrainerEditor_RoyalePoints": "Punti Royale",
+  "TrainerEditor_RoyalePointsInfinite": "Punti Royale Infinita",
   "TrainerEditor_BattleChateau": "Castello di Lotta",
   "TrainerEditor_Rank": "Rango",
   "TrainerEditor_Points": "Punti",

--- a/PKHeX.Presentation/Localization/Strings/ja.json
+++ b/PKHeX.Presentation/Localization/Strings/ja.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "メリットポイント",
   "TrainerEditor_PokeMiles": "ポケマイル",
   "TrainerEditor_GimmighoulCoins": "コレクレーコイン",
+  "TrainerEditor_RoyalePoints": "ロワイヤルポイント",
+  "TrainerEditor_RoyalePointsInfinite": "無限ロワイヤルポイント",
   "TrainerEditor_BattleChateau": "バトルシャトー",
   "TrainerEditor_Rank": "ランク",
   "TrainerEditor_Points": "ポイント",

--- a/PKHeX.Presentation/Localization/Strings/ko.json
+++ b/PKHeX.Presentation/Localization/Strings/ko.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "메리트 포인트",
   "TrainerEditor_PokeMiles": "포케마일",
   "TrainerEditor_GimmighoulCoins": "삐끄뭉치 코인",
+  "TrainerEditor_RoyalePoints": "로열 포인트",
+  "TrainerEditor_RoyalePointsInfinite": "무한 로열 포인트",
   "TrainerEditor_BattleChateau": "배틀 샤토",
   "TrainerEditor_Rank": "랭크",
   "TrainerEditor_Points": "포인트",

--- a/PKHeX.Presentation/Localization/Strings/zh-Hans.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hans.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "功绩点",
   "TrainerEditor_PokeMiles": "宝可里程",
   "TrainerEditor_GimmighoulCoins": "藏钱奇的硬币",
+  "TrainerEditor_RoyalePoints": "登峰战点数",
+  "TrainerEditor_RoyalePointsInfinite": "无限登峰战点数",
   "TrainerEditor_BattleChateau": "对战宅邸",
   "TrainerEditor_Rank": "等级",
   "TrainerEditor_Points": "点数",

--- a/PKHeX.Presentation/Localization/Strings/zh-Hant.json
+++ b/PKHeX.Presentation/Localization/Strings/zh-Hant.json
@@ -2095,6 +2095,8 @@
   "TrainerEditor_MeritPoints": "功績點數",
   "TrainerEditor_PokeMiles": "寶可里數",
   "TrainerEditor_GimmighoulCoins": "藏寶怪金幣",
+  "TrainerEditor_RoyalePoints": "登峰戰點數",
+  "TrainerEditor_RoyalePointsInfinite": "無限登峰戰點數",
   "TrainerEditor_BattleChateau": "對戰城堡",
   "TrainerEditor_Rank": "等級",
   "TrainerEditor_Points": "點數",

--- a/Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs
@@ -2,6 +2,7 @@
 using Avalonia.Headless.XUnit;
 using Moq;
 using PKHeX.Avalonia.Services;
+using PKHeX.Avalonia.Tests.Fixtures;
 using PKHeX.Presentation.ViewModels;
 using PKHeX.Core;
 using Xunit;
@@ -233,8 +234,76 @@ public class TrainerEditorTests
         // if we use a type that we know typically doesn't have the "Badges" int property exposed *yet* 
         // or if we just use a type that definitely doesn't.
         
-        // However, it's safer to just rely on the first test for positive confirmation. 
+        // However, it's safer to just rely on the first test for positive confirmation.
         // If we want a negative test, we'd need a concrete SaveFile subclass that definitely doesn't have the property.
         // Let's skip the negative test for now unless we are sure about which one lacks it.
+    }
+
+    // Issue #250: ZA Trainer editor renders an empty Currencies section. The ViewModel already
+    // loaded RoyalePoints/RoyalePointsInfinite correctly, but TrainerEditor.axaml had no controls
+    // for them in the Currencies WrapPanel, so the card showed as visible-but-empty.
+
+    [AvaloniaFact]
+    public void ZARoyalePoints_ShouldLoad_FromRealSave()
+    {
+        var dir = SaveFileFixture.FindSaveFilesPath();
+        if (dir is null)
+            return; // Tests/savefiles not present in this environment
+
+        var path = Path.Combine(dir, "gen9a_legendsza.main");
+        var sav = SaveFileFixture.LoadSave(path) as SAV9ZA;
+        if (sav is null)
+            return; // gen9a_legendsza.main not present — run Tests/savefiles/download_saves.sh
+
+        var vm = new TrainerEditorViewModel(sav);
+
+        Assert.True(vm.HasRoyalePoints);
+        Assert.True(vm.HasRoyalePointsInfinite);
+        Assert.True(vm.AnyCurrencyVisible);
+    }
+
+    [AvaloniaFact]
+    public void ZARoyalePoints_ShouldPersist_RoundTrip()
+    {
+        var dir = SaveFileFixture.FindSaveFilesPath();
+        if (dir is null)
+            return; // Tests/savefiles not present in this environment
+
+        var path = Path.Combine(dir, "gen9a_legendsza.main");
+        var sav = SaveFileFixture.LoadSave(path) as SAV9ZA;
+        if (sav is null)
+            return; // gen9a_legendsza.main not present — run Tests/savefiles/download_saves.sh
+
+        // 1. Load ViewModel
+        var vm = new TrainerEditorViewModel(sav);
+        Assert.True(vm.HasRoyalePoints);
+        Assert.True(vm.HasRoyalePointsInfinite);
+
+        // 2. Modify
+        vm.RoyalePoints = 12345;
+        vm.RoyalePointsInfinite = 6789;
+
+        // 3. Save
+        vm.SaveCommand.Execute(null);
+
+        // 4. Verify persistence directly on the SaveFile
+        Assert.Equal(12345u, sav.TicketPointsRoyale);
+        Assert.Equal(6789u, sav.TicketPointsRoyaleInfinite);
+
+        // 5. Verify reload
+        var reloadedVm = new TrainerEditorViewModel(sav);
+        Assert.Equal(12345u, reloadedVm.RoyalePoints);
+        Assert.Equal(6789u, reloadedVm.RoyalePointsInfinite);
+    }
+
+    [AvaloniaFact]
+    public void ZACurrencyFlags_ShouldNotAppear_ForNonZASave()
+    {
+        // SAV3E has no concept of ZA Royale ticket points.
+        var sav = new SAV3E();
+        var vm = new TrainerEditorViewModel(sav);
+
+        Assert.False(vm.HasRoyalePoints);
+        Assert.False(vm.HasRoyalePointsInfinite);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #250: the ZA Trainer editor's Currencies section rendered as an empty card for Pokémon Legends Z-A saves.
- **Root cause**: `TrainerEditorViewModel` already loaded `RoyalePoints`/`RoyalePointsInfinite` from `SAV9ZA` correctly and turned `AnyCurrencyVisible` on, but `TrainerEditor.axaml`'s Currencies `WrapPanel` had no `StackPanel` entries bound to those two properties — so the card appeared but had nothing in it. Confirmed against the real fixture (`Tests/savefiles/gen9a_legendsza.main`): Royale = 260000, Royale Infinite = 10000, both unreachable in the UI before this fix.
- **Fix**: added the two missing labeled `NumericUpDown` controls to the WrapPanel, matching the existing sibling pattern exactly (`Width="140"`, `Margin="0,0,16,12"`, `Minimum="0"`, `FormatString="0"`, `ShowButtonSpinner="False"`, no explicit `Maximum` — verified via a headless test that Avalonia's `NumericUpDown` defaults `Maximum` to `decimal.MaxValue`, so a bare `uint` value is never clamped, same as the existing `Watts`/`BP`/`Coins` entries).
- **HyperspacePoints investigated, not wired up**: `SaveBlockAccessor9ZA` declares `KHyperspaceSurveyPoints` as a bare block-key constant with no type annotation and no wrapping property anywhere in `SAV9ZA.cs` (unlike `TicketPointsRoyale`/`TicketPointsRoyaleInfinite`, which are real typed properties). Verified empirically: the real save fixture doesn't have this block at all (`HasBlock` → false), and even a freshly constructed `SAV9ZA()` reports it as `SCTypeCode.None` (an untyped placeholder) rather than real data. Since Core exposes no usable value here, `HasHyperspacePoints`/`HyperspacePoints` were intentionally left untouched in the ViewModel (no control added) so the change stays minimal — this is a `PKHeX.Core` gap, not something fixable from the consumer layer.
- **Localization**: added `TrainerEditor_RoyalePoints` / `TrainerEditor_RoyalePointsInfinite` to all 9 locale files (`de, en, es, fr, it, ja, ko, zh-Hans, zh-Hant`), grounded in Bulbapedia's official in-game "Z-A Royale" localization table rather than guessed translations.
- Bumped `UIVersion` 1.48.3 → 1.48.4 (patch, per repo convention for a `fix`).

## Test plan

New tests in `Tests/PKHeX.Avalonia.Tests/TrainerEditorTests.cs`:
- [x] `ZARoyalePoints_ShouldLoad_FromRealSave` — loading the real ZA fixture sets `HasRoyalePoints`/`HasRoyalePointsInfinite`/`AnyCurrencyVisible`.
- [x] `ZARoyalePoints_ShouldPersist_RoundTrip` — set both values, Save, verify persisted on the `SaveFile`, and verify a fresh ViewModel reload reads them back.
- [x] `ZACurrencyFlags_ShouldNotAppear_ForNonZASave` — a non-ZA save (`SAV3E`) does not report the ZA currency flags.

Verification (Release, from a clean rebase onto current `main`):
- [x] `dotnet build PKHeX.sln -c Release` → 0 Warning(s), 0 Error(s)
- [x] `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release` → Passed: 2577, Skipped: 1 (pre-existing, unrelated), Failed: 0
- [x] `AccessibilityAuditTests` and `LocalizationAuditTests` guardrails pass
- [x] `LocalizationServiceTests.AllNineLanguageFiles_Exist_And_Are_KeyComplete_Against_English` passes (all 9 locale files stay key-complete)

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)