### PR TITLE
fix: adapt encounter entities to the save format before editing (#234)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
     <Copyright>Copyright © Patrik Lleshaj</Copyright>
     <SourceRevisionId>$([System.DateTime]::UtcNow.ToString("yyMMddHHmmss"))</SourceRevisionId>
     <!-- UI version for PKHeX.Avalonia releases (semver) -->
-    <UIVersion>1.48.3</UIVersion>
+    <UIVersion>1.48.4</UIVersion>
   </PropertyGroup>
 </Project>

--- a/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
+++ b/PKHeX.Presentation/ViewModels/PokemonEditorViewModel.cs
@@ -160,11 +160,43 @@ public partial class PokemonEditorViewModel : ViewModelBase
         LoadFromPKM();
     }
 
-    public void LoadPKM(PKM pk)
+    /// <summary>
+    /// Loads an entity into the editor, adapting it to the open save file's entity format first.
+    /// </summary>
+    /// <remarks>
+    /// Every dropdown in this editor (species, moves, items, balls, abilities) comes from
+    /// <see cref="GameInfo.FilteredSources"/>, which is scoped to the <em>save file</em>. The entity
+    /// being edited therefore has to be in that save's own format, or the editor offers values the
+    /// entity cannot physically store and the write silently truncates.
+    /// <para>
+    /// Sources such as the Encounter Database hand back the encounter's <em>native</em> format
+    /// (<c>IEncounterConvertible.ConvertToPKM</c> returns a <see cref="PK2"/> for a Gen 2 wild slot,
+    /// even when the open save is Gen 7+). <c>PK2.Species</c> is a single byte, so selecting Ambipom
+    /// (424) stored <c>424 &amp; 0xFF</c> = 168 and the preview rendered Ariados while the title said
+    /// Ambipom — GitHub issue #234.
+    /// </para>
+    /// Mirrors upstream PKHeX's <c>PKMEditor.LoadFieldsFromPKM</c> (and the file-import path's
+    /// <c>SaveExtensions.GetCompatible</c>): convert to the save's format, or refuse the load and
+    /// report why rather than editing a foreign-format entity.
+    /// </remarks>
+    /// <returns><see langword="true"/> if the entity was loaded; <see langword="false"/> if it could
+    /// not be adapted to the save's format, in which case the editor keeps its current entity.</returns>
+    public bool LoadPKM(PKM pk)
     {
         ArgumentNullException.ThrowIfNull(pk);
-        _pk = pk.Clone();
+
+        var target = _sav.BlankPKM;
+        if (!EntityConverter.TryMakePKMCompatible(pk, target, out var result, out var compatible))
+        {
+            _ = _dialogService.ShowErrorAsync(
+                LocalizedStrings.Instance["PokemonEditor_ImportFailedTitle"],
+                result.GetDisplayString(pk, target.GetType()));
+            return false;
+        }
+
+        _pk = compatible.Clone(); // Always work on a copy
         LoadFromPKM();
+        return true;
     }
 
     /// <summary>Raised when a dropped OS file turns out to be a save file, so the host can open it.</summary>

