### PR TITLE
fix: recalculate move PP when a move or PP-Up changes (#226)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.48.3</UIVersion>
+    <UIVersion>1.48.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Moves.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.Moves.cs
@@ -162,12 +162,32 @@ public partial class PokemonEditorViewModel
         LoadFromPKM();
     }
 
-    partial void OnMove1Changed(int value) { if (!_isLoading) Validate(); }
-    partial void OnMove2Changed(int value) { if (!_isLoading) Validate(); }
-    partial void OnMove3Changed(int value) { if (!_isLoading) Validate(); }
-    partial void OnMove4Changed(int value) { if (!_isLoading) Validate(); }
+    partial void OnMove1Changed(int value) { if (!_isLoading) { Pp1 = GetRecalculatedPp(value, PpUps1); Validate(); } }
+    partial void OnMove2Changed(int value) { if (!_isLoading) { Pp2 = GetRecalculatedPp(value, PpUps2); Validate(); } }
+    partial void OnMove3Changed(int value) { if (!_isLoading) { Pp3 = GetRecalculatedPp(value, PpUps3); Validate(); } }
+    partial void OnMove4Changed(int value) { if (!_isLoading) { Pp4 = GetRecalculatedPp(value, PpUps4); Validate(); } }
+    partial void OnPpUps1Changed(int value) { if (!_isLoading) { Pp1 = GetRecalculatedPp(Move1, value); Validate(); } }
+    partial void OnPpUps2Changed(int value) { if (!_isLoading) { Pp2 = GetRecalculatedPp(Move2, value); Validate(); } }
+    partial void OnPpUps3Changed(int value) { if (!_isLoading) { Pp3 = GetRecalculatedPp(Move3, value); Validate(); } }
+    partial void OnPpUps4Changed(int value) { if (!_isLoading) { Pp4 = GetRecalculatedPp(Move4, value); Validate(); } }
     partial void OnRelearnMove1Changed(int value) { if (!_isLoading) Validate(); }
     partial void OnRelearnMove2Changed(int value) { if (!_isLoading) Validate(); }
     partial void OnRelearnMove3Changed(int value) { if (!_isLoading) Validate(); }
     partial void OnRelearnMove4Changed(int value) { if (!_isLoading) Validate(); }
+
+    /// <summary>
+    /// Recalculates a move slot's current PP from its move ID and PP Ups, mirroring the semantics of
+    /// <see cref="PKM.HealPPIndex"/>. Called whenever a move or its PP Ups change so the previous
+    /// move's (or PP Up count's) current PP is never left stale — which fails legality when the new
+    /// maximum differs from the old one.
+    /// </summary>
+    private int GetRecalculatedPp(int move, int ppUps)
+    {
+        // Move 0 (None) must always heal to 0 PP. Most PP tables already return a base PP of 0 for
+        // move ID 0, but not every context's table guarantees that, so it is handled explicitly here.
+        if (move == 0 || _pk is null)
+            return 0;
+
+        return _pk.GetMovePP((ushort)move, ppUps);
+    }
 }

--- a/Tests/PKHeX.Avalonia.Tests/ComprehensiveTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/ComprehensiveTests.cs
@@ -309,11 +309,11 @@ public class ComprehensiveTests
         var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
         
         vm.Move1 = 33; // Tackle
+        vm.PpUps1 = 3; // recalculates Pp1 to the new max (issue #226); explicit edit below overrides it
         vm.Pp1 = 35;
-        vm.PpUps1 = 3;
-        
+
         var result = vm.PreparePKM();
-        
+
         Assert.Equal(35, result.Move1_PP);
         Assert.Equal(3, result.Move1_PPUps);
     }
@@ -489,6 +489,9 @@ public class ComprehensiveTests
             "Species", "Form", "Ability", "Level", "TargetPKM", "Nature", "Gender",
             "EggLocation", "MetLocation", "MetLevel", "OriginalTrainerGender", "Ball",
             "RelearnMove1", "RelearnMove2", "RelearnMove3", "RelearnMove4",
+            // Recalculated as a side effect of Move/PpUps changes (issue #226), so independently
+            // fuzzing them in isolation from the field that derives them isn't meaningful here.
+            "Pp1", "Pp2", "Pp3", "Pp4",
             "StatHPCurrent", "StatHPMax", "Valid", "Version", "StatAlignment", "HpType",
             "IsPokerusInfected", "IsPokerusCured", "AbilityNumber", "Id32", "IsNicknamed",
             "StatusCondition", "HandlingTrainerName", "HandlingTrainerGender",

