### PR TITLE
fix: place living dex on the UI thread and refresh after failure (#262)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.48.3</UIVersion>
+    <UIVersion>1.48.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Application/Services/UndoRedoService.cs
+++ b/PKHeX.Application/Services/UndoRedoService.cs
@@ -18,6 +18,17 @@ namespace PKHeX.Application.Services;
 /// tracked entirely on this side instead: each group entry captures its own before/after snapshot per slot
 /// and is undone/redone by writing those snapshots back directly, so one <see cref="Undo"/> reverts the whole
 /// group no matter how Core stacks the individual entries.
+///
+/// <para>
+/// <b>Thread affinity: call every member on the UI thread.</b> This type has no synchronization of its
+/// own, and its <see cref="StateChanged"/>, <see cref="UndoPerformed"/>, and <see cref="RedoPerformed"/>
+/// events are raised synchronously on the calling thread straight into UI-bound listeners (command
+/// <c>CanExecuteChanged</c>, box/party refreshes). It also has no ownership of the <see cref="SaveFile"/>
+/// it mutates, which the UI thread reads concurrently. Calling from a worker thread previously produced
+/// Avalonia's "Call from invalid thread" and raced the save's box buffer (issue #262). Offload the
+/// expensive work that <i>computes</i> a change, then apply and record it here on the UI thread — the
+/// split <c>BatchEditorViewModel</c> and <c>LivingDexGeneratorViewModel</c> both use.
+/// </para>
 /// </remarks>
 public sealed class UndoRedoService
 {

--- a/PKHeX.Application/UseCases/LivingDexPlacementUseCase.cs
+++ b/PKHeX.Application/UseCases/LivingDexPlacementUseCase.cs
@@ -79,16 +79,31 @@ public sealed class LivingDexPlacementUseCase
             return LivingDexPlacementResult.Refuse(requiredSlots: pokemon.Count, availableSlots: contiguous);
 
         undoRedo?.BeginBatch();
-        for (var i = 0; i < pokemon.Count; i++)
+        try
         {
-            var index = startIndex + i;
-            var box = index / slotsPerBox;
-            var slot = index % slotsPerBox;
+            for (var i = 0; i < pokemon.Count; i++)
+            {
+                var index = startIndex + i;
+                var box = index / slotsPerBox;
+                var slot = index % slotsPerBox;
 
-            undoRedo?.AddChange(new SlotInfoBox(box, slot, sav));
-            sav.SetBoxSlotAtIndex(pokemon[i], box, slot);
+                undoRedo?.AddChange(new SlotInfoBox(box, slot, sav));
+                sav.SetBoxSlotAtIndex(pokemon[i], box, slot);
+            }
         }
-        undoRedo?.EndBatch();
+        finally
+        {
+            // Core writes box slots straight into the box buffer (SetBoxSlotAtIndex -> SetBoxSlot ->
+            // WriteSlotStored) and never touches SaveFileState, so nothing else marks the save dirty
+            // for a Living Dex fill. Set it here, and set it even when a write threw partway: at that
+            // point earlier slots are already written, and under-reporting a modified save is the
+            // dangerous direction.
+            sav.State.Edited = true;
+
+            // Always close the batch. Leaving it open after a mid-loop failure would silently absorb
+            // the next unrelated edit into this dead group, and the partial writes must stay undoable.
+            undoRedo?.EndBatch();
+        }
 
         return LivingDexPlacementResult.Ok(pokemon.Count);
     }

--- a/PKHeX.Presentation/ViewModels/LivingDexGeneratorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/LivingDexGeneratorViewModel.cs
@@ -69,6 +69,11 @@ public partial class LivingDexGeneratorViewModel : ViewModelBase
         StatusMessage = "Generating a legal Pokémon for every species in this game…";
         _cts = new CancellationTokenSource();
 
+        // Set the moment placement starts writing, and cleared again only once we know it wrote
+        // nothing. Anything that reaches the finally block with this still set may have left entities
+        // in the boxes, so the host is told to refresh even on the failure paths (issue #262).
+        var boxesMayHaveChanged = false;
+
         try
         {
             var options = new LivingDexOptions(IncludeForms, SetShiny);
@@ -92,7 +97,18 @@ public partial class LivingDexGeneratorViewModel : ViewModelBase
                 return;
             }
 
-            var placement = await Task.Run(() => _placement.TryPlace(_sav, result.Pokemon, startBox, _undoRedo), token);
+            token.ThrowIfCancellationRequested();
+
+            // Placement runs on the UI thread deliberately (issue #262). It mutates the save's box
+            // buffer and closes an UndoRedoService batch whose StateChanged event drives UI-bound
+            // command state; doing that from a Task.Run worker both raced the UI thread's reads of the
+            // same buffer and made Avalonia throw "Call from invalid thread". Only the expensive
+            // generation above is offloaded - the same split BatchEditorViewModel already uses (build
+            // the plan off-thread, commit it on the UI thread). Placement is a few hundred buffer
+            // writes with no legality work, so it is imperceptible next to generation.
+            boxesMayHaveChanged = true;
+            var placement = _placement.TryPlace(_sav, result.Pokemon, startBox, _undoRedo);
+            boxesMayHaveChanged = placement.Status == LivingDexPlacementStatus.Success;
 
             if (placement.Status == LivingDexPlacementStatus.InsufficientSpace)
             {
@@ -106,18 +122,28 @@ public partial class LivingDexGeneratorViewModel : ViewModelBase
             StatusMessage = $"Placed {placement.PlacedCount} legal Pokémon starting at "
                 + $"\"{BoxNames.ElementAtOrDefault(startBox) ?? $"Box {startBox + 1}"}\".";
             ReportSkipped(result);
-            BoxesUpdated?.Invoke();
         }
         catch (OperationCanceledException)
         {
+            // Only reachable before placement begins: TryPlace takes no token and cannot be cancelled.
             StatusMessage = "Generation cancelled. No changes were made.";
         }
         catch (Exception ex)
         {
-            StatusMessage = $"Unexpected error: {ex.Message}";
+            // TryPlace writes slot by slot, so a failure partway leaves entities already in the boxes.
+            // Say so instead of implying nothing happened; the whole attempt is still one undo step.
+            StatusMessage = boxesMayHaveChanged
+                ? $"Placement failed partway through: {ex.Message} Some Pokémon were already written to the boxes - use Undo to revert them."
+                : $"Unexpected error: {ex.Message}";
         }
         finally
         {
+            // Exactly one refresh on every path that may have written to the boxes, success or not.
+            // Before #262 this only ran on success, so a mid-placement failure left the box view
+            // showing empty slots over a save that had actually been modified.
+            if (boxesMayHaveChanged)
+                BoxesUpdated?.Invoke();
+
             IsRunning = false;
             Progress = 0;
             _cts = null;

--- a/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/MainWindowViewModel.cs
@@ -164,11 +164,15 @@ public partial class MainWindowViewModel : ViewModelBase
         _slotService.MoveRequested += OnMoveRequested;
         _slotService.ReplaceRequested += OnReplaceRequested;
 
-        _undoRedo.StateChanged += (_, _) =>
+        // Marshalled (issue #262): NotifyCanExecuteChanged reaches the Undo/Redo MenuItems, which read
+        // an AvaloniaProperty and therefore assert UI-thread access. UndoRedoService is a shared
+        // singleton with no thread affinity of its own, so any caller that closes a change off the UI
+        // thread would otherwise take the whole shell down with "Call from invalid thread".
+        _undoRedo.StateChanged += (_, _) => PostToUi(() =>
         {
             UndoCommand.NotifyCanExecuteChanged();
             RedoCommand.NotifyCanExecuteChanged();
-        };
+        });
         _undoRedo.UndoPerformed += OnUndoRedoPerformed;
         _undoRedo.RedoPerformed += OnUndoRedoPerformed;
 
@@ -316,6 +320,21 @@ public partial class MainWindowViewModel : ViewModelBase
             action();
         else
             _uiContext.Post(_ => action(), null);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the UI thread, inline when already there. Mirrors
+    /// <c>BatchEditorViewModel.PostToUi</c> and goes through the <see cref="IUiDispatcher"/> port, so
+    /// Presentation stays framework-free. Deliberately separate from <see cref="RunOnUiThread"/> above,
+    /// which predates the port and still serves the update-check notification; consolidating the two is
+    /// left to its own change.
+    /// </summary>
+    private void PostToUi(Action action)
+    {
+        if (_uiDispatcher is null || _uiDispatcher.CheckAccess())
+            action();
+        else
+            _uiDispatcher.Post(action);
     }
 
     /// <summary>

--- a/Tests/PKHeX.Avalonia.Tests/Harness/HeadlessAppFixture.cs
+++ b/Tests/PKHeX.Avalonia.Tests/Harness/HeadlessAppFixture.cs
@@ -57,7 +57,12 @@ public sealed class HeadlessAppFixture : IDisposable
     /// <summary>The main box viewer once a save is loaded, or <see langword="null"/>.</summary>
     public BoxViewerViewModel? BoxViewer => ViewModel.BoxViewer;
 
-    public HeadlessAppFixture()
+    /// <param name="configureOverrides">
+    /// Optional extra DI registrations, applied last so they win over both the production wiring and
+    /// the two host doubles below. Use it to swap a long-running production service for a fast stub
+    /// (e.g. <c>ILivingDexService</c>) while keeping the rest of the object graph real.
+    /// </param>
+    public HeadlessAppFixture(Action<IServiceCollection>? configureOverrides = null)
     {
         Dialogs = new RecordingDialogService();
         Windows = new NoopWindowService();
@@ -73,6 +78,7 @@ public sealed class HeadlessAppFixture : IDisposable
                 // Registered last, so DI's last-wins resolution replaces the production host services.
                 svc.AddSingleton<IDialogService>(Dialogs);
                 svc.AddSingleton<IWindowService>(Windows);
+                configureOverrides?.Invoke(svc);
             });
 
         Gateway = Services.GetRequiredService<ISaveFileGateway>();

