### PR TITLE
ci: also ignore root-level markdown in the release path filter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ on:
     # a packaging or signing change does change what ships.
     paths-ignore:
       - '**/*.md'
+      - '*.md'
       - 'docs/**'
       - '.claude/**'
       - '.codex/**'


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml`'s `paths-ignore` list (added in #276) includes `**/*.md`, intended to stop docs-only pushes from cutting a release.
- `AGENTS.md` and `README.md` live at the repo **root**. Whether `**/*.md` matches a root-level file depends on the glob implementation treating `**` as matching zero directories — that assumption was never empirically verified against GitHub Actions' actual `paths-ignore` filter semantics.
- If it does *not* match, a PR that only touches root-level markdown would trigger the release workflow and cut a contentless release (bump + tag + empty-diff build).
- This adds `- '*.md'` alongside the existing `- '**/*.md'` entry so root-level markdown is ignored explicitly, regardless of how `**` is interpreted. Cheap insurance, no behavior change if the globstar already matched.

## Change

One line in `.github/workflows/release.yml`:

```diff
     paths-ignore:
       - '**/*.md'
+      - '*.md'
       - 'docs/**'
```

Nothing else in the workflow changed, and `Directory.Build.props` was not touched — version bumping is owned by CI per #276.

Refs #276.

## Test plan

- [x] `dotnet build PKHeX.sln -c Release` — 0 warnings, 0 errors
- [x] YAML validated with `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses cleanly, `paths-ignore` contains both `**/*.md` and `*.md`
- [x] `git diff` confirms this is the only change (one insertion, one file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)