--- a/Tests/PKHeX.Avalonia.Tests/PokemonEditorReportsTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/PokemonEditorReportsTests.cs
@@ -313,4 +313,113 @@ public class PokemonEditorReportsTests
         Assert.True(strain.Bounds.Width > 0);
         Assert.True(days.Bounds.Right < strain.Bounds.Left, $"Pokérus fields overlap: {days.Bounds} / {strain.Bounds}");
     }
+
+    [Fact]
+    public void ChangingAMoveWithADifferentBasePp_RecalculatesThatSlotsCurrentPp()
+    {
+        var sav = new SAV6XY();
+        const int oldMove = 33;
+        const int newMove = 76;
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+            Move1 = oldMove,
+            Move1_PP = 5,
+            Move1_PPUps = 0,
+        };
+        var oldMax = pkm.GetMovePP((ushort)oldMove, 0);
+        var newMax = pkm.GetMovePP((ushort)newMove, 0);
+        Assert.NotEqual(oldMax, newMax); // sanity: the two moves must actually differ in base PP
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        vm.Move1 = newMove;
+
+        Assert.Equal(newMax, vm.Pp1);
+    }
+
+    [Fact]
+    public void ChangingPpUps_RecalculatesThatSlotsCurrentPp()
+    {
+        var sav = new SAV6XY();
+        const int move = 45;
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+            Move2 = move,
+            Move2_PP = 10,
+            Move2_PPUps = 0,
+        };
+        var expected = pkm.GetMovePP((ushort)move, 3);
+        Assert.NotEqual(10, expected); // sanity: raising PP Ups must actually change the max
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        vm.PpUps2 = 3;
+
+        Assert.Equal(expected, vm.Pp2);
+    }
+
+    [Fact]
+    public void LoadingAPokemonWithDamagedPp_KeepsTheReducedPpUntilTheUserChangesSomething()
+    {
+        var sav = new SAV6XY();
+        const int move = 33;
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+            Move1 = move,
+            Move1_PPUps = 0,
+        };
+        var fullPp = pkm.GetMovePP((ushort)move, 0);
+        Assert.True(fullPp > 1); // sanity: there must be room to simulate a used PP below the max
+        pkm.Move1_PP = fullPp - 1;
+
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        Assert.Equal(fullPp - 1, vm.Pp1);
+    }
+
+    [Fact]
+    public void ClearingAMoveToNone_ZeroesThatSlotsCurrentPp()
+    {
+        var sav = new SAV6XY();
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+            Move3 = 45,
+            Move3_PP = 10,
+            Move3_PPUps = 2,
+        };
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        vm.Move3 = 0;
+
+        Assert.Equal(0, vm.Pp3);
+    }
+
+    [Fact]
+    public void ChangingOneMoveSlot_DoesNotAffectTheOtherSlotsCurrentPp()
+    {
+        var sav = new SAV6XY();
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+            Move1 = 33, Move1_PP = 5, Move1_PPUps = 0,
+            Move2 = 45, Move2_PP = 10, Move2_PPUps = 1,
+            Move3 = 76, Move3_PP = 15, Move3_PPUps = 0,
+            Move4 = 92, Move4_PP = 8, Move4_PPUps = 2,
+        };
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        vm.Move1 = 10;
+
+        Assert.Equal(pkm.GetMovePP(10, 0), vm.Pp1);
+        Assert.Equal(10, vm.Pp2);
+        Assert.Equal(15, vm.Pp3);
+        Assert.Equal(8, vm.Pp4);
+    }
 }

--- a/Tests/PKHeX.Avalonia.Tests/PokemonEditorReportsTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/PokemonEditorReportsTests.cs
@@ -422,4 +422,33 @@ public class PokemonEditorReportsTests
         Assert.Equal(15, vm.Pp3);
         Assert.Equal(8, vm.Pp4);
     }
+
+    [Fact]
+    public void ManuallyEditingCurrentPpAfterSelectingAMove_PersistsTheDamagedValue()
+    {
+        var sav = new SAV6XY();
+        const int move = 33;
+        var pkm = new PK6
+        {
+            Species = 25,
+            Language = (int)LanguageID.English,
+        };
+        var (vm, _, _) = TestHelpers.CreateTestViewModel(pkm, sav);
+
+        vm.Move1 = move; // recalculates Pp1 to the full max for the selected move
+        var fullPp = vm.Pp1;
+        Assert.True(fullPp > 1); // sanity: there must be room to simulate battle damage below the max
+
+        vm.Pp1 = fullPp - 8; // user hand-enters a damaged current PP (e.g. after battle), below the recalculated max
+        Assert.NotEqual(fullPp, vm.Pp1);
+
+        // An unrelated field edit re-runs Validate() the same way normal use would; it must not
+        // silently re-derive and clobber the manually-entered PP.
+        vm.Nickname = "Damaged";
+
+        var result = vm.PreparePKM();
+
+        Assert.Equal(fullPp - 8, vm.Pp1);
+        Assert.Equal(fullPp - 8, result.Move1_PP);
+    }
 }