--- a/Tests/PKHeX.Avalonia.Tests/LivingDexPlacementUiThreadTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/LivingDexPlacementUiThreadTests.cs
@@ -1,0 +1,207 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using PKHeX.Application.UseCases;
+using PKHeX.Avalonia.Tests.Harness;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using Xunit;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// Regression coverage for issue #262 - "Living Dex placement failing with an invalid-thread error".
+///
+/// <para>
+/// The shipped bug: <c>LivingDexGeneratorViewModel.GenerateAsync</c> ran <b>placement</b> (not just
+/// generation) inside <c>Task.Run</c>. Placement mutates the save and closes an
+/// <see cref="UndoRedoService"/> batch, whose <c>StateChanged</c> event reaches
+/// <c>MainWindowViewModel</c>'s <c>UndoCommand.NotifyCanExecuteChanged()</c>. The Undo/Redo
+/// <c>MenuItem</c>s in <c>MainWindow.axaml</c> are direct XAML children, so they are attached to the
+/// logical tree - and subscribed to <c>CanExecuteChanged</c> - from the moment the window loads, with
+/// no menu ever opened. Raising that event off the UI thread makes Avalonia's
+/// <c>Dispatcher.VerifyAccess()</c> throw <c>InvalidOperationException: Call from invalid thread</c>.
+/// </para>
+///
+/// <para>
+/// Why the nine existing <see cref="LivingDexTests"/> missed it: every one of them calls
+/// <see cref="LivingDexPlacementUseCase.TryPlace"/> synchronously against a bare
+/// <see cref="UndoRedoService"/> that has <b>no subscribers</b>, so no thread boundary and no UI-bound
+/// listener is ever involved. These tests instead drive the real command through
+/// <see cref="HeadlessAppFixture"/> - the real composition root, the real <c>MainWindow</c>, and
+/// therefore the real <c>MenuItem</c> command subscribers - with only <see cref="ILivingDexService"/>
+/// stubbed so the run is fast.
+/// </para>
+/// </summary>
+public class LivingDexPlacementUiThreadTests
+{
+    /// <summary>
+    /// Stands in for the real (minutes-long) generator. Also records whether it was invoked off the UI
+    /// thread, so a "fix" that simply made the whole flow synchronous would fail the assertion.
+    /// </summary>
+    private sealed class StubLivingDexService(IReadOnlyList<PKM> pokemon) : ILivingDexService
+    {
+        public bool RanOffUiThread { get; private set; }
+
+        public LivingDexGenerationResult Generate(
+            SaveFile sav,
+            LivingDexOptions options,
+            IProgress<LivingDexGenerationProgress>? progress = null,
+            CancellationToken cancellationToken = default,
+            int? maxSpeciesId = null)
+        {
+            RanOffUiThread = !Dispatcher.UIThread.CheckAccess();
+            progress?.Report(new LivingDexGenerationProgress(pokemon.Count, pokemon.Count));
+            return LivingDexGenerationResult.Ok(pokemon, []);
+        }
+    }
+
+    /// <summary>A cheap, format-correct entity for <paramref name="sav"/>. Placement performs no legality work.</summary>
+    private static PKM MakeEntity(SaveFile sav, ushort species)
+    {
+        var pk = sav.BlankPKM;
+        pk.Species = species;
+        return pk;
+    }
+
+    private static LivingDexGeneratorViewModel OpenGenerator(HeadlessAppFixture app)
+    {
+        app.ViewModel.OpenLivingDexGeneratorCommand.Execute(null);
+        app.Pump();
+        return app.Windows.ShownTools.Select(t => t.ViewModel).OfType<LivingDexGeneratorViewModel>().Single();
+    }
+
+    // -------------------------------------------------------------------
+    // The reported failure: generation succeeds, placement dies on the thread boundary
+    // -------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public async Task GenerateCommand_PlacesTheDex_WithoutAnInvalidThreadError()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        var pokemon = new List<PKM> { MakeEntity(sav, 25), MakeEntity(sav, 52), MakeEntity(sav, 133) };
+        var service = new StubLivingDexService(pokemon);
+
+        using var app = new HeadlessAppFixture(svc => svc.AddSingleton<ILivingDexService>(service));
+        app.LoadSaveInstance(sav);
+
+        var vm = OpenGenerator(app);
+        var refreshes = 0;
+        vm.BoxesUpdated += () => refreshes++;
+
+        await vm.GenerateCommand.ExecuteAsync(null);
+        app.Pump();
+
+        Assert.DoesNotContain("invalid thread", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Unexpected error", vm.StatusMessage, StringComparison.Ordinal);
+        Assert.Contains("Placed 3", vm.StatusMessage, StringComparison.Ordinal);
+
+        // The Pokemon actually reached the boxes...
+        for (var i = 0; i < pokemon.Count; i++)
+            Assert.Equal(pokemon[i].Species, sav.GetBoxSlotAtIndex(0, i).Species);
+
+        // ...the host was told exactly once to refresh, so the box view is not left stale...
+        Assert.Equal(1, refreshes);
+
+        // ...the whole fill is one undoable operation...
+        var undoRedo = app.Services.GetRequiredService<UndoRedoService>();
+        Assert.True(undoRedo.CanUndo);
+
+        // ...and generation itself is still offloaded (the expensive part must not move to the UI thread).
+        Assert.True(service.RanOffUiThread, "Living Dex generation must keep running off the UI thread.");
+    }
+
+    // -------------------------------------------------------------------
+    // The second half of #262: a mid-placement failure left the save silently mutated
+    // -------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public async Task GenerateCommand_WhenPlacementFailsPartway_RefreshesTheBoxesAndSaysSo()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        // The third entity is the wrong PKM format for this save, so SaveFile.SetBoxSlot throws *after*
+        // the first two slots have already been written - the exact partial-write shape #262 hid.
+        var written = new List<PKM> { MakeEntity(sav, 25), MakeEntity(sav, 52) };
+        var pokemon = new List<PKM>(written) { new PK9 { Species = 133 } };
+        var service = new StubLivingDexService(pokemon);
+
+        using var app = new HeadlessAppFixture(svc => svc.AddSingleton<ILivingDexService>(service));
+        app.LoadSaveInstance(sav);
+
+        var vm = OpenGenerator(app);
+        var refreshes = 0;
+        vm.BoxesUpdated += () => refreshes++;
+
+        await vm.GenerateCommand.ExecuteAsync(null);
+        app.Pump();
+
+        // The boxes really were modified, so the UI must be refreshed rather than left showing empties.
+        Assert.Equal(written[0].Species, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.Equal(written[1].Species, sav.GetBoxSlotAtIndex(0, 1).Species);
+        Assert.Equal(1, refreshes);
+
+        // The message must admit the save was touched instead of implying nothing happened.
+        Assert.Contains("partway", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Undo", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+
+        // The partial writes stay undoable: the batch is closed even though the loop threw.
+        var undoRedo = app.Services.GetRequiredService<UndoRedoService>();
+        Assert.True(undoRedo.CanUndo);
+        undoRedo.Undo();
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, 0).Species);
+        Assert.Equal(0, sav.GetBoxSlotAtIndex(0, 1).Species);
+    }
+
+    // -------------------------------------------------------------------
+    // Defense in depth: an off-thread StateChanged must never crash the shell again
+    // -------------------------------------------------------------------
+
+    [AvaloniaFact]
+    public async Task UndoRedoStateChanged_RaisedOffTheUiThread_DoesNotCrashTheShell()
+    {
+        using var app = new HeadlessAppFixture();
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        app.LoadSaveInstance(sav);
+
+        var undoRedo = app.Services.GetRequiredService<UndoRedoService>();
+
+        // AddChange -> SetChangeCount -> StateChanged -> MainWindowViewModel's Undo/RedoCommand
+        // NotifyCanExecuteChanged -> the real MenuItem command subscribers.
+        var thrown = await Record.ExceptionAsync(
+            () => Task.Run(() => undoRedo.AddChange(new SlotInfoBox(0, 0, sav))));
+
+        Assert.Null(thrown);
+        app.Pump();
+        Assert.True(undoRedo.CanUndo);
+    }
+
+    // -------------------------------------------------------------------
+    // Dirty-state bookkeeping
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void TryPlace_MarksTheSaveEdited()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        Assert.False(sav.State.Edited);
+
+        var result = new LivingDexPlacementUseCase().TryPlace(sav, [MakeEntity(sav, 25)], startBox: 0);
+
+        Assert.Equal(LivingDexPlacementStatus.Success, result.Status);
+        Assert.True(sav.State.Edited);
+    }
+
+    [Fact]
+    public void TryPlace_WhenRefused_LeavesTheSaveUnedited()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.SW);
+        sav.SetBoxSlotAtIndex(MakeEntity(sav, 25), 0, 1); // break the contiguous run at slot 1
+        sav.State.Edited = false;
+
+        var result = new LivingDexPlacementUseCase()
+            .TryPlace(sav, [MakeEntity(sav, 52), MakeEntity(sav, 133)], startBox: 0);
+
+        Assert.Equal(LivingDexPlacementStatus.InsufficientSpace, result.Status);
+        Assert.False(sav.State.Edited);
+    }
+}