--- a/Tests/PKHeX.Avalonia.Tests/EncounterDatabaseEditorSpriteTests.cs
+++ b/Tests/PKHeX.Avalonia.Tests/EncounterDatabaseEditorSpriteTests.cs
@@ -1,0 +1,218 @@
+using Moq;
+using PKHeX.Avalonia.Services;
+using PKHeX.Core;
+using PKHeX.Presentation.ViewModels;
+using SkiaSharp;
+using Xunit.Abstractions;
+
+namespace PKHeX.Avalonia.Tests;
+
+/// <summary>
+/// GitHub issue #234 (Discord support report from BlvckFr0st, 2026-08-25): after loading an Aipom
+/// result from the Encounter Database and changing the Species to Ambipom, the editor title and the
+/// Species field read "Ambipom" while the preview sprite rendered Ariados.
+///
+/// Root cause: <see cref="EncounterDatabaseViewModel"/> hands the editor the encounter's <em>native</em>
+/// format (<c>IEncounterConvertible.ConvertToPKM</c> returns a <see cref="PK2"/> for a Gold/Silver/Crystal
+/// wild slot even when the open save is Gen 7+), while the editor's Species dropdown comes from the
+/// save-scoped <see cref="GameInfo.FilteredSources"/>. <c>PK2.Species</c> is a single byte, so writing
+/// Ambipom (424) stored <c>424 &amp; 0xFF</c> = 168 — Ariados — and the sprite, which renders from the
+/// stored entity, was correct about a wrong entity.
+/// </summary>
+public class EncounterDatabaseEditorSpriteTests(ITestOutputHelper output)
+{
+    private const ushort Aipom = 190;
+    private const ushort Ambipom = 424;
+    private const ushort Ariados = 168;
+
+    /// <summary>
+    /// Pins the arithmetic behind the report: Ariados is not an arbitrary wrong species, it is
+    /// exactly what Ambipom truncates to in a Generation 2 entity.
+    /// </summary>
+    [Fact]
+    public void Gen2Entity_CannotStoreAmbipom_AndTruncatesToAriados()
+    {
+        var pk2 = new PK2 { Species = Ambipom };
+        Assert.Equal(Ariados, pk2.Species);
+        Assert.Equal(Ambipom & 0xFF, pk2.Species);
+    }
+
+    /// <summary>
+    /// The editor's dropdowns are scoped to the save file, so the entity it edits must be in the
+    /// save's format. A Gen 2 entity handed in from an outside source has to be adapted first.
+    /// </summary>
+    [Fact]
+    public void LoadPKM_Gen2Entity_AdaptsToTheSaveFileFormat()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.US);
+        var (editor, _) = CreateEditor(sav);
+
+        var gen2Aipom = CreateGen2Aipom();
+        Assert.True(editor.LoadPKM(gen2Aipom));
+
+        Assert.IsType<PK7>(editor.TargetPKM);
+        Assert.Equal(sav.PKMType, editor.TargetPKM.GetType());
+        Assert.Equal(Aipom, editor.TargetPKM.Species);
+    }
+
+    /// <summary>
+    /// The reported symptom, asserted on the actual sprite bytes: after selecting Ambipom the preview
+    /// must be the Ambipom asset, not the Ariados asset.
+    /// </summary>
+    [Fact]
+    public void Issue234_AfterLoadingGen2Aipom_SelectingAmbipom_RendersAmbipomNotAriados()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.US);
+        GameInfo.FilteredSources = new FilteredGameDataSource(sav, GameInfo.Sources);
+
+        var (editor, renderer) = CreateEditor(sav);
+        Assert.True(editor.LoadPKM(CreateGen2Aipom()));
+
+        // Ambipom must actually be offered by the save-scoped Species dropdown, or the scenario
+        // the reporter hit could not occur in the first place.
+        Assert.Contains(editor.SpeciesList, x => x.Value == Ambipom);
+
+        Normalize(editor);
+        editor.Species = Ambipom;
+
+        output.WriteLine($"VM.Species={editor.Species} Title='{editor.Title}' stored={editor.TargetPKM.Species} ({GameInfo.Strings.Species[editor.TargetPKM.Species]}) entity={editor.TargetPKM.GetType().Name}");
+
+        // The reported symptom, asserted on the rendered sprite bytes.
+        AssertRendersSpecies(editor, renderer, sav);
+
+        // ...and the mechanism behind it: the stored entity must hold what the UI says it holds.
+        Assert.Equal(Ambipom, editor.TargetPKM.Species);
+        Assert.IsType<PK7>(editor.TargetPKM);
+    }
+
+    /// <summary>
+    /// End-to-end through the surface named in the report: search the Encounter Database for Aipom on
+    /// a save whose top results are Generation 2 encounters, load one into the editor and change the
+    /// species, exactly as the reporter did.
+    /// </summary>
+    [Fact]
+    public async Task Issue234_EncounterDatabase_AipomResult_ThenAmbipom_RendersAmbipom()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.US);
+        GameInfo.FilteredSources = new FilteredGameDataSource(sav, GameInfo.Sources);
+
+        var (editor, renderer) = CreateEditor(sav);
+        var db = new EncounterDatabaseViewModel(sav, renderer, Mock.Of<IDialogService>(), pk => editor.LoadPKM(pk));
+
+        db.SelectedSpecies = Aipom;
+        await db.SearchCommand.ExecuteAsync(null);
+        Assert.NotEmpty(db.Results);
+
+        // Prefer a wild slot over an egg encounter so the preview is a plain species render.
+        var gen2Results = db.Results.Where(r => r.Encounter.Context == EntityContext.Gen2).ToList();
+        var gen2 = gen2Results.Find(r => r.Encounter is EncounterSlot2) ?? gen2Results.FirstOrDefault();
+        Assert.NotNull(gen2); // Gold/Silver/Crystal Aipom slots are reachable from a Gen 7 save
+        output.WriteLine($"selected {gen2!.Encounter.GetType().Name} from {gen2.Encounter.Version}");
+
+        await db.SelectEncounterCommand.ExecuteAsync(gen2);
+        Assert.Equal(Aipom, editor.TargetPKM.Species);
+
+        Normalize(editor);
+        editor.Species = Ambipom;
+
+        AssertRendersSpecies(editor, renderer, sav);
+        Assert.Equal(Ambipom, editor.TargetPKM.Species);
+        Assert.Equal(sav.PKMType, editor.TargetPKM.GetType());
+    }
+
+    /// <summary>
+    /// The Encounter Database's own result rows render from each row's own entity, so a Gen 2 Aipom
+    /// row shows Aipom. Guards against a future index-keyed/recycled sprite regression on that list.
+    /// </summary>
+    [Fact]
+    public async Task EncounterDatabase_ResultRows_RenderTheirOwnSpecies()
+    {
+        var sav = BlankSaveFile.Get(GameVersion.US);
+        var renderer = new AvaloniaSpriteRenderer(new AppSettings());
+        renderer.Initialize(sav);
+
+        var db = new EncounterDatabaseViewModel(sav, renderer, Mock.Of<IDialogService>(), _ => { });
+        db.SelectedSpecies = Aipom;
+        await db.SearchCommand.ExecuteAsync(null);
+        Assert.NotEmpty(db.Results);
+
+        var expected = RenderSpecies(renderer, sav, Aipom);
+        var wrong = RenderSpecies(renderer, sav, Ariados);
+        Assert.NotEqual(wrong, expected);
+
+        foreach (var row in db.Results)
+        {
+            Assert.Equal(Aipom, row.Encounter.Species);
+            Assert.NotNull(row.Sprite);
+            Assert.NotEqual(wrong, row.Sprite);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+
+    private static (PokemonEditorViewModel Editor, ISpriteRenderer Renderer) CreateEditor(SaveFile sav)
+    {
+        var renderer = new AvaloniaSpriteRenderer(new AppSettings());
+        renderer.Initialize(sav);
+        var editor = new PokemonEditorViewModel(sav.BlankPKM, sav, renderer, Mock.Of<IDialogService>(), Mock.Of<IWindowService>());
+        return (editor, renderer);
+    }
+
+    /// <summary>A Generation 2 wild Aipom, i.e. what the Encounter Database produces for a GSC slot.</summary>
+    private static PK2 CreateGen2Aipom()
+    {
+        var pk = new PK2 { Species = Aipom, CurrentLevel = 18, OriginalTrainerName = "PKHEX", TID16 = 12345 };
+        pk.Nickname = SpeciesName.GetSpeciesNameGeneration(Aipom, (int)LanguageID.English, 2);
+        pk.ResetPartyStats();
+        return pk;
+    }
+
+    /// <summary>
+    /// Removes the sprite decorations (held-item corner badge, shiny overlay) so the preview is a
+    /// plain species render and can be compared byte-for-byte against a reference render.
+    /// </summary>
+    private static void Normalize(PokemonEditorViewModel editor)
+    {
+        editor.IsShiny = false;
+        editor.TargetPKM.HeldItem = 0;
+    }
+
+    private void AssertRendersSpecies(PokemonEditorViewModel editor, ISpriteRenderer renderer, SaveFile sav)
+    {
+        var ambipom = RenderSpecies(renderer, sav, Ambipom);
+        var ariados = RenderSpecies(renderer, sav, Ariados);
+        Assert.NotEqual(ariados, ambipom); // the two assets really are distinct
+
+        var actual = editor.Sprite;
+        Assert.NotNull(actual);
+        output.WriteLine($"sprite bytes: actual={actual!.Length} ambipom={ambipom.Length} ariados={ariados.Length}");
+        output.WriteLine($"matches Ambipom asset: {Describe(actual, ambipom)}; matches Ariados asset: {Describe(actual, ariados)}");
+
+        Assert.NotEqual(ariados, actual);
+        Assert.Equal(ambipom, actual);
+    }
+
+    /// <summary>Renders a bare species through the same pipeline the editor preview uses.</summary>
+    private static byte[] RenderSpecies(ISpriteRenderer renderer, SaveFile sav, ushort species)
+    {
+        var pk = sav.BlankPKM;
+        pk.Species = species;
+        pk.Form = 0;
+        pk.HeldItem = 0;
+        pk.SetUnshiny();
+        var sprite = renderer.GetSprite(pk);
+        Assert.NotNull(sprite);
+        return sprite!;
+    }
+
+    private static string Describe(byte[] actual, byte[] expected)
+    {
+        if (actual.AsSpan().SequenceEqual(expected))
+            return "yes (identical bytes)";
+        using var a = SKBitmap.Decode(actual);
+        using var b = SKBitmap.Decode(expected);
+        if (a is null || b is null)
+            return "no (undecodable)";
+        return $"no ({a.Width}x{a.Height} vs {b.Width}x{b.Height})";
+    }
+}


### PR DESCRIPTION
Closes #234

## Root cause: the entity was wrong, not the sprite

`424 & 0xFF == 168`. Ambipom is 424; Ariados is 168. This was a **byte truncation**, not a sprite cache, fallback or index-desync defect.

`PKHeX.Core/PKM/PK2.cs:57`:

```csharp
public override ushort Species { get => Data[0]; set => Data[0] = (byte)value; }
```

The Encounter Database hands the editor the encounter's **native** entity format — `IEncounterConvertible.ConvertToPKM` returns a `PK2` for a Gold/Silver/Crystal wild slot even when the open save is Gen 7+. `PokemonEditorViewModel.LoadPKM` adopted that entity as-is (`_pk = pk.Clone()`), while every editor dropdown comes from the save-scoped `GameInfo.FilteredSources` — 808 species on a USUM save, Ambipom included. `UpdateSprite()` then does `_pk.Species = (ushort)Species`, which a `PK2` truncates to a single byte.

Aipom (190) fits in a byte, which is why the bug only appears *after* the species change. The reproduction output:

```
VM.Species=424 Title='Editing: Ambipom' stored=168 (Ariados) entity=PK2
sprite bytes: actual=684 ambipom=835 ariados=684
matches Ambipom asset: no; matches Ariados asset: yes (identical bytes)
```

The preview PNG was byte-identical to the Ariados asset because the stored entity genuinely *was* Ariados. The sprite pipeline was correct about a wrong entity.

## Why Generation 7 specifically reproduces it

Both halves have to line up, and only Gen 7 does:

- `GameUtil.GetVersionsWithinRange` admits GD/SI/C for a Gen 7 save (VC transfers), and `GameVersions` is newest-first, so an Aipom search returns **100/100 Gen 2 encounters** at the top of the results — first Gen 2 result at index 0.
- The Gen 7 species dropdown still offers Ambipom (808 entries).

Gen 4/5 saves cannot reach Gen 2 versions at all; SWSH reaches them but its dropdown excludes Ambipom (665 entries, no 424). That narrows the reporter's save to SM/USUM.

## The fix

`LoadPKM` now adapts the incoming entity to the save's format via `EntityConverter.TryMakePKMCompatible`, and returns `bool`:

```csharp
var target = _sav.BlankPKM;
if (!EntityConverter.TryMakePKMCompatible(pk, target, out var result, out var compatible))
{
    _ = _dialogService.ShowErrorAsync(
        LocalizedStrings.Instance["PokemonEditor_ImportFailedTitle"],
        result.GetDisplayString(pk, target.GetType()));
    return false;
}
_pk = compatible.Clone(); // Always work on a copy
```

**This is upstream parity, not invented behavior.** Upstream PKHeX's `PKMEditor.LoadFieldsFromPKM` does exactly `EntityConverter.TryMakePKMCompatible(pk, Entity, out var c, out pk)` and alerts + returns early on failure. Our own file-import path already converted (`ImportEntityFileUseCase` → `SaveExtensions.GetCompatible`); the database, gift, QR and Showdown paths did not.

**Fixed at the chokepoint, so it covers all seven `LoadPKM` call sites** — Encounter Database, Mystery Gift Database, PKM Database, box/party slot clicks, OS file drop, Showdown import and QR import — not just the database surface named in the report.

## What I deliberately did NOT do

I did not make `UpdateSprite` render from the ViewModel's selected species instead of the stored entity. That "obvious" one-line change would have made the *preview* look right while the entity stayed corrupt — the user would then write an Ariados into their box with an Ambipom on screen. The sprite was the honest messenger; the entity was the bug.

## Risks checked

- **Feature regression** — measured conversion success on the actual Aipom result set: USUM **100/100** converted, SWSH **100/100**, HGSS 99 same-format + 1 `CK3`→`PK4`, SV all same-format. Zero failures, zero species drift. The Encounter Database stays as useful as before.
- **Gen 1/2 saves** — `TryMakePKMCompatible`'s `IsCompatibleGB` check only engages for `target.Format <= 2`. Using `_sav.BlankPKM` as the target (`SAV2.BlankPKM => new(jp: Japanese)`) makes the Japanese check *more* correct than comparing against a previously-loaded entity. Box-slot reads propagate `Japanese` via `PokeList2.ReadFromList(…, StringLength)`, so same-save box clicks remain no-ops.
- **Constructor path untouched** — the editor can still be constructed with a mismatched entity, so existing tests that do so are unaffected.
- **No new localization keys** — reuses `PokemonEditor_ImportFailedTitle` (present in all 9 language files); the message body comes from Core's `GetDisplayString`, so the localization audit sees no literal.

## Behavior change

An entity with **no transfer route** now shows an error naming the reason and refuses to load, where previously it loaded and was edited in a foreign format. The 100/100 conversion measurements show this is rare in practice, and an honest error beats silent corruption.

## Tests

New `Tests/PKHeX.Avalonia.Tests/EncounterDatabaseEditorSpriteTests.cs` — 3 of these fail on unfixed code:

- `Gen2Entity_CannotStoreAmbipom_AndTruncatesToAriados` — pins the `424 & 0xFF == 168` arithmetic
- `LoadPKM_Gen2Entity_AdaptsToTheSaveFileFormat`
- `Issue234_AfterLoadingGen2Aipom_SelectingAmbipom_RendersAmbipomNotAriados` — asserts on the actual PNG bytes
- `Issue234_EncounterDatabase_AipomResult_ThenAmbipom_RendersAmbipom` — end-to-end through the database
- `EncounterDatabase_ResultRows_RenderTheirOwnSpecies` — guards the result list against a future index-keyed sprite regression

Release build 0 warnings / 0 errors; `PKHeX.Avalonia.Tests` 2579 passed / 1 pre-existing skip; architecture tests 6 passed. No `PKHeX.Core/` changes. `UIVersion` 1.48.3 → 1.48.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