### PR DESCRIPTION
## Summary

- `PokemonEditorViewModel` left a move slot's current PP untouched when the move itself changed, so a slot that previously held a lower-max-PP move kept its stale current-PP value (e.g. old move's PP was 10, new move's max is 15, current PP stayed at 10) — which fails legality once the new move's max PP differs from the old one.
- `OnMove1Changed`..`OnMove4Changed` now recalculate that slot's current PP via `PKM.GetMovePP(move, ppUps)` (the same semantics as Core's `PKM.HealPPIndex`), through a new `GetRecalculatedPp` helper on the ViewModel.
- **PP-Ups changes are included too**: raising PP-Ups raises the max PP for a slot, and leaving current PP stale reproduces the exact same illegal state. New `OnPpUps1Changed`..`OnPpUps4Changed` handlers (these didn't previously exist) recalculate current PP the same way whenever PP-Ups changes.
- Both sets of handlers respect the ViewModel's existing `_isLoading` guard, so loading a Pokémon that already has damaged/reduced PP (e.g. from battle use) leaves that value untouched until the user actually edits a move or PP-Ups — recalculation only ever happens in response to a genuine edit, never on load.
- Clearing a move slot to None (move ID 0) is handled with an explicit `move == 0` check rather than trusting `GetMovePP(0, ppUps)` to return 0 for every context. It doesn't: `PKHeX.Core/Moves/MoveInfo9a.cs` (Gen9a / Legends: Z-A) has a base PP of **35** at table index 0, unlike every other generation's table, which is 0 there. This is an existing quirk in upstream `PKHeX.Core`, so per repo policy it is worked around in the consumer (`PokemonEditorViewModel.Moves.cs`) rather than edited in Core.
- No recursion risk: the new handlers only ever write to `PpX`, and `PpX` has no change handler of its own, so a PP write can never cascade back into a move or PP-Ups change.

## Pre-existing tests modified (and why)

Two tests in `ComprehensiveTests.cs` encoded the old buggy behavior as correct and needed updating once PP-Ups changes started recalculating PP:

- **`RoundTrip_All_Int_Properties`**: this reflection-based fuzzer sets every public `int` property on the ViewModel to a canned value, independently, then checks each one reads back unchanged. `Pp1`..`Pp4` are now derived from `Move`/`PpUps`, so setting them in isolation is no longer meaningful the same way — the fuzzer's own property enumeration order sets `PpUps1` *after* `Pp1`, which now legitimately recalculates `Pp1` and breaks the naive read-back check. `Pp1`..`Pp4` are added to the test's existing `exclusions` set, the same escape hatch already used for `AbilityNumber` (also derived from another field via a side effect).
- **`PP_And_PPUps_Persist_Correctly`**: reordered so `PpUps1` is set *before* the explicit `Pp1 = 35` override, instead of after. Previously the test set `Pp1` then `PpUps1`, so the final `PpUps1` write silently recalculated `Pp1` out from under the test — passing only because the recalculated value coincidentally never got checked against the pre-fix code path. The reorder makes the manual `Pp1` edit the one that actually sticks, matching real UI usage (set PP-Ups, then optionally hand-edit current PP for battle damage), with the same final assertions (`35`, `3`).

## New test coverage

Added to `PokemonEditorReportsTests.cs`:
- `ChangingAMoveWithADifferentBasePp_RecalculatesThatSlotsCurrentPp`
- `ChangingPpUps_RecalculatesThatSlotsCurrentPp`
- `LoadingAPokemonWithDamagedPp_KeepsTheReducedPpUntilTheUserChangesSomething`
- `ClearingAMoveToNone_ZeroesThatSlotsCurrentPp`
- `ChangingOneMoveSlot_DoesNotAffectTheOtherSlotsCurrentPp`
- `ManuallyEditingCurrentPpAfterSelectingAMove_PersistsTheDamagedValue` (added during review: proves a user-entered damaged PP, e.g. below the recalculated max, is never silently clobbered by later unrelated field edits that also re-run `Validate()`)

Closes #226

## Test plan

- [x] `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test Tests/PKHeX.Avalonia.Tests/PKHeX.Avalonia.Tests.csproj -c Release` — 2580 passed, 1 pre-existing unrelated skip, 0 failed
- [x] `dotnet test Tests/PKHeX.Architecture.Tests/PKHeX.Architecture.Tests.csproj -c Release` — 6/6 passed (no Clean Architecture layering violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)