### PR DESCRIPTION
Closes #262

## Root cause

`LivingDexGeneratorViewModel.GenerateAsync` offloaded **placement** to `Task.Run`, not just generation. Placement mutates the save and closes an `UndoRedoService` batch, and the resulting chain crosses into UI-bound state from a worker thread:

```
Task.Run -> LivingDexPlacementUseCase.TryPlace
         -> UndoRedoService.EndBatch -> SetChangeCount -> StateChanged
         -> MainWindowViewModel: UndoCommand.NotifyCanExecuteChanged()
         -> Avalonia MenuItem.CanExecuteChanged -> MenuItem.TryUpdateCanExecute()
         -> MenuItem.get_Command() -> AvaloniaObject.VerifyAccess()
         -> Dispatcher.VerifyAccess() -> InvalidOperationException: "Call from invalid thread"
```

The Undo/Redo `MenuItem`s in `MainWindow.axaml` are **direct XAML children**, so they are attached to the logical tree — and subscribed to `CanExecuteChanged` — from the moment the window loads. The failure is therefore deterministic with the Options menu never opened, which matches the reported repro. (Confirmed against a standalone Avalonia 11.3.18 harness: the same structure built with `ItemsSource` instead of direct `Items` does *not* subscribe until first open, which is why the XAML shape here makes it fire 100% of the time.)

## The reported "no Pokémon are placed" was actually a silent partial mutation

`TryPlace` writes every slot **before** closing the batch, so by the time `EndBatch()` threw, the entities were already committed to the save's box buffer. Only the `BoxesUpdated` refresh was skipped. The user saw `Unexpected error` over empty-looking boxes on a save that had in fact been modified — and a subsequent File > Save would have written the dex to disk. This is the more dangerous half of the bug and it survives the threading fix, since any other mid-placement exception reproduces it.

## Changes

- **Placement runs on the UI thread**; generation stays in `Task.Run`. This is the split `BatchEditorViewModel` already uses (build the plan off-thread, commit it on the UI thread). It also removes an unsynchronized race: `TryPlace` was writing the box buffer while the UI thread rendered slots from it and `BatchEditorViewModel`'s background preview read it, with no lock anywhere. Placement is a few hundred buffer writes with no legality work — imperceptible next to a minutes-long generation.
- **`BoxesUpdated` now fires on every path that may have written**, moved into `finally` and gated so it fires exactly once and never on paths that provably wrote nothing (`InsufficientSpace`). A mid-placement failure reports `Placement failed partway through: … Some Pokémon were already written to the boxes - use Undo to revert them.` instead of implying nothing happened.
- **`_pendingBatch` leak fixed.** `TryPlace` left the undo batch open when a write threw mid-loop, so the partial writes were unrecoverable *and* the orphaned batch would have silently absorbed the user's next unrelated edit into a dead group. The write loop is now wrapped in `try`/`finally` with `EndBatch()` in the `finally`, so partial writes stay undoable in one step.
- **`sav.State.Edited` bookkeeping.** Verified (not assumed) that Core does not mark the save dirty on this path: `SetBoxSlotAtIndex` -> `SetBoxSlot` -> `WriteSlotStored` -> `pk.WriteEncryptedDataStored(data)` is a raw span write, and `State.Edited = true` appears only in `SaveFile.SetData` and `SaveFile.SetFlag`. A test asserting it failed before this change and passes after. **Note:** this has no user-visible effect today — `State.Edited` has writers but **zero readers** across all four app projects, and the `Settings_WarnClosingModified` toggle is bound to nothing that acts on it. This is correct bookkeeping in the layer that owns the mutation and a prerequisite for the close prompt when it lands; the missing prompt is tracked separately.
- **Shell hardening.** `MainWindowViewModel`'s `StateChanged` handler is marshalled through the `IUiDispatcher` port the VM already held but never used, mirroring `BatchEditorViewModel.PostToUi`, so no future off-thread notifier can take the shell down. Presentation stays framework-free. The older `_uiContext`/`RunOnUiThread` helper and its single existing consumer are deliberately left alone; consolidating the two is its own change.
- **`UndoRedoService` thread-affinity documented** (doc only, no behavior change): every member must be called on the UI thread, since it has no synchronization, raises its events synchronously into UI-bound listeners, and does not own the `SaveFile` the UI thread reads concurrently.
- **`HeadlessAppFixture` gained an optional `configureOverrides` parameter**, applied last so a test can swap one production service for a stub while keeping the rest of the object graph real. The parameter defaults to `null`, and with `null` the registration lambda is byte-for-byte what it was — **zero behavior change for every existing call site**.

## Why this shipped, and the new coverage

All nine existing `LivingDexTests` call `TryPlace` synchronously against a bare `UndoRedoService` with **no subscribers**, so no thread boundary and no UI-bound listener was ever exercised. The new tests drive the real command through `HeadlessAppFixture` — real composition root, real `MainWindow`, real `MenuItem` command subscribers — with only `ILivingDexService` stubbed so the run is fast:

- `GenerateCommand_PlacesTheDex_WithoutAnInvalidThreadError`
- `GenerateCommand_WhenPlacementFailsPartway_RefreshesTheBoxesAndSaysSo`
- `UndoRedoStateChanged_RaisedOffTheUiThread_DoesNotCrashTheShell`
- `TryPlace_MarksTheSaveEdited`
- `TryPlace_WhenRefused_LeavesTheSaveUnedited`

Before the fix: **4 failed / 1 passed**, with the exact `Dispatcher.VerifyAccess` stack above. After: **5 passed**. The partial-failure test's pre-fix failure was `refreshes Expected: 1, Actual: 0` *while its assertions that the slots held the entities passed* — independent confirmation of the silent-mutation finding.

## Verification

- `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- `dotnet test Tests/PKHeX.Avalonia.Tests` — 2579 passed, 0 failed, 1 skipped (pre-existing `Skip=` attribute, unchanged from main)
- `dotnet test Tests/PKHeX.Architecture.Tests` — 6 passed (layering intact; `IUiDispatcher` was already an Application abstraction consumed by Presentation)
- No edits under `PKHeX.Core/` or `PKHeX.AutoMod/`. `UIVersion` 1.48.3 -> 1.48.4 (patch, fